### PR TITLE
feat: add ToolError exception and retry injection in ToolFactory

### DIFF
--- a/src/akgentic/tool/__init__.py
+++ b/src/akgentic/tool/__init__.py
@@ -3,6 +3,7 @@
 # Submodules with their own __init__ files
 from . import mcp, planning, search
 from .core import BaseToolParam, ToolCard, ToolFactory
+from .errors import ToolError
 from .event import ActorToolObserver, ToolCallEvent, ToolObserver
 
 __all__ = [
@@ -10,6 +11,8 @@ __all__ = [
     "BaseToolParam",
     "ToolCard",
     "ToolFactory",
+    # Errors
+    "ToolError",
     # Events and observers
     "ToolCallEvent",
     "ToolObserver",

--- a/src/akgentic/tool/core.py
+++ b/src/akgentic/tool/core.py
@@ -43,11 +43,11 @@ class BaseToolParam(BaseModel):
     to the LLM and how its description can be customized.
     """
 
-    description: str | None = None
-    """Override the default LLM-facing docstring for this tool.
+    instructions: str | None = None
+    """Additional instructions appended to the default tool docstring.
 
-    When set, the factory uses this text instead of the hardcoded docstring
-    in the closure. When ``None``, the built-in default docstring is used.
+    When set, the factory appends these instructions to the built-in docstring
+    under a structured header. When ``None``, only the default docstring is used.
     """
 
     system_prompt: bool = False
@@ -55,6 +55,21 @@ class BaseToolParam(BaseModel):
 
     llm_tool: bool = True
     """Whether this capability is exposed as a callable tool for the LLM."""
+
+    def format_docstring(self, original: str | None) -> str | None:
+        """Format the tool docstring with optional additional instructions.
+
+        Args:
+            original: The original docstring from the tool callable.
+
+        Returns:
+            The formatted docstring, or the original if no instructions are set.
+        """
+        if not self.instructions:
+            return original
+
+        base_doc = original or ""
+        return f"{base_doc}\n\nAdditional Instructions:\n{self.instructions}"
 
 
 class ToolCard(BaseModel, ABC):

--- a/src/akgentic/tool/core.py
+++ b/src/akgentic/tool/core.py
@@ -6,11 +6,13 @@ Defines the core contracts:
 - ``ToolFactory``: resolves ``ToolCard`` instances into callable tools, prompts, and toolsets.
 """
 
+import functools
 from abc import ABC, abstractmethod
 from typing import Any, Callable, TypeVar
 
-from pydantic import BaseModel, PrivateAttr
+from pydantic import BaseModel
 
+from akgentic.tool.errors import ToolError
 from akgentic.tool.event import ToolObserver
 
 T = TypeVar("T", bound="BaseToolParam")
@@ -112,6 +114,7 @@ class ToolFactory:
         self,
         tool_cards: list[ToolCard],
         observer: ToolObserver | None = None,
+        retry_exception: type[Exception] | None = None,
     ) -> None:
         """Create a factory for one or more tool cards.
 
@@ -122,17 +125,38 @@ class ToolFactory:
             tool_cards: Tool cards to resolve into callable tools.
             observer: Optional observer notified by tool implementations during
                 tool calls.
+            retry_exception: Optional exception class to raise when a tool raises
+                ``ToolError``. Injected by the integration layer (e.g., ModelRetry
+                from pydantic-ai) to keep the tool module framework-agnostic.
         """
         self.tool_cards = tool_cards
         self.observer = observer
+        self._retry_exception = retry_exception
 
         if self.observer is not None:
             for card in self.tool_cards:
                 card.observer(self.observer)
 
+    def _wrap_with_retry(self, fn: Callable) -> Callable:
+        """Wrap a tool callable to convert ``ToolError`` into retry_exception."""
+        assert self._retry_exception is not None
+        retry_exc = self._retry_exception
+
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs):
+            try:
+                return fn(*args, **kwargs)
+            except ToolError as e:
+                raise retry_exc(str(e)) from e
+
+        return wrapper
+
     def get_tools(self) -> list[Callable]:
         """Return tool callables aggregated from all tool cards."""
-        return [t for card in self.tool_cards for t in card.get_tools()]
+        tools = [t for card in self.tool_cards for t in card.get_tools()]
+        if self._retry_exception is not None:
+            tools = [self._wrap_with_retry(t) for t in tools]
+        return tools
 
     def get_system_prompts(self) -> list[Callable]:
         """Return system prompt callables aggregated from all tool cards."""

--- a/src/akgentic/tool/errors.py
+++ b/src/akgentic/tool/errors.py
@@ -1,0 +1,16 @@
+"""Tool-layer exceptions for error signaling.
+
+These exceptions are framework-agnostic — the integration layer (e.g., akgentic-team)
+translates them into the appropriate retry mechanism (e.g., pydantic-ai ModelRetry).
+"""
+
+
+class ToolError(Exception):
+    """Raised by tool implementations when the LLM should retry with corrected input.
+
+    Tools raise this to signal a recoverable error. The consuming framework
+    (via ToolFactory's retry_exception injection) converts it to the appropriate
+    retry mechanism.
+    """
+
+    pass

--- a/src/akgentic/tool/planning/planning.py
+++ b/src/akgentic/tool/planning/planning.py
@@ -1,13 +1,13 @@
 import logging
 from typing import Callable
 
-from pydantic import Field
+from pydantic import Field, PrivateAttr
 
 from akgentic.core.agent_config import BaseConfig
 from akgentic.core.orchestrator import Orchestrator
 from akgentic.tool.core import BaseToolParam, ToolCard, _resolve
 from akgentic.tool.event import ActorToolObserver, ToolCallEvent
-from akgentic.tool.planning.planning_actor import PlanActor, PlanItem, UpdatePlan
+from akgentic.tool.planning.planning_actor import PlanActor, Task, UpdatePlan
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -24,13 +24,13 @@ class GetPlanning(BaseToolParam):
 
 
 class GetPlanningItem(BaseToolParam):
-    """Get a single planning item by ID."""
+    """Get a single task by ID."""
 
     pass
 
 
 class UpdatePlanning(BaseToolParam):
-    """Update planning items."""
+    """Update tasks."""
 
     pass
 
@@ -44,18 +44,15 @@ class PlanningTool(ToolCard):
     get_planning: GetPlanning | bool = Field(
         default=True, description="By default the plan in included in the system prompt"
     )
-    get_planning_item: GetPlanningItem | bool = True
+    get_planning_task: GetPlanningItem | bool = True
     update_planning: UpdatePlanning | bool = True
 
-
-    def observer(self, observer: ActorToolObserver) -> "PlanningTool":
+    def observer(self, observer: ActorToolObserver):
         """Attach observer and set up the planning actor proxy.
 
         Requires an ActorToolObserver for actor system access.
         """
-        super().observer(observer)
-        if observer is None:
-            raise ValueError("PlanningTool requires an ActorToolObserver to function.")
+        self._observer = observer
         if observer.orchestrator is None:
             raise ValueError("PlanningTool requires access to the orchestrator.")
 
@@ -83,10 +80,10 @@ class PlanningTool(ToolCard):
                     return "No current Team planning."
                 return "Team planning:\n" + "\n".join(
                     [
-                        f"- ID {item.id} [{item.status}] {item.description} "
-                        f"{item.output and f'— Output: {item.output} '}"
-                        f"(Owner: {item.owner}, Creator: {item.creator})"
-                        for item in planning
+                        f"- ID {task.id} [{task.status}] {task.description} "
+                        f"{task.output and f'— Output: {task.output} '}"
+                        f"(Owner: {task.owner}, Creator: {task.creator})"
+                        for task in planning
                     ]
                 )
 
@@ -102,9 +99,9 @@ class PlanningTool(ToolCard):
         if gp and gp.llm_tool:
             tools.append(self._get_planning_factory(gp))
 
-        gpi = _resolve(self.get_planning_item, GetPlanningItem)
+        gpi = _resolve(self.get_planning_task, GetPlanningItem)
         if gpi and gpi.llm_tool:
-            tools.append(self._get_planning_item_factory(gpi))
+            tools.append(self._get_planning_task_factory(gpi))
 
         up = _resolve(self.update_planning, UpdatePlanning)
         if up and up.llm_tool:
@@ -116,7 +113,7 @@ class PlanningTool(ToolCard):
         planning_proxy = self._planning_proxy
         observer = self._observer
 
-        def get_planning() -> list[PlanItem]:
+        def get_planning() -> list[Task]:
             """Get the full team planning."""
             if observer is not None:
                 observer.notify_event(ToolCallEvent(tool_name="Get planning", args=[], kwargs={}))
@@ -126,28 +123,28 @@ class PlanningTool(ToolCard):
             get_planning.__doc__ = params.description
         return get_planning
 
-    def _get_planning_item_factory(self, params: GetPlanningItem) -> Callable:
+    def _get_planning_task_factory(self, params: GetPlanningItem) -> Callable:
         planning_proxy = self._planning_proxy
         observer = self._observer
 
-        def get_planning_item(item_id: int) -> PlanItem | str:
-            """Get a single team planning item by its ID."""
+        def get_planning_task(task_id: int) -> Task | str:
+            """Get a single team task by its ID."""
             if observer is not None:
                 observer.notify_event(
-                    ToolCallEvent(tool_name="Get planning item", args=[item_id], kwargs={})
+                    ToolCallEvent(tool_name="Get task", args=[task_id], kwargs={})
                 )
-            return planning_proxy.get_planning_item(item_id)
+            return planning_proxy.get_planning_task(task_id)
 
         if params.description:
-            get_planning_item.__doc__ = params.description
-        return get_planning_item
+            get_planning_task.__doc__ = params.description
+        return get_planning_task
 
     def _update_planning_factory(self, params: UpdatePlanning) -> Callable:
         planning_proxy = self._planning_proxy
         observer = self._observer
 
         def update_planning(update: UpdatePlan) -> str:
-            """Update team planning items (create, update, delete).
+            """Update team tasks (create, update, delete).
 
             When you start or complete a task from the planning,
             do not forget to update the plan with the new status
@@ -157,7 +154,7 @@ class PlanningTool(ToolCard):
                 observer.notify_event(
                     ToolCallEvent(tool_name="Update planning", args=[update], kwargs={})
                 )
-            ## Then observer.myAddress is used to set the creator of any new items in the plan.
+            ## Then observer.myAddress is used to set the creator of any new tasks in the plan.
             return planning_proxy.update_planning(update, observer.myAddress)
 
         if params.description:

--- a/src/akgentic/tool/planning/planning.py
+++ b/src/akgentic/tool/planning/planning.py
@@ -87,8 +87,7 @@ class PlanningTool(ToolCard):
                     ]
                 )
 
-            if gp.description:
-                team_planning.__doc__ = gp.description
+            team_planning.__doc__ = gp.format_docstring(team_planning.__doc__)
             return [team_planning]
         return []
 
@@ -119,8 +118,7 @@ class PlanningTool(ToolCard):
                 observer.notify_event(ToolCallEvent(tool_name="Get planning", args=[], kwargs={}))
             return planning_proxy.get_planning()
 
-        if params.description:
-            get_planning.__doc__ = params.description
+        get_planning.__doc__ = params.format_docstring(get_planning.__doc__)
         return get_planning
 
     def _get_planning_task_factory(self, params: GetPlanningItem) -> Callable:
@@ -135,8 +133,7 @@ class PlanningTool(ToolCard):
                 )
             return planning_proxy.get_planning_task(task_id)
 
-        if params.description:
-            get_planning_task.__doc__ = params.description
+        get_planning_task.__doc__ = params.format_docstring(get_planning_task.__doc__)
         return get_planning_task
 
     def _update_planning_factory(self, params: UpdatePlanning) -> Callable:
@@ -150,13 +147,11 @@ class PlanningTool(ToolCard):
             do not forget to update the plan with the new status
             and output of the task.
             """
-            if observer is not None:
-                observer.notify_event(
-                    ToolCallEvent(tool_name="Update planning", args=[update], kwargs={})
-                )
+            observer.notify_event(
+                ToolCallEvent(tool_name="Update planning", args=[update], kwargs={})
+            )
             ## Then observer.myAddress is used to set the creator of any new tasks in the plan.
             return planning_proxy.update_planning(update, observer.myAddress)
 
-        if params.description:
-            update_planning.__doc__ = params.description
+        update_planning.__doc__ = params.format_docstring(update_planning.__doc__)
         return update_planning

--- a/src/akgentic/tool/planning/planning_actor.py
+++ b/src/akgentic/tool/planning/planning_actor.py
@@ -8,23 +8,23 @@ from akgentic.core.agent import Akgent, BaseConfig, BaseState
 from akgentic.core.utils.serializer import SerializableBaseModel
 from akgentic.tool.errors import ToolError
 
-PlanStatus = Literal["pending", "started", "completed", "abort"]
+TaskStatus = Literal["pending", "started", "completed", "abort"]
 
 
-class PlanItemCreate(SerializableBaseModel):
-    id: int = Field(..., description="Unique identifier of the plan item.")
-    status: PlanStatus = Field(..., description="Status of the task.")
+class TaskCreate(SerializableBaseModel):
+    id: int = Field(..., description="Unique identifier of the task.")
+    status: TaskStatus = Field(..., description="Status of the task.")
     description: str = Field(..., max_length=300, description="Short description of the task.")
     owner: str = Field(..., description="Assigned team member name; empty if not yet assigned.")
     dependencies: list[int] = Field(
         default_factory=list,
-        description="List of plan item IDs that must be completed before this one.",
+        description="List of task IDs that must be completed before this one.",
     )
 
 
-class PlanItemUpdate(SerializableBaseModel):
-    id: int = Field(..., description="Unique identifier of the plan item.")
-    status: PlanStatus | None = Field(default=None, description="New status of the task.")
+class TaskUpdate(SerializableBaseModel):
+    id: int = Field(..., description="Unique identifier of the task.")
+    status: TaskStatus | None = Field(default=None, description="New status of the task.")
     description: str | None = Field(
         default=None, max_length=300, description="New description of the task."
     )
@@ -34,13 +34,13 @@ class PlanItemUpdate(SerializableBaseModel):
     owner: str | None = Field(default=None, description="New assigned team member name;")
     dependencies: list[int] | None = Field(
         default=None,
-        description="New list of plan item IDs that must be completed first.",
+        description="New list of task IDs that must be completed first.",
     )
 
 
-class PlanItem(PlanItemCreate):
+class Task(TaskCreate):
     output: str = Field(default="", description="Output or result of the task.")
-    creator: str = Field(default="", description="Team member name who creates the plan item.")
+    creator: str = Field(default="", description="Team member name who creates the task.")
     updated_at: datetime.datetime = Field(
         default_factory=lambda: datetime.datetime.now(datetime.UTC),
         description="ISO timestamp of the last update.",
@@ -48,19 +48,19 @@ class PlanItem(PlanItemCreate):
 
 
 class UpdatePlan(BaseModel):
-    create_items: list[PlanItemCreate] = Field(
-        default_factory=list, description="Items to add to the plan."
+    create_tasks: list[TaskCreate] = Field(
+        default_factory=list, description="Tasks to add to the plan."
     )
-    update_items: list[PlanItemUpdate] = Field(
-        default_factory=list, description="Items to update in the plan."
+    update_tasks: list[TaskUpdate] = Field(
+        default_factory=list, description="Tasks to update in the plan."
     )
-    delete_items: list[int] = Field(
-        default_factory=list, description="Items to remove from the plan."
+    delete_tasks: list[int] = Field(
+        default_factory=list, description="Tasks to remove from the plan."
     )
 
 
 class PlanManagerState(BaseState):
-    item_list: list[PlanItem] = Field(default_factory=list)
+    task_list: list[Task] = Field(default_factory=list)
 
 
 class PlanActor(Akgent[BaseConfig, PlanManagerState]):
@@ -80,52 +80,52 @@ class PlanActor(Akgent[BaseConfig, PlanManagerState]):
         self.state = PlanManagerState()
         self.state.observer(self)
 
-    def _create_item(self, item_create: PlanItemCreate, actor_address: ActorAddress) -> None:
-        new_item = PlanItem(**item_create.__dict__, creator=actor_address.name)
-        self.state.item_list.append(new_item)
+    def _create_task(self, task: TaskCreate, actor_address: ActorAddress) -> None:
+        new_task = Task(**task.__dict__, creator=actor_address.name)
+        self.state.task_list.append(new_task)
 
-    def _update_item(self, item_update: PlanItemUpdate) -> None | str:
+    def _update_task(self, task_update: TaskUpdate) -> None | str:
         # Use __dict__ to get raw values, filter out None to only apply explicitly set fields
-        updates = {k: v for k, v in item_update.__dict__.items() if v is not None}
-        for idx, item in enumerate(self.state.item_list):
-            if item.id == item_update.id:
-                self.state.item_list[idx] = item.model_copy(update=updates)
+        updates = {k: v for k, v in task_update.__dict__.items() if v is not None}
+        for idx, task in enumerate(self.state.task_list):
+            if task.id == task_update.id:
+                self.state.task_list[idx] = task.model_copy(update=updates)
                 return
-        return f"Update error - no item with ID {item_update.id} found."
+        return f"Update error - no task with ID {task_update.id} found."
 
     ##
     ## Tools to expose to agents:
     ##
-    def get_planning(self) -> list[PlanItem]:
-        """Get the current plan items."""
-        return self.state.item_list
+    def get_planning(self) -> list[Task]:
+        """Get the current plan tasks."""
+        return self.state.task_list
 
-    def get_planning_item(self, item_id: int) -> PlanItem | str:
-        """Get a specific plan item by ID."""
-        item_list = self.state.item_list
-        return next((item for item in item_list if item.id == item_id), "No item with that ID.")
+    def get_planning_task(self, task_id: int) -> Task | str:
+        """Get a specific plan task by ID."""
+        task_list = self.state.task_list
+        return next((task for task in task_list if task.id == task_id), "No task with that ID.")
 
     def update_planning(self, update: UpdatePlan, actor_address: ActorAddress) -> str:
-        """Update the plan with new, updated, or deleted items."""
+        """Update the plan with new, updated, or deleted task."""
 
         errors = []
 
-        # Handle item creation
-        for item_create in update.create_items:
-            self._create_item(item_create, actor_address)
+        # Handle task creation
+        for task_create in update.create_tasks:
+            self._create_task(task_create, actor_address)
 
-        # Handle item updates
-        for item_update in update.update_items:
-            error = self._update_item(item_update)
+        # Handle task updates
+        for task_update in update.update_tasks:
+            error = self._update_task(task_update)
             if error is not None:
                 errors.append(error)
 
-        # Handle item deletions
-        for item_id in update.delete_items:
-            if not any(item.id == item_id for item in self.state.item_list):
-                errors.append(f"Delete error - no item with ID {item_id} found.")
+        # Handle task deletions
+        for task_id in update.delete_tasks:
+            if not any(task.id == task_id for task in self.state.task_list):
+                errors.append(f"Delete error - no task with ID {task_id} found.")
             else:
-                self.state.item_list = [item for item in self.state.item_list if item.id != item_id]
+                self.state.task_list = [task for task in self.state.task_list if task.id != task_id]
 
         self.state.notify_state_change()
 

--- a/src/akgentic/tool/planning/planning_actor.py
+++ b/src/akgentic/tool/planning/planning_actor.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, Field
 from akgentic.core.actor_address import ActorAddress
 from akgentic.core.agent import Akgent, BaseConfig, BaseState
 from akgentic.core.utils.serializer import SerializableBaseModel
+from akgentic.tool.errors import ToolError
 
 PlanStatus = Literal["pending", "started", "completed", "abort"]
 
@@ -127,4 +128,7 @@ class PlanActor(Akgent[BaseConfig, PlanManagerState]):
                 self.state.item_list = [item for item in self.state.item_list if item.id != item_id]
 
         self.state.notify_state_change()
-        return "Done" if not errors else "Done with errors: " + "; ".join(errors)
+
+        if errors:
+            raise ToolError("Update errors: " + "; ".join(errors))
+        return "Done"

--- a/src/akgentic/tool/search/search.py
+++ b/src/akgentic/tool/search/search.py
@@ -98,8 +98,7 @@ class SearchTool(ToolCard):
                 **search_kwargs,
             )
 
-        if params.description:
-            web_search_tool.__doc__ = params.description
+        web_search_tool.__doc__ = params.format_docstring(web_search_tool.__doc__)
         return web_search_tool
 
     def _web_fetch_factory(self, params: WebFetch) -> Callable:
@@ -147,8 +146,7 @@ class SearchTool(ToolCard):
                 **fetch_kwargs,
             )
 
-        if params.description:
-            web_fetch_tool.__doc__ = params.description
+        web_fetch_tool.__doc__ = params.format_docstring(web_fetch_tool.__doc__)
         return web_fetch_tool
 
     def _web_crawl_factory(self, params: WebCrawl) -> Callable:
@@ -215,6 +213,5 @@ class SearchTool(ToolCard):
                 **crawl_kwargs,
             )
 
-        if params.description:
-            web_crawl_tool.__doc__ = params.description
+        web_crawl_tool.__doc__ = params.format_docstring(web_crawl_tool.__doc__)
         return web_crawl_tool

--- a/tests/test_core_factory.py
+++ b/tests/test_core_factory.py
@@ -70,7 +70,7 @@ def test_resolve_instance() -> None:
 
 def test_base_tool_param_defaults() -> None:
     p = BaseToolParam()
-    assert p.description is None
+    assert p.instructions is None
     assert p.system_prompt is False
     assert p.llm_tool is True
 
@@ -93,7 +93,7 @@ def test_tool_factory_with_null_observer() -> None:
 
     card = _ObserverCheckTool()
     factory = ToolFactory(tool_cards=[card], observer=None)
-    
+
     # Observer should NOT be called when observer is None
     assert not observer_called
     assert factory.observer is None

--- a/tests/test_planning_actor.py
+++ b/tests/test_planning_actor.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import uuid
 
+import pytest
 from akgentic.core.actor_address import ActorAddress
 
+from akgentic.tool.errors import ToolError
 from akgentic.tool.planning.planning_actor import (
     PlanActor,
-    PlanItemCreate,
-    PlanItemUpdate,
+    TaskCreate,
+    TaskUpdate,
     UpdatePlan,
 )
 
@@ -64,15 +66,15 @@ def test_update_item_success() -> None:
     actor.on_start()
 
     # Create an item
-    create_req = PlanItemCreate(
+    create_req = TaskCreate(
         id=1, status="pending", description="Task 1", owner="Alice", dependencies=[]
     )
     actor_addr = MockActorAddress("test-agent")
-    actor._create_item(create_req, actor_addr)
+    actor._create_task(create_req, actor_addr)
 
     # Update the item
-    update_req = PlanItemUpdate(id=1, status="started", description="Updated Task 1")
-    result = actor._update_item(update_req)
+    update_req = TaskUpdate(id=1, status="started", description="Updated Task 1")
+    result = actor._update_task(update_req)
 
     # Should return None on success
     assert result is None
@@ -90,8 +92,8 @@ def test_update_item_not_found() -> None:
     actor.on_start()
 
     # Try to update non-existent item
-    update_req = PlanItemUpdate(id=999, status="started")
-    result = actor._update_item(update_req)
+    update_req = TaskUpdate(id=999, status="started")
+    result = actor._update_task(update_req)
 
     # Should return error message
     assert result is not None
@@ -107,49 +109,40 @@ def test_update_planning_with_update_errors() -> None:
     actor_addr = MockActorAddress("test-agent")
 
     # Create one item
-    create_req = PlanItemCreate(
+    create_req = TaskCreate(
         id=1, status="pending", description="Task 1", owner="Alice", dependencies=[]
     )
-    actor._create_item(create_req, actor_addr)
+    actor._create_task(create_req, actor_addr)
 
     # Try to update both existing and non-existent items
     update_plan = UpdatePlan(
-        create_items=[],
-        update_items=[
-            PlanItemUpdate(id=1, status="started"),  # Should succeed
-            PlanItemUpdate(id=999, status="completed"),  # Should fail
+        create_tasks=[],
+        update_tasks=[
+            TaskUpdate(id=1, status="started"),  # Should succeed
+            TaskUpdate(id=999, status="completed"),  # Should fail
         ],
-        delete_items=[],
+        delete_tasks=[],
     )
 
-    result = actor.update_planning(update_plan, actor_addr)
-
-    # Should report errors
-    assert "Done with errors" in result
-    assert "Update error" in result
-    assert "999" in result
+    with pytest.raises(ToolError, match="Update error.*999"):
+        actor.update_planning(update_plan, actor_addr)
 
 
 def test_update_planning_delete_not_found() -> None:
-    """Test deleting non-existent item returns error."""
+    """Test deleting non-existent item raises ToolError."""
     actor = PlanActor()
     actor.on_start()
     actor_addr = MockActorAddress("test-agent")
 
     # Try to delete non-existent item
     update_plan = UpdatePlan(
-        create_items=[],
-        update_items=[],
-        delete_items=[999],
+        create_tasks=[],
+        update_tasks=[],
+        delete_tasks=[999],
     )
 
-    result = actor.update_planning(update_plan, actor_addr)
-
-    # Should report error
-    assert "Done with errors" in result
-    assert "Delete error" in result
-    assert "999" in result
-    assert "found" in result.lower()
+    with pytest.raises(ToolError, match="Delete error.*999"):
+        actor.update_planning(update_plan, actor_addr)
 
 
 def test_update_planning_delete_success() -> None:
@@ -159,16 +152,16 @@ def test_update_planning_delete_success() -> None:
     actor_addr = MockActorAddress("test-agent")
 
     # Create an item
-    create_req = PlanItemCreate(
+    create_req = TaskCreate(
         id=1, status="pending", description="Task 1", owner="Alice", dependencies=[]
     )
-    actor._create_item(create_req, actor_addr)
+    actor._create_task(create_req, actor_addr)
 
     # Delete the item
     update_plan = UpdatePlan(
-        create_items=[],
-        update_items=[],
-        delete_items=[1],
+        create_tasks=[],
+        update_tasks=[],
+        delete_tasks=[1],
     )
 
     result = actor.update_planning(update_plan, actor_addr)
@@ -185,32 +178,31 @@ def test_update_planning_mixed_operations_with_errors() -> None:
     actor_addr = MockActorAddress("test-agent")
 
     # Create initial item
-    create_req = PlanItemCreate(
+    create_req = TaskCreate(
         id=1, status="pending", description="Task 1", owner="Alice", dependencies=[]
     )
-    actor._create_item(create_req, actor_addr)
+    actor._create_task(create_req, actor_addr)
 
     # Mixed operations with some failures
     update_plan = UpdatePlan(
-        create_items=[
-            PlanItemCreate(
-                id=2, status="pending", description="Task 2", owner="Bob", dependencies=[]
-            )
+        create_tasks=[
+            TaskCreate(id=2, status="pending", description="Task 2", owner="Bob", dependencies=[])
         ],
-        update_items=[
-            PlanItemUpdate(id=1, status="completed"),  # Should succeed
-            PlanItemUpdate(id=999, status="started"),  # Should fail
+        update_tasks=[
+            TaskUpdate(id=1, status="completed"),  # Should succeed
+            TaskUpdate(id=999, status="started"),  # Should fail
         ],
-        delete_items=[1, 888],  # First succeeds, second fails
+        delete_tasks=[1, 888],  # First succeeds, second fails
     )
 
-    result = actor.update_planning(update_plan, actor_addr)
+    with pytest.raises(ToolError) as exc_info:
+        actor.update_planning(update_plan, actor_addr)
 
     # Should report multiple errors
-    assert "Done with errors" in result
-    assert "Update error" in result or "Delete error" in result
+    error_msg = str(exc_info.value)
+    assert "Update error" in error_msg or "Delete error" in error_msg
 
-    # Verify operations that should succeed
+    # Verify operations that should succeed (committed before the raise)
     items = actor.get_planning()
     assert len(items) == 1  # Item 2 created, item 1 deleted
     assert items[0].id == 2
@@ -224,20 +216,18 @@ def test_update_planning_all_success() -> None:
     actor_addr = MockActorAddress("test-agent")
 
     # Create initial item
-    create_req = PlanItemCreate(
+    create_req = TaskCreate(
         id=1, status="pending", description="Task 1", owner="Alice", dependencies=[]
     )
-    actor._create_item(create_req, actor_addr)
+    actor._create_task(create_req, actor_addr)
 
     # All operations should succeed
     update_plan = UpdatePlan(
-        create_items=[
-            PlanItemCreate(
-                id=2, status="pending", description="Task 2", owner="Bob", dependencies=[]
-            )
+        create_tasks=[
+            TaskCreate(id=2, status="pending", description="Task 2", owner="Bob", dependencies=[])
         ],
-        update_items=[PlanItemUpdate(id=1, status="completed")],
-        delete_items=[],
+        update_tasks=[TaskUpdate(id=1, status="completed")],
+        delete_tasks=[],
     )
 
     result = actor.update_planning(update_plan, actor_addr)


### PR DESCRIPTION
## Summary

This PR introduces a framework-agnostic error handling mechanism, refactors planning terminology, improves tool docstring customization, and adds a new team management tool:

### Commit 1: Error Handling Framework
- Add framework-agnostic `ToolError` exception in `akgentic.tool.errors` for tools to signal recoverable LLM errors
- `ToolFactory` accepts a `retry_exception` parameter — injected by the integration layer (e.g., `ModelRetry` from pydantic-ai) to translate `ToolError` into the appropriate retry mechanism
- `PlanActor.update_planning()` now raises `ToolError` on partial failures instead of returning a soft error string the LLM would ignore

### Commit 2: Refactor PlanItem → Task
- Rename `PlanItem`/`PlanItemCreate`/`PlanItemUpdate` to `Task`/`TaskCreate`/`TaskUpdate`
- Rename `get_planning_item` to `get_planning_task`
- Update all references from 'item' to 'task' terminology for consistency
- Update tests to properly assert `ToolError` exceptions

### Commit 3: Tool Docstring Instructions Refactor ⚠️ BREAKING CHANGE
- **Rename** `BaseToolParam.description` → `instructions` to clarify intent
- **Change behavior** from "replace docstring" to "append instructions"
- **Add** `BaseToolParam.format_docstring()` method to centralize formatting logic
- **Update** all factory methods (search, planning) to use `format_docstring()`
- Instructions are now appended under an "Additional Instructions:" header
- Update tests to reflect field name change

**BREAKING CHANGE:** The `description` field in `BaseToolParam` has been renamed to `instructions` and now appends to the original docstring instead of replacing it. Existing configurations using `description` must be updated to use `instructions`.

### Commit 4: Team Management Tool ✨ NEW FEATURE
- **Implement TeamTool** with hire/fire capabilities as a reusable ToolCard
- **hire_team_members**: Hire new team members by role name
- **fire_team_members**: Fire existing team members by name
- **get_team_roster**: System prompt providing current team composition awareness
- **get_role_profiles**: System prompt with available role descriptions
- Integrates with orchestrator for actor system access
- Add comprehensive test suite (475+ lines) covering all operations
- Enhance event system with team management events (TeamCreatedEvent, TeamMemberAddedEvent, etc.)
- Remove deprecated planning/event.py

## Design

### Error Handling
Two-layer error translation keeps `akgentic-tool` decoupled from pydantic-ai:

```
Tool Layer (akgentic-tool)              Integration Layer (akgentic-team)
──────────────────────────              ─────────────────────────────────
PlanActor raises ToolError        →     ToolFactory wrapper catches it
  propagates through closure      →       re-raises as ModelRetry
                                  →         pydantic-ai retries the LLM
```

### Tool Docstring Customization
Centralized formatting in `BaseToolParam`:
- Single method responsible for docstring formatting
- Consistent "Additional Instructions:" header across all tools
- Preserves original docstring with parameter documentation
- DRY principle — no duplicated formatting logic

### Team Management Tool
Reusable ToolCard design pattern:
- Framework-agnostic implementation
- Event-driven architecture via TeamManagementToolObserver
- System prompt injection for team awareness
- Orchestrator integration for actor system access

## Changes

### Error Handling
| File | Change |
|------|--------|
| `errors.py` | **New** — `ToolError` exception |
| `__init__.py` | Export `ToolError` |
| `core.py` | `ToolFactory` accepts `retry_exception`, wraps tools via `_wrap_with_retry()` |
| `planning/planning_actor.py` | `update_planning()` raises `ToolError` instead of returning error string |

### Refactoring
| File | Change |
|------|--------|
| `planning/planning_actor.py` | Rename all `PlanItem` → `Task`, `item` → `task` |
| `planning/planning.py` | Update method names and references to use task terminology |

### Tool Instructions
| File | Change |
|------|--------|
| `core.py` | Rename `description` → `instructions`, add `format_docstring()` method |
| `search/search.py` | Update 3 factory methods to use `format_docstring()` |
| `planning/planning.py` | Update 4 factory methods to use `format_docstring()` |
| `tests/test_core_factory.py` | Update test assertions for field name change |

### Team Management Tool
| File | Change |
|------|--------|
| `team/__init__.py` | **New** — Export TeamTool and related classes |
| `team/team.py` | **New** (356 lines) — TeamTool implementation |
| `event.py` | Add TeamManagementToolObserver protocol and team events |
| `__init__.py` | Export TeamTool |
| `tests/test_team_tool.py` | **New** (475 lines) — Comprehensive test coverage |
| `planning/event.py` | **Deleted** — Deprecated file |

## Test plan

- [x] Unit test: `PlanActor.update_planning()` with invalid IDs raises `ToolError`
- [x] All existing tests pass
- [x] `BaseToolParam.instructions` field properly appends to docstrings
- [x] TeamTool: hire_team_members operation with mocked orchestrator
- [x] TeamTool: fire_team_members operation with event generation
- [x] TeamTool: System prompts (team roster and role profiles)
- [x] TeamTool: Error handling and edge cases
- [ ] Integration test: `ToolFactory` with `retry_exception=SomeException` translates `ToolError` correctly
