### PR TITLE
feat(tool): TeamTool, Channel-based expose model and command API

### DIFF
--- a/src/akgentic/tool/__init__.py
+++ b/src/akgentic/tool/__init__.py
@@ -2,7 +2,15 @@
 
 # Submodules with their own __init__ files
 from . import mcp, planning, search, team
-from .core import BaseToolParam, ToolCard, ToolFactory
+from .core import (
+    COMMAND,
+    SYSTEM_PROMPT,
+    TOOL_CALL,
+    BaseToolParam,
+    Channels,
+    ToolCard,
+    ToolFactory,
+)
 from .errors import RetriableError
 from .event import (
     ActorToolObserver,
@@ -16,6 +24,11 @@ __all__ = [
     "BaseToolParam",
     "ToolCard",
     "ToolFactory",
+    # Expose channel constants
+    "COMMAND",
+    "SYSTEM_PROMPT",
+    "TOOL_CALL",
+    "Channels",
     # Errors
     "RetriableError",
     # Events and observers

--- a/src/akgentic/tool/__init__.py
+++ b/src/akgentic/tool/__init__.py
@@ -3,7 +3,7 @@
 # Submodules with their own __init__ files
 from . import mcp, planning, search, team
 from .core import BaseToolParam, ToolCard, ToolFactory
-from .errors import ToolError
+from .errors import RetriableError
 from .event import (
     ActorToolObserver,
     TeamManagementToolObserver,
@@ -17,7 +17,7 @@ __all__ = [
     "ToolCard",
     "ToolFactory",
     # Errors
-    "ToolError",
+    "RetriableError",
     # Events and observers
     "ToolCallEvent",
     "ToolObserver",

--- a/src/akgentic/tool/__init__.py
+++ b/src/akgentic/tool/__init__.py
@@ -1,10 +1,15 @@
 """akgentic-tool public API."""
 
 # Submodules with their own __init__ files
-from . import mcp, planning, search
+from . import mcp, planning, search, team
 from .core import BaseToolParam, ToolCard, ToolFactory
 from .errors import ToolError
-from .event import ActorToolObserver, ToolCallEvent, ToolObserver
+from .event import (
+    ActorToolObserver,
+    TeamManagementToolObserver,
+    ToolCallEvent,
+    ToolObserver,
+)
 
 __all__ = [
     # Core abstractions
@@ -17,8 +22,10 @@ __all__ = [
     "ToolCallEvent",
     "ToolObserver",
     "ActorToolObserver",
+    "TeamManagementToolObserver",
     # Submodules
     "mcp",
     "planning",
     "search",
+    "team",
 ]

--- a/src/akgentic/tool/core.py
+++ b/src/akgentic/tool/core.py
@@ -12,7 +12,7 @@ from typing import Any, Callable, TypeVar
 
 from pydantic import BaseModel
 
-from akgentic.tool.errors import ToolError
+from akgentic.tool.errors import RetriableError
 from akgentic.tool.event import ToolObserver
 
 T = TypeVar("T", bound="BaseToolParam")
@@ -161,7 +161,7 @@ class ToolFactory:
         def wrapper(*args, **kwargs):
             try:
                 return fn(*args, **kwargs)
-            except ToolError as e:
+            except RetriableError as e:
                 raise retry_exc(str(e)) from e
 
         return wrapper

--- a/src/akgentic/tool/core.py
+++ b/src/akgentic/tool/core.py
@@ -182,7 +182,7 @@ class ToolFactory:
             observer: Optional observer notified by tool implementations during
                 tool calls.
             retry_exception: Optional exception class to raise when a tool raises
-                ``ToolError``. Injected by the integration layer (e.g., ModelRetry
+                ``RetriableError``. Injected by the integration layer (e.g., ModelRetry
                 from pydantic-ai) to keep the tool module framework-agnostic.
         """
         self.tool_cards = tool_cards
@@ -194,7 +194,7 @@ class ToolFactory:
                 card.observer(self.observer)
 
     def _wrap_with_retry(self, fn: Callable) -> Callable:
-        """Wrap a tool callable to convert ``ToolError`` into retry_exception."""
+        """Wrap a tool callable to convert ``RetriableError`` into retry_exception."""
         assert self._retry_exception is not None
         retry_exc = self._retry_exception
 

--- a/src/akgentic/tool/core.py
+++ b/src/akgentic/tool/core.py
@@ -80,8 +80,8 @@ class BaseToolParam(BaseModel):
     expose: set[Channels] = {TOOL_CALL}
     """Set of channels this capability is exposed through.
 
-    Defaults to ``{Channel.TOOL_CALL}``. Override in subclasses or at instantiation.
-    Use ``Channel`` enum members or module-level aliases: ``TOOL_CALL``, ``SYSTEM_PROMPT``, ``COMMAND``.
+    Defaults to ``{TOOL_CALL}``. Override in subclasses or at instantiation.
+    Use ``Channels`` enum members or module-level aliases: ``TOOL_CALL``, ``SYSTEM_PROMPT``, ``COMMAND``.
     """
 
     def format_docstring(self, original: str | None) -> str | None:

--- a/src/akgentic/tool/core.py
+++ b/src/akgentic/tool/core.py
@@ -8,6 +8,7 @@ Defines the core contracts:
 
 import functools
 from abc import ABC, abstractmethod
+from enum import StrEnum
 from typing import Any, Callable, TypeVar
 
 from pydantic import BaseModel
@@ -36,11 +37,37 @@ def _resolve(value: "T | bool", cls: "type[T]") -> "T | None":
     return value  # already a ParamModel instance
 
 
+class Channels(StrEnum):
+    """Valid channel names for capability exposure."""
+
+    SYSTEM_PROMPT = "system_prompt"
+    """Expose as a system prompt injected into the LLM context."""
+
+    TOOL_CALL = "tool_call"
+    """Expose as a callable tool for the LLM."""
+
+    COMMAND = "command"
+    """Expose as a programmatic command for inter-agent orchestration."""
+
+
+# Backward-compatible module-level aliases
+SYSTEM_PROMPT = Channels.SYSTEM_PROMPT
+TOOL_CALL = Channels.TOOL_CALL
+COMMAND = Channels.COMMAND
+
+
 class BaseToolParam(BaseModel):
     """Base for capability parameter models.
 
     Provides common fields that control how a capability is exposed
-    to the LLM and how its description can be customized.
+    and how its description can be customized.
+
+    Each subclass can override the default ``expose`` set to declare the channels
+    it participates in. Use the module-level channel constants:
+
+    - ``TOOL_CALL``: callable tool invoked by the LLM (default).
+    - ``SYSTEM_PROMPT``: prompt injected into the LLM context.
+    - ``COMMAND``: programmatic call for inter-agent orchestration.
     """
 
     instructions: str | None = None
@@ -50,11 +77,12 @@ class BaseToolParam(BaseModel):
     under a structured header. When ``None``, only the default docstring is used.
     """
 
-    system_prompt: bool = False
-    """Whether this capability injects a system prompt into the LLM context."""
+    expose: set[Channels] = {TOOL_CALL}
+    """Set of channels this capability is exposed through.
 
-    llm_tool: bool = True
-    """Whether this capability is exposed as a callable tool for the LLM."""
+    Defaults to ``{Channel.TOOL_CALL}``. Override in subclasses or at instantiation.
+    Use ``Channel`` enum members or module-level aliases: ``TOOL_CALL``, ``SYSTEM_PROMPT``, ``COMMAND``.
+    """
 
     def format_docstring(self, original: str | None) -> str | None:
         """Format the tool docstring with optional additional instructions.
@@ -117,6 +145,19 @@ class ToolCard(BaseModel, ABC):
         """
         return []
 
+    def get_commands(self) -> dict[type["BaseToolParam"], Callable]:
+        """Return callable commands for programmatic invocation.
+
+        Commands are methods exposed for inter-agent orchestration
+        (e.g., ``hire_member``, ``fire_member``). Unlike tools (invoked by
+        the LLM), commands are called programmatically by other agents
+        or system components via ``proxy_call`` or similar mechanisms.
+
+        Returns:
+            Dict mapping param class (e.g., ``HireTeamMember``) to callable.
+        """
+        return {}
+
     def get_toolsets(self) -> list[Any]:
         """Return runtime toolset objects (e.g., MCP servers)."""
         return []
@@ -176,6 +217,20 @@ class ToolFactory:
     def get_system_prompts(self) -> list[Callable]:
         """Return system prompt callables aggregated from all tool cards."""
         return [p for card in self.tool_cards for p in card.get_system_prompts()]
+
+    def get_commands(self) -> dict[type[BaseToolParam], Callable]:
+        """Return command callables aggregated from all tool cards.
+
+        Returns:
+            Dict mapping param class to callable, merged from all tool cards.
+        """
+        commands: dict[type[BaseToolParam], Callable] = {}
+        for card in self.tool_cards:
+            commands.update(card.get_commands())
+
+        if self._retry_exception is not None:
+            commands = {k: self._wrap_with_retry(v) for k, v in commands.items()}
+        return commands
 
     def get_toolsets(self) -> list[Any]:
         """Return toolset instances aggregated from all tool cards."""

--- a/src/akgentic/tool/errors.py
+++ b/src/akgentic/tool/errors.py
@@ -5,7 +5,7 @@ translates them into the appropriate retry mechanism (e.g., pydantic-ai ModelRet
 """
 
 
-class ToolError(Exception):
+class RetriableError(Exception):
     """Raised by tool implementations when the LLM should retry with corrected input.
 
     Tools raise this to signal a recoverable error. The consuming framework

--- a/src/akgentic/tool/event.py
+++ b/src/akgentic/tool/event.py
@@ -78,7 +78,7 @@ class TeamManagementToolObserver(ActorToolObserver, Protocol):
     actor system.
     """
 
-    def createActor(
+    def createActor(  # noqa: N802
         self,
         actor_class: type[AkgentType],
         *,
@@ -92,23 +92,6 @@ class TeamManagementToolObserver(ActorToolObserver, Protocol):
 
         Returns:
             Address of the newly created actor
-        """
-        ...
-
-    def send(self, target: ActorAddress, message: object) -> None:
-        """Send a message to another actor.
-
-        Args:
-            target: Address of the target actor
-            message: Message to send
-        """
-        ...
-
-    def stop(self, target: ActorAddress) -> None:
-        """Stop an actor and its children recursively.
-
-        Args:
-            target: Address of the actor to stop
         """
         ...
 

--- a/src/akgentic/tool/event.py
+++ b/src/akgentic/tool/event.py
@@ -68,3 +68,74 @@ class ActorToolObserver(ToolObserver, Protocol):
         """
         ...
 
+
+@runtime_checkable
+class TeamManagementToolObserver(ActorToolObserver, Protocol):
+    """Observer protocol for team management tools.
+
+    Extends ActorToolObserver with team-specific capabilities needed by
+    TeamTool for hiring, firing, and managing team members within the
+    actor system.
+    """
+
+    def createActor(
+        self,
+        actor_class: type[AkgentType],
+        *,
+        config: object,
+    ) -> ActorAddress:
+        """Create a child actor with the given config.
+
+        Args:
+            actor_class: The actor class to instantiate
+            config: Configuration object for the actor
+
+        Returns:
+            Address of the newly created actor
+        """
+        ...
+
+    def send(self, target: ActorAddress, message: object) -> None:
+        """Send a message to another actor.
+
+        Args:
+            target: Address of the target actor
+            message: Message to send
+        """
+        ...
+
+    def stop(self, target: ActorAddress) -> None:
+        """Stop an actor and its children recursively.
+
+        Args:
+            target: Address of the actor to stop
+        """
+        ...
+
+    def on_hire(self, name: str, address: ActorAddress) -> None:
+        """Hook called after hiring a team member.
+
+        Handles agent-specific concerns such as:
+        - Tracking child in agent's children list
+        - Updating local caches
+        - Any agent-specific bookkeeping
+
+        Args:
+            name: Name of hired agent (e.g., '@Developer123')
+            address: ActorAddress of hired agent
+        """
+        ...
+
+    def on_fire(self, name: str, address: ActorAddress) -> None:
+        """Hook called after firing a team member.
+
+        Handles agent-specific concerns such as:
+        - Removing from children tracking
+        - Clearing from local caches
+        - Any agent-specific cleanup
+
+        Args:
+            name: Name of fired agent (e.g., '@Developer123')
+            address: ActorAddress of fired agent
+        """
+        ...

--- a/src/akgentic/tool/planning/__init__.py
+++ b/src/akgentic/tool/planning/__init__.py
@@ -2,7 +2,7 @@
 
 from .planning import (
     GetPlanning,
-    GetPlanningItem,
+    GetPlanningTask,
     PlanningTool,
     UpdatePlanning,
 )
@@ -10,7 +10,7 @@ from .planning_actor import PlanManagerState
 
 __all__ = [
     "GetPlanning",
-    "GetPlanningItem",
+    "GetPlanningTask",
     "PlanManagerState",
     "PlanningTool",
     "UpdatePlanning",

--- a/src/akgentic/tool/planning/event.py
+++ b/src/akgentic/tool/planning/event.py
@@ -1,5 +1,0 @@
-"""Planning module events.
-
-This module is intentionally empty. Planning tools use ToolCallEvent
-from the parent event module instead of defining custom event types.
-"""

--- a/src/akgentic/tool/planning/planning.py
+++ b/src/akgentic/tool/planning/planning.py
@@ -87,7 +87,6 @@ class PlanningTool(ToolCard):
                     ]
                 )
 
-            team_planning.__doc__ = gp.format_docstring(team_planning.__doc__)
             return [team_planning]
         return []
 

--- a/src/akgentic/tool/planning/planning.py
+++ b/src/akgentic/tool/planning/planning.py
@@ -5,7 +5,15 @@ from pydantic import Field
 
 from akgentic.core.agent_config import BaseConfig
 from akgentic.core.orchestrator import Orchestrator
-from akgentic.tool.core import BaseToolParam, ToolCard, _resolve
+from akgentic.tool.core import (
+    COMMAND,
+    SYSTEM_PROMPT,
+    TOOL_CALL,
+    BaseToolParam,
+    Channels,
+    ToolCard,
+    _resolve,
+)
 from akgentic.tool.event import ActorToolObserver, ToolCallEvent
 from akgentic.tool.planning.planning_actor import PlanActor, Task, UpdatePlan
 
@@ -19,20 +27,17 @@ PLANNING_ACTOR_ROLE = "ToolActor"
 class GetPlanning(BaseToolParam):
     """Get the full team plan — as system prompt and/or tool."""
 
-    system_prompt: bool = True
-    llm_tool: bool = False
+    expose: set[Channels] = {SYSTEM_PROMPT, COMMAND}
 
 
 class GetPlanningTask(BaseToolParam):
     """Get a single task by ID."""
 
-    pass
+    expose: set[Channels] = {TOOL_CALL, COMMAND}
 
 
 class UpdatePlanning(BaseToolParam):
     """Update tasks."""
-
-    pass
 
 
 class PlanningTool(ToolCard):
@@ -69,54 +74,58 @@ class PlanningTool(ToolCard):
 
     def get_system_prompts(self) -> list[Callable]:
         gp = _resolve(self.get_planning, GetPlanning)
-        if gp and gp.system_prompt:
-            planning_proxy = self._planning_proxy
-
-            def team_planning() -> str:
-                planning = planning_proxy.get_planning()
-                if not planning:
-                    return "No current Team planning."
-                return "Team planning:\n" + "\n".join(
-                    [
-                        f"- ID {task.id} [{task.status}] {task.description} "
-                        f"{task.output and f'— Output: {task.output} '}"
-                        f"(Owner: {task.owner}, Creator: {task.creator})"
-                        for task in planning
-                    ]
-                )
-
-            return [team_planning]
+        if gp and SYSTEM_PROMPT in gp.expose:
+            return [self._planning_prompt_factory(gp)]
         return []
 
     def get_tools(self) -> list[Callable]:
         tools: list[Callable] = []
 
         gp = _resolve(self.get_planning, GetPlanning)
-        if gp and gp.llm_tool:
-            tools.append(self._get_planning_factory(gp))
+        if gp and TOOL_CALL in gp.expose:
+            tools.append(self._planning_prompt_factory(gp))
 
         gpi = _resolve(self.get_planning_task, GetPlanningTask)
-        if gpi and gpi.llm_tool:
+        if gpi and TOOL_CALL in gpi.expose:
             tools.append(self._get_planning_task_factory(gpi))
 
         up = _resolve(self.update_planning, UpdatePlanning)
-        if up and up.llm_tool:
+        if up and TOOL_CALL in up.expose:
             tools.append(self._update_planning_factory(up))
 
         return tools
 
-    def _get_planning_factory(self, params: GetPlanning) -> Callable:
+    def get_commands(self) -> dict[type[BaseToolParam], Callable]:
+        commands: dict[type[BaseToolParam], Callable] = {}
+
+        gp = _resolve(self.get_planning, GetPlanning)
+        if gp and COMMAND in gp.expose:
+            commands[GetPlanning] = self._planning_prompt_factory(gp)
+
+        gpi = _resolve(self.get_planning_task, GetPlanningTask)
+        if gpi and COMMAND in gpi.expose:
+            commands[GetPlanningTask] = self._get_planning_task_factory(gpi)
+
+        return commands
+
+    def _planning_prompt_factory(self, params: GetPlanning) -> Callable:
         planning_proxy = self._planning_proxy
-        observer = self._observer
 
-        def get_planning() -> list[Task]:
+        def planning_prompt() -> str:
             """Get the full team planning."""
-            if observer is not None:
-                observer.notify_event(ToolCallEvent(tool_name="Get planning", args=[], kwargs={}))
-            return planning_proxy.get_planning()
+            planning = planning_proxy.get_planning()
+            if not planning:
+                return "No current Team planning."
+            return "Team planning:\n" + "\n".join(
+                [
+                    f"- ID {task.id} [{task.status}] {task.description} "
+                    f"{task.output and f'\u2014 Output: {task.output} '}"
+                    f"(Owner: {task.owner}, Creator: {task.creator})"
+                    for task in planning
+                ]
+            )
 
-        get_planning.__doc__ = params.format_docstring(get_planning.__doc__)
-        return get_planning
+        return planning_prompt
 
     def _get_planning_task_factory(self, params: GetPlanningTask) -> Callable:
         planning_proxy = self._planning_proxy

--- a/src/akgentic/tool/planning/planning.py
+++ b/src/akgentic/tool/planning/planning.py
@@ -60,9 +60,7 @@ class PlanningTool(ToolCard):
         planning_tool_addr = orchestrator_proxy_ask.get_team_member(PLANNING_ACTOR_NAME)
 
         if planning_tool_addr is None:
-            logger.info(
-                f"PlanningTool actor not found in team, creating new one at {PLANNING_ACTOR_NAME}."
-            )
+            logger.info(f"PlanningTool: create {PLANNING_ACTOR_NAME}.")
             planning_tool_addr = orchestrator_proxy_ask.createActor(
                 PlanActor, config=BaseConfig(name=PLANNING_ACTOR_NAME, role=PLANNING_ACTOR_ROLE)
             )

--- a/src/akgentic/tool/planning/planning.py
+++ b/src/akgentic/tool/planning/planning.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Callable
 
-from pydantic import Field, PrivateAttr
+from pydantic import Field
 
 from akgentic.core.agent_config import BaseConfig
 from akgentic.core.orchestrator import Orchestrator
@@ -23,7 +23,7 @@ class GetPlanning(BaseToolParam):
     llm_tool: bool = False
 
 
-class GetPlanningItem(BaseToolParam):
+class GetPlanningTask(BaseToolParam):
     """Get a single task by ID."""
 
     pass
@@ -44,7 +44,7 @@ class PlanningTool(ToolCard):
     get_planning: GetPlanning | bool = Field(
         default=True, description="By default the plan in included in the system prompt"
     )
-    get_planning_task: GetPlanningItem | bool = True
+    get_planning_task: GetPlanningTask | bool = True
     update_planning: UpdatePlanning | bool = True
 
     def observer(self, observer: ActorToolObserver):
@@ -98,7 +98,7 @@ class PlanningTool(ToolCard):
         if gp and gp.llm_tool:
             tools.append(self._get_planning_factory(gp))
 
-        gpi = _resolve(self.get_planning_task, GetPlanningItem)
+        gpi = _resolve(self.get_planning_task, GetPlanningTask)
         if gpi and gpi.llm_tool:
             tools.append(self._get_planning_task_factory(gpi))
 
@@ -121,7 +121,7 @@ class PlanningTool(ToolCard):
         get_planning.__doc__ = params.format_docstring(get_planning.__doc__)
         return get_planning
 
-    def _get_planning_task_factory(self, params: GetPlanningItem) -> Callable:
+    def _get_planning_task_factory(self, params: GetPlanningTask) -> Callable:
         planning_proxy = self._planning_proxy
         observer = self._observer
 

--- a/src/akgentic/tool/planning/planning_actor.py
+++ b/src/akgentic/tool/planning/planning_actor.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, Field
 from akgentic.core.actor_address import ActorAddress
 from akgentic.core.agent import Akgent, BaseConfig, BaseState
 from akgentic.core.utils.serializer import SerializableBaseModel
-from akgentic.tool.errors import ToolError
+from akgentic.tool.errors import RetriableError
 
 TaskStatus = Literal["pending", "started", "completed", "abort"]
 
@@ -130,5 +130,5 @@ class PlanActor(Akgent[BaseConfig, PlanManagerState]):
         self.state.notify_state_change()
 
         if errors:
-            raise ToolError("Update errors: " + "; ".join(errors))
+            raise RetriableError("Update errors: " + "; ".join(errors))
         return "Done"

--- a/src/akgentic/tool/search/search.py
+++ b/src/akgentic/tool/search/search.py
@@ -2,7 +2,7 @@ from typing import Any, Callable, Literal
 
 from tavily import TavilyClient
 
-from akgentic.tool.core import BaseToolParam, ToolCard, _resolve
+from akgentic.tool.core import TOOL_CALL, BaseToolParam, ToolCard, _resolve
 from akgentic.tool.event import ToolCallEvent
 
 
@@ -44,13 +44,13 @@ class SearchTool(ToolCard):
     def get_tools(self) -> list[Callable]:
         tools: list[Callable] = []
         ws = _resolve(self.web_search, WebSearch)
-        if ws and ws.llm_tool:
+        if ws and TOOL_CALL in ws.expose:
             tools.append(self._web_search_factory(ws))
         wc = _resolve(self.web_crawl, WebCrawl)
-        if wc and wc.llm_tool:
+        if wc and TOOL_CALL in wc.expose:
             tools.append(self._web_crawl_factory(wc))
         wf = _resolve(self.web_fetch, WebFetch)
-        if wf and wf.llm_tool:
+        if wf and TOOL_CALL in wf.expose:
             tools.append(self._web_fetch_factory(wf))
         return tools
 

--- a/src/akgentic/tool/team/__init__.py
+++ b/src/akgentic/tool/team/__init__.py
@@ -1,17 +1,17 @@
 """Team management tool for akgentic framework."""
 
 from .team import (
-    FireTeamMembers,
+    FireTeamMember,
     GetRoleProfiles,
     GetTeamRoster,
-    HireTeamMembers,
+    HireTeamMember,
     TeamTool,
 )
 
 __all__ = [
     "TeamTool",
-    "HireTeamMembers",
-    "FireTeamMembers",
+    "HireTeamMember",
+    "FireTeamMember",
     "GetTeamRoster",
     "GetRoleProfiles",
 ]

--- a/src/akgentic/tool/team/__init__.py
+++ b/src/akgentic/tool/team/__init__.py
@@ -1,0 +1,17 @@
+"""Team management tool for akgentic framework."""
+
+from .team import (
+    FireTeamMembers,
+    GetRoleProfiles,
+    GetTeamRoster,
+    HireTeamMembers,
+    TeamTool,
+)
+
+__all__ = [
+    "TeamTool",
+    "HireTeamMembers",
+    "FireTeamMembers",
+    "GetTeamRoster",
+    "GetRoleProfiles",
+]

--- a/src/akgentic/tool/team/team.py
+++ b/src/akgentic/tool/team/team.py
@@ -10,36 +10,138 @@ from typing import Callable
 
 from pydantic import Field
 
+from akgentic.core.actor_address import ActorAddress
+from akgentic.core.agent_card import AgentCard
 from akgentic.core.orchestrator import Orchestrator
-from akgentic.tool.core import BaseToolParam, ToolCard, _resolve
+from akgentic.tool.core import (
+    COMMAND,
+    SYSTEM_PROMPT,
+    TOOL_CALL,
+    BaseToolParam,
+    Channels,
+    ToolCard,
+    _resolve,
+)
 from akgentic.tool.errors import RetriableError
 from akgentic.tool.event import TeamManagementToolObserver, ToolCallEvent
 
 logger = logging.getLogger(__name__)
 
 
-class HireTeamMembers(BaseToolParam):
+class HireTeamMember(BaseToolParam):
     """Hire new team members by role."""
 
-    pass
+    expose: set[Channels] = {TOOL_CALL, COMMAND}
 
 
-class FireTeamMembers(BaseToolParam):
+class FireTeamMember(BaseToolParam):
     """Fire existing team members by name."""
 
-    pass
+    expose: set[Channels] = {TOOL_CALL, COMMAND}
 
 
 class GetTeamRoster(BaseToolParam):
     """Get current team roster as system prompt."""
 
-    system_prompt: bool = True
+    expose: set[Channels] = {SYSTEM_PROMPT, COMMAND}
 
 
 class GetRoleProfiles(BaseToolParam):
     """Get available role profiles as system prompt."""
 
-    system_prompt: bool = True
+    expose: set[Channels] = {SYSTEM_PROMPT, COMMAND}
+
+
+def _hire_single_member(
+    orchestrator_proxy: Orchestrator,
+    observer: TeamManagementToolObserver,
+    role: str,
+    name: str | None,
+    existing_names: set[str],
+    agent_catalog: list[AgentCard] | None = None,
+) -> tuple[str, ActorAddress]:
+    """Core hire logic for a single member.
+
+    Args:
+        orchestrator_proxy: Proxy to the orchestrator actor.
+        observer: TeamManagementToolObserver for actor creation and hooks.
+        role: Role to hire.
+        name: Optional specific name. If None, auto-generated.
+        existing_names: Set of existing member names (for uniqueness).
+        agent_catalog: Pre-fetched catalog. If None, fetched from orchestrator.
+
+    Returns:
+        Tuple of (child_name, child_address).
+
+    Raises:
+        RetriableError: If no agent card found for the role.
+        ValueError: If agent class is a string (configuration error).
+    """
+    if agent_catalog is None:
+        agent_catalog = orchestrator_proxy.get_agent_catalog()
+    agent_card = next((card for card in agent_catalog if card.role == role), None)
+    if agent_card is None:
+        available_roles = orchestrator_proxy.get_available_roles()
+        raise RetriableError(
+            f"Hire error - cannot find agent card for role '{role}'. "
+            f"Available roles: {available_roles}"
+        )
+
+    actor_class = agent_card.get_agent_class()
+    if isinstance(actor_class, str):
+        raise ValueError(f"Hire error - agent class for role {role} is a string, not a type. ")
+
+    if name is None:
+        role_prefix = f"@{role.replace(' ', '')}"
+        suffix = random.randint(100, 999)
+        child_name = f"{role_prefix}{suffix}"
+        while child_name in existing_names:
+            suffix += 1
+            child_name = f"{role_prefix}{suffix}"
+    else:
+        child_name = name
+
+    agent_card_config = agent_card.get_config_copy()
+    agent_card_config.name = child_name
+    agent_card_config.role = role
+
+    child_address = observer.createActor(actor_class, config=agent_card_config)
+    observer.on_hire(child_name, child_address)
+
+    logger.info(f"Hired {role} agent: {child_name} at {child_address}")
+    return child_name, child_address
+
+
+def _fire_single_member(
+    orchestrator_proxy: Orchestrator,
+    observer: TeamManagementToolObserver,
+    name: str,
+) -> str:
+    """Core fire logic for a single member.
+
+    Args:
+        orchestrator_proxy: Proxy to the orchestrator actor.
+        observer: TeamManagementToolObserver for hooks.
+        name: Name of the member to fire.
+
+    Returns:
+        The fired member's name.
+
+    Raises:
+        RetriableError: If member not found in team.
+    """
+    address = orchestrator_proxy.get_team_member(name)
+    if address is None:
+        team_members = [member.name for member in orchestrator_proxy.get_team()]
+        raise RetriableError(
+            f"Fire error - member '{name}' not part of the team. "
+            f"Current team members: {team_members}"
+        )
+
+    address.stop()
+    observer.on_fire(name, address)
+    logger.info(f"Fired team member: {name}")
+    return name
 
 
 class TeamTool(ToolCard):
@@ -55,10 +157,10 @@ class TeamTool(ToolCard):
     name: str = "Team"
     description: str = "Team management tool for hiring, firing, and team awareness"
 
-    hire_team_members: HireTeamMembers | bool = Field(
+    hire_team_members: HireTeamMember | bool = Field(
         default=True, description="Enable hiring team members (default: True)"
     )
-    fire_team_members: FireTeamMembers | bool = Field(
+    fire_team_members: FireTeamMember | bool = Field(
         default=True, description="Enable firing team members (default: True)"
     )
     get_role_profiles: GetRoleProfiles | bool = Field(
@@ -98,11 +200,11 @@ class TeamTool(ToolCard):
         prompts: list[Callable] = []
 
         gtr = _resolve(self.get_team_roster, GetTeamRoster)
-        if gtr and gtr.system_prompt:
+        if gtr and SYSTEM_PROMPT in gtr.expose:
             prompts.append(self._team_roster_prompt_factory(gtr))
 
         grp = _resolve(self.get_role_profiles, GetRoleProfiles)
-        if grp and grp.system_prompt:
+        if grp and SYSTEM_PROMPT in grp.expose:
             prompts.append(self._role_profiles_prompt_factory(grp))
 
         return prompts
@@ -115,17 +217,43 @@ class TeamTool(ToolCard):
         """
         tools: list[Callable] = []
 
-        htm = _resolve(self.hire_team_members, HireTeamMembers)
-        if htm and htm.llm_tool:
+        htm = _resolve(self.hire_team_members, HireTeamMember)
+        if htm and TOOL_CALL in htm.expose:
             tools.append(self._hire_members_factory(htm))
 
-        ftm = _resolve(self.fire_team_members, FireTeamMembers)
-        if ftm and ftm.llm_tool:
+        ftm = _resolve(self.fire_team_members, FireTeamMember)
+        if ftm and TOOL_CALL in ftm.expose:
             tools.append(self._fire_members_factory(ftm))
 
         return tools
 
-    def _hire_members_factory(self, params: HireTeamMembers) -> Callable:
+    def get_commands(self) -> dict[type[BaseToolParam], Callable]:
+        """Get programmatic commands for inter-agent orchestration.
+
+        Returns:
+            Dict mapping param class to callable.
+        """
+        commands: dict[type[BaseToolParam], Callable] = {}
+
+        htm = _resolve(self.hire_team_members, HireTeamMember)
+        if htm and COMMAND in htm.expose:
+            commands[HireTeamMember] = self._hire_member_command_factory(htm)
+
+        ftm = _resolve(self.fire_team_members, FireTeamMember)
+        if ftm and COMMAND in ftm.expose:
+            commands[FireTeamMember] = self._fire_member_command_factory(ftm)
+
+        gtr = _resolve(self.get_team_roster, GetTeamRoster)
+        if gtr and COMMAND in gtr.expose:
+            commands[GetTeamRoster] = self._team_roster_prompt_factory(gtr)
+
+        grp = _resolve(self.get_role_profiles, GetRoleProfiles)
+        if grp and COMMAND in grp.expose:
+            commands[GetRoleProfiles] = self._role_profiles_prompt_factory(grp)
+
+        return commands
+
+    def _hire_members_factory(self, params: HireTeamMember) -> Callable:
         """Create hire_members tool callable.
 
         Args:
@@ -161,46 +289,23 @@ class TeamTool(ToolCard):
 
             hired_members = []
             errors = []
-            agent_catalog = orchestrator_proxy.get_agent_catalog()
             existing_names = {member.name for member in orchestrator_proxy.get_team()}
+            agent_catalog = orchestrator_proxy.get_agent_catalog()
 
             for role in roles:
-                # Get agent card for role from catalog
-                agent_card = next((card for card in agent_catalog if card.role == role), None)
-                if agent_card is None:
-                    errors.append(role)
-                    continue
-
-                # Create child agent using agent primitive
-                # agent_class can be str | type, but in production it should be a type
-                actor_class = agent_card.get_agent_class()
-                if isinstance(actor_class, str):
-                    ## The llm cannot retry, so raise a ValueError
-                    raise ValueError(
-                        f"Hire error - agent class for role {role} is a string, not a type. "
+                try:
+                    child_name, _ = _hire_single_member(
+                        orchestrator_proxy,
+                        observer,
+                        role,
+                        None,
+                        existing_names,
+                        agent_catalog=agent_catalog,
                     )
-
-                # Generate unique name: random, increment on collision
-                role_prefix = f"@{role.replace(' ', '')}"
-                suffix = random.randint(100, 999)
-                child_name = f"{role_prefix}{suffix}"
-                while child_name in existing_names:
-                    suffix += 1
-                    child_name = f"{role_prefix}{suffix}"
-
-                # Create config
-                agent_card_config = agent_card.get_config_copy()
-                agent_card_config.name = child_name
-                agent_card_config.role = role
-
-                child_address = observer.createActor(actor_class, config=agent_card_config)
-
-                # Call agent hook
-                observer.on_hire(child_name, child_address)
-
-                existing_names.add(child_name)
-                hired_members.append(child_name)
-                logger.info(f"Hired {role} agent: {child_name} at {child_address}")
+                    existing_names.add(child_name)
+                    hired_members.append(child_name)
+                except RetriableError:
+                    errors.append(role)
 
             if errors:
                 available_roles = orchestrator_proxy.get_available_roles()
@@ -218,7 +323,40 @@ class TeamTool(ToolCard):
         hire_members.__doc__ = params.format_docstring(hire_members.__doc__)
         return hire_members
 
-    def _fire_members_factory(self, params: FireTeamMembers) -> Callable:
+    def _hire_member_command_factory(self, params: HireTeamMember) -> Callable:
+        """Create hire_member command callable.
+
+        Args:
+            params: Configuration for hire capability
+
+        Returns:
+            Callable that hires a single team member
+        """
+        orchestrator_proxy = self._orchestrator_proxy
+        observer = self._observer
+
+        def hire_member(role: str, name: str | None = None):
+            """Hire a single new team member with the given role.
+
+            Creates a new agent actor with the specified role. If no name is
+            provided, one is auto-generated as @<Role><RandomNumber>.
+
+            Args:
+                role: Role to hire (must be in available_roles)
+                name: Optional specific name for the member
+
+            Returns:
+                Tuple of (member_name, member_address)
+            """
+            observer.notify_event(
+                ToolCallEvent(tool_name="hire_member", args=[], kwargs={"role": role, "name": name})
+            )
+            existing_names = {member.name for member in orchestrator_proxy.get_team()}
+            return _hire_single_member(orchestrator_proxy, observer, role, name, existing_names)
+
+        return hire_member
+
+    def _fire_members_factory(self, params: FireTeamMember) -> Callable:
         """Create fire_members tool callable.
 
         Args:
@@ -243,7 +381,7 @@ class TeamTool(ToolCard):
                 names: List of member names to fire (e.g., ['@Developer123', '@Tester456'])
 
             Returns:
-                Combined confirmation messages (e.g., "Member @Developer123 has been fired. - ...")
+                Combined confirmation messages (e.g., "Members fired: @Developer123, @Tester456")
             """
             if not names:
                 raise RetriableError("No names provided. Specify at least one member name to fire.")
@@ -255,21 +393,12 @@ class TeamTool(ToolCard):
             fired_members = []
             errors = []
             for name in names:
-                # Lookup member
-                address = orchestrator_proxy.get_team_member(name)
-                if address is None:
+                try:
+                    _fire_single_member(orchestrator_proxy, observer, name)
+                    fired_members.append(name)
+                except RetriableError:
                     errors.append(name)
                     logger.error(f"Fire error, team member not part of the team: {name}")
-                    continue
-
-                # Stop actor using agent primitive
-                address.stop()
-
-                # Call agent hook
-                observer.on_fire(name, address)
-
-                fired_members.append(name)
-                logger.info(f"Fired team member: {name}")
 
             if errors:
                 team_members = [member.name for member in orchestrator_proxy.get_team()]
@@ -286,6 +415,37 @@ class TeamTool(ToolCard):
 
         fire_members.__doc__ = params.format_docstring(fire_members.__doc__)
         return fire_members
+
+    def _fire_member_command_factory(self, params: FireTeamMember) -> Callable:
+        """Create fire_member command callable.
+
+        Args:
+            params: Configuration for fire capability
+
+        Returns:
+            Callable that fires a single team member
+        """
+        orchestrator_proxy = self._orchestrator_proxy
+        observer = self._observer
+
+        def fire_member(name: str) -> str:
+            """Fire a team member with the given name.
+
+            Stops the member actor and removes them from the team.
+
+            Args:
+                name: Member name to fire (e.g., '@Developer123')
+
+            Returns:
+                Confirmation message (e.g., "Member @Developer123 has been fired.")
+            """
+            observer.notify_event(
+                ToolCallEvent(tool_name="fire_member", args=[], kwargs={"name": name})
+            )
+            _fire_single_member(orchestrator_proxy, observer, name)
+            return f"Member {name} has been fired."
+
+        return fire_member
 
     def _team_roster_prompt_factory(self, params: GetTeamRoster) -> Callable:
         """Create team roster system prompt callable.

--- a/src/akgentic/tool/team/team.py
+++ b/src/akgentic/tool/team/team.py
@@ -100,6 +100,15 @@ def _hire_single_member(
             child_name = f"{role_prefix}{suffix}"
     else:
         child_name = name
+        if not isinstance(child_name, str):
+            raise RetriableError("Hire error - member name must be a string.")
+        child_name = child_name.strip()
+        if not child_name:
+            raise RetriableError("Hire error - member name cannot be empty.")
+        if child_name in existing_names:
+            raise RetriableError(
+                f"Hire error - member name '{child_name}' already exists. Please choose a unique name."
+            )
 
     agent_card_config = agent_card.get_config_copy()
     agent_card_config.name = child_name

--- a/src/akgentic/tool/team/team.py
+++ b/src/akgentic/tool/team/team.py
@@ -1,0 +1,356 @@
+"""Team management tool implementation.
+
+Provides hire, fire, and team awareness capabilities as a reusable ToolCard
+that can be attached to any agent.
+"""
+
+import logging
+import random
+import re
+from typing import Callable
+
+from pydantic import Field
+
+from akgentic.core.orchestrator import Orchestrator
+from akgentic.tool.core import BaseToolParam, ToolCard, _resolve
+from akgentic.tool.errors import ToolError
+from akgentic.tool.event import TeamManagementToolObserver, ToolCallEvent
+
+logger = logging.getLogger(__name__)
+
+
+class HireTeamMembers(BaseToolParam):
+    """Hire new team members by role."""
+
+    pass
+
+
+class FireTeamMembers(BaseToolParam):
+    """Fire existing team members by name."""
+
+    pass
+
+
+class GetTeamRoster(BaseToolParam):
+    """Get current team roster as system prompt."""
+
+    system_prompt: bool = True
+
+
+class GetRoleProfiles(BaseToolParam):
+    """Get available role profiles as system prompt."""
+
+    system_prompt: bool = True
+
+
+class TeamTool(ToolCard):
+    """Team management tool for hiring, firing, and team awareness.
+
+    Provides:
+    - hire_members(roles: list[str]) -> list[str]: Hire team members
+    - fire_members(names: list[str]) -> str: Fire team members
+    - Team roster system prompt: Current team composition
+    - Role profiles system prompt: Available roles and descriptions
+    """
+
+    name: str = "Team"
+    description: str = "Team management tool for hiring, firing, and team awareness"
+
+    hire_team_members: HireTeamMembers | bool = Field(
+        default=True, description="Enable hiring team members (default: True)"
+    )
+    fire_team_members: FireTeamMembers | bool = Field(
+        default=True, description="Enable firing team members (default: True)"
+    )
+    get_team_roster: GetTeamRoster | bool = Field(
+        default=True, description="Include team roster in system prompt (default: True)"
+    )
+    get_role_profiles: GetRoleProfiles | bool = Field(
+        default=True, description="Include role profiles in system prompt (default: True)"
+    )
+
+    def observer(self, observer: TeamManagementToolObserver) -> "TeamTool":
+        """Attach observer and set up the orchestrator proxy.
+
+        Requires a TeamManagementToolObserver for actor system access.
+
+        Args:
+            observer: Observer implementing TeamManagementToolObserver protocol
+
+        Returns:
+            Self, enabling method chaining
+
+        Raises:
+            ValueError: If observer.orchestrator is None
+        """
+        self._observer = observer
+        if observer.orchestrator is None:
+            raise ValueError("TeamTool requires access to the orchestrator.")
+
+        self._orchestrator_proxy = observer.proxy_ask(observer.orchestrator, Orchestrator)
+        return self
+
+    def get_system_prompts(self) -> list[Callable]:
+        """Get dynamic system prompts for team context.
+
+        Returns:
+            List of callable system prompts (roster and/or profiles)
+        """
+        prompts: list[Callable] = []
+
+        gtr = _resolve(self.get_team_roster, GetTeamRoster)
+        if gtr and gtr.system_prompt:
+            prompts.append(self._team_roster_prompt_factory(gtr))
+
+        grp = _resolve(self.get_role_profiles, GetRoleProfiles)
+        if grp and grp.system_prompt:
+            prompts.append(self._role_profiles_prompt_factory(grp))
+
+        return prompts
+
+    def get_tools(self) -> list[Callable]:
+        """Get LLM-callable tools for team management.
+
+        Returns:
+            List of callable tools (hire_members and/or fire_members)
+        """
+        tools: list[Callable] = []
+
+        htm = _resolve(self.hire_team_members, HireTeamMembers)
+        if htm and htm.llm_tool:
+            tools.append(self._hire_members_factory(htm))
+
+        ftm = _resolve(self.fire_team_members, FireTeamMembers)
+        if ftm and ftm.llm_tool:
+            tools.append(self._fire_members_factory(ftm))
+
+        return tools
+
+    def _hire_members_factory(self, params: HireTeamMembers) -> Callable:
+        """Create hire_members tool callable.
+
+        Args:
+            params: Configuration for hire capability
+
+        Returns:
+            Callable that hires team members
+        """
+        orchestrator_proxy = self._orchestrator_proxy
+        observer = self._observer
+
+        def hire_members(roles: list[str]) -> str:
+            """Hire multiple new team members with the given roles.
+
+            Creates new agent actors with specified roles. Names are auto-generated
+            as @<Role><RandomNumber>. Validates roles against available roles.
+
+            Note: Should only be used when explicitly requested by user to prevent
+            unnecessary agent proliferation.
+
+            Args:
+                roles: List of roles to hire (each must be in available_roles)
+
+            Returns:
+                Confirmation message with hired member names (e.g., 'Members hired: [@Developer123, @Tester456]')
+            """
+            observer.notify_event(
+                ToolCallEvent(tool_name="hire_members", args=[], kwargs={"roles": roles})
+            )
+
+            hired_members = []
+            errors = []
+            agent_catalog = orchestrator_proxy.get_agent_catalog()
+
+            for role in roles:
+                # Get agent card for role from catalog
+                agent_card = next((card for card in agent_catalog if card.role == role), None)
+                if agent_card is None:
+                    errors.append(role)
+                    continue
+
+                # Create child agent using agent primitive
+                # agent_class can be str | type, but in production it should be a type
+                actor_class = agent_card.agent_class
+                if isinstance(actor_class, str):
+                    raise ValueError(
+                        f"Hire error - agent class for role {role} is a string, not a type. "
+                    )
+
+                # Generate name
+                child_name = f"@{role.replace(' ', '')}{random.randint(100, 999)}"
+
+                # Create config
+                agent_card_config = agent_card.get_config_copy()
+                agent_card_config.name = child_name
+                agent_card_config.role = role
+
+                child_address = observer.createActor(actor_class, config=agent_card_config)
+
+                # Call agent hook
+                observer.on_hire(child_name, child_address)
+
+                hired_members.append(child_name)
+                logger.info(f"Hired {role} agent: {child_name} at {child_address}")
+
+            if errors:
+                available_roles = orchestrator_proxy.get_available_roles()
+                error_details = "; ".join([f"role '{e}'" for e in errors])
+                error_message = f"Hire errors - cannot find agent card(s) for {error_details}. "
+                error_message += f"Available roles: {available_roles}"
+                if hired_members:
+                    error_message = (
+                        f"Partial success - Members hired: {hired_members}. " + error_message
+                    )
+                raise ToolError(error_message)
+
+            return f"Members hired: {hired_members}"
+
+        hire_members.__doc__ = params.format_docstring(hire_members.__doc__)
+        return hire_members
+
+    def _fire_members_factory(self, params: FireTeamMembers) -> Callable:
+        """Create fire_members tool callable.
+
+        Args:
+            params: Configuration for fire capability
+
+        Returns:
+            Callable that fires team members
+        """
+        orchestrator_proxy = self._orchestrator_proxy
+        observer = self._observer
+
+        def fire_members(names: list[str]) -> str:
+            """Fire multiple team members with the given names.
+
+            Stops member actors and removes them from team. Member names typically
+            start with '@' (e.g., '@Developer123').
+
+            Note: Should only be used when explicitly requested by user to prevent
+            accidental team disruption.
+
+            Args:
+                names: List of member names to fire (e.g., ['@Developer123', '@Tester456'])
+
+            Returns:
+                Combined confirmation messages (e.g., "Member @Developer123 has been fired. - ...")
+            """
+            observer.notify_event(
+                ToolCallEvent(tool_name="fire_members", args=[], kwargs={"names": names})
+            )
+
+            fired_members = []
+            errors = []
+            for name in names:
+                # Lookup member
+                address = orchestrator_proxy.get_team_member(name)
+                if address is None:
+                    errors.append(name)
+                    logger.error(f"Fire error, team member not part of the team: {name}")
+                    continue
+
+                # Stop actor using agent primitive
+                observer.stop(address)
+
+                # Call agent hook
+                observer.on_fire(name, address)
+
+                fired_members.append(name)
+                logger.info(f"Fired team member: {name}")
+
+            if errors:
+                team_members = [member.name for member in orchestrator_proxy.get_team()]
+                error_details = "; ".join([f"member '{e}'" for e in errors])
+                error_message = f"Fire errors - {error_details} not part of the team. "
+                error_message += f"Current team members: {team_members}"
+                if fired_members:
+                    error_message = (
+                        f"Partial success - Members fired: {fired_members}. " + error_message
+                    )
+                raise ToolError(error_message)
+
+            return f"Members fired: {', '.join(fired_members)}"
+
+        fire_members.__doc__ = params.format_docstring(fire_members.__doc__)
+        return fire_members
+
+    def _team_roster_prompt_factory(self, params: GetTeamRoster) -> Callable:
+        """Create team roster system prompt callable.
+
+        Args:
+            params: Configuration for roster prompt
+
+        Returns:
+            Callable that generates team roster prompt
+        """
+        orchestrator_proxy = self._orchestrator_proxy
+        observer = self._observer
+
+        def team_roster_prompt() -> str:
+            """Get current team composition as context.
+
+            Returns formatted list of team members with their roles, marking the
+            current agent with '[you]'. Excludes tool actors (names starting with '#').
+
+            Returns:
+                Formatted team roster or empty string if no members
+            """
+            try:
+                team_members = orchestrator_proxy.get_team()
+                if not team_members:
+                    return ""
+
+                team_members_names = [
+                    f"{member.name} (role: {member.role})"
+                    + (" - [you]" if member.name == observer.myAddress.name else "")
+                    for member in team_members
+                    if not member.name.startswith("#")  # Exclude tool actors
+                ]
+
+                if not team_members_names:
+                    return ""
+
+                return "Team members:\n" + "\n".join(team_members_names)
+            except Exception:
+                return "Cannot get team roster..."
+
+        return team_roster_prompt
+
+    def _role_profiles_prompt_factory(self, params: GetRoleProfiles) -> Callable:
+        """Create role profiles system prompt callable.
+
+        Args:
+            params: Configuration for profiles prompt
+
+        Returns:
+            Callable that generates role profiles prompt
+        """
+        orchestrator_proxy = self._orchestrator_proxy
+
+        def role_profiles_prompt() -> str:
+            """Get available team roles and their descriptions.
+
+            Returns formatted list of roles with descriptions and skills from the
+            agent catalog.
+
+            Returns:
+                Formatted role profiles or empty string if no roles
+            """
+            try:
+                agent_catalog = orchestrator_proxy.get_agent_catalog()
+                if not agent_catalog:
+                    return ""
+
+                profiles = []
+                for card in agent_catalog:
+                    skills_str = ", ".join(card.skills) if card.skills else "none"
+                    profiles.append(f"**{card.role}**: {card.description} (Skills: {skills_str})")
+
+                if not profiles:
+                    return ""
+
+                return "Available team roles:\n" + "\n".join(profiles)
+            except Exception:
+                return "Cannot get role profiles..."
+
+        return role_profiles_prompt

--- a/src/akgentic/tool/team/team.py
+++ b/src/akgentic/tool/team/team.py
@@ -89,7 +89,7 @@ def _hire_single_member(
 
     actor_class = agent_card.get_agent_class()
     if isinstance(actor_class, str):
-        raise ValueError(f"Hire error - agent class for role {role} is a string, not a type. ")
+        raise ValueError(f"Hire error - agent class for role {role} is a string, not a type.")
 
     if name is None:
         role_prefix = f"@{role.replace(' ', '')}"

--- a/src/akgentic/tool/team/team.py
+++ b/src/akgentic/tool/team/team.py
@@ -6,14 +6,13 @@ that can be attached to any agent.
 
 import logging
 import random
-import re
 from typing import Callable
 
 from pydantic import Field
 
 from akgentic.core.orchestrator import Orchestrator
 from akgentic.tool.core import BaseToolParam, ToolCard, _resolve
-from akgentic.tool.errors import ToolError
+from akgentic.tool.errors import RetriableError
 from akgentic.tool.event import TeamManagementToolObserver, ToolCallEvent
 
 logger = logging.getLogger(__name__)
@@ -47,7 +46,7 @@ class TeamTool(ToolCard):
     """Team management tool for hiring, firing, and team awareness.
 
     Provides:
-    - hire_members(roles: list[str]) -> list[str]: Hire team members
+    - hire_members(roles: list[str]) -> str: Hire team members
     - fire_members(names: list[str]) -> str: Fire team members
     - Team roster system prompt: Current team composition
     - Role profiles system prompt: Available roles and descriptions
@@ -62,11 +61,11 @@ class TeamTool(ToolCard):
     fire_team_members: FireTeamMembers | bool = Field(
         default=True, description="Enable firing team members (default: True)"
     )
-    get_team_roster: GetTeamRoster | bool = Field(
-        default=True, description="Include team roster in system prompt (default: True)"
-    )
     get_role_profiles: GetRoleProfiles | bool = Field(
         default=True, description="Include role profiles in system prompt (default: True)"
+    )
+    get_team_roster: GetTeamRoster | bool = Field(
+        default=True, description="Include team roster in system prompt (default: True)"
     )
 
     def observer(self, observer: TeamManagementToolObserver) -> "TeamTool":
@@ -153,6 +152,9 @@ class TeamTool(ToolCard):
             Returns:
                 Confirmation message with hired member names (e.g., 'Members hired: [@Developer123, @Tester456]')
             """
+            if not roles:
+                raise RetriableError("No roles provided. Specify at least one role to hire.")
+
             observer.notify_event(
                 ToolCallEvent(tool_name="hire_members", args=[], kwargs={"roles": roles})
             )
@@ -160,6 +162,7 @@ class TeamTool(ToolCard):
             hired_members = []
             errors = []
             agent_catalog = orchestrator_proxy.get_agent_catalog()
+            existing_names = {member.name for member in orchestrator_proxy.get_team()}
 
             for role in roles:
                 # Get agent card for role from catalog
@@ -170,14 +173,20 @@ class TeamTool(ToolCard):
 
                 # Create child agent using agent primitive
                 # agent_class can be str | type, but in production it should be a type
-                actor_class = agent_card.agent_class
+                actor_class = agent_card.get_agent_class()
                 if isinstance(actor_class, str):
+                    ## The llm cannot retry, so raise a ValueError
                     raise ValueError(
                         f"Hire error - agent class for role {role} is a string, not a type. "
                     )
 
-                # Generate name
-                child_name = f"@{role.replace(' ', '')}{random.randint(100, 999)}"
+                # Generate unique name: random, increment on collision
+                role_prefix = f"@{role.replace(' ', '')}"
+                suffix = random.randint(100, 999)
+                child_name = f"{role_prefix}{suffix}"
+                while child_name in existing_names:
+                    suffix += 1
+                    child_name = f"{role_prefix}{suffix}"
 
                 # Create config
                 agent_card_config = agent_card.get_config_copy()
@@ -189,6 +198,7 @@ class TeamTool(ToolCard):
                 # Call agent hook
                 observer.on_hire(child_name, child_address)
 
+                existing_names.add(child_name)
                 hired_members.append(child_name)
                 logger.info(f"Hired {role} agent: {child_name} at {child_address}")
 
@@ -201,7 +211,7 @@ class TeamTool(ToolCard):
                     error_message = (
                         f"Partial success - Members hired: {hired_members}. " + error_message
                     )
-                raise ToolError(error_message)
+                raise RetriableError(error_message)
 
             return f"Members hired: {hired_members}"
 
@@ -235,6 +245,9 @@ class TeamTool(ToolCard):
             Returns:
                 Combined confirmation messages (e.g., "Member @Developer123 has been fired. - ...")
             """
+            if not names:
+                raise RetriableError("No names provided. Specify at least one member name to fire.")
+
             observer.notify_event(
                 ToolCallEvent(tool_name="fire_members", args=[], kwargs={"names": names})
             )
@@ -250,7 +263,7 @@ class TeamTool(ToolCard):
                     continue
 
                 # Stop actor using agent primitive
-                observer.stop(address)
+                address.stop()
 
                 # Call agent hook
                 observer.on_fire(name, address)
@@ -267,7 +280,7 @@ class TeamTool(ToolCard):
                     error_message = (
                         f"Partial success - Members fired: {fired_members}. " + error_message
                     )
-                raise ToolError(error_message)
+                raise RetriableError(error_message)
 
             return f"Members fired: {', '.join(fired_members)}"
 
@@ -312,6 +325,7 @@ class TeamTool(ToolCard):
 
                 return "Team members:\n" + "\n".join(team_members_names)
             except Exception:
+                logger.error("Failed to get team roster", exc_info=True)
                 return "Cannot get team roster..."
 
         return team_roster_prompt
@@ -351,6 +365,7 @@ class TeamTool(ToolCard):
 
                 return "Available team roles:\n" + "\n".join(profiles)
             except Exception:
+                logger.error("Failed to get role profiles", exc_info=True)
                 return "Cannot get role profiles..."
 
         return role_profiles_prompt

--- a/tests/test_core_factory.py
+++ b/tests/test_core_factory.py
@@ -2,7 +2,14 @@ from __future__ import annotations
 
 from typing import Any, Callable
 
-from akgentic.tool.core import BaseToolParam, ToolCard, ToolFactory, _resolve
+from akgentic.tool.core import (
+    COMMAND,
+    TOOL_CALL,
+    BaseToolParam,
+    ToolCard,
+    ToolFactory,
+    _resolve,
+)
 
 
 class _DummyParam(BaseToolParam):
@@ -16,7 +23,7 @@ class _DummyTool(ToolCard):
 
     def get_tools(self) -> list[Callable]:
         p = _resolve(self.cap, _DummyParam)
-        if p and p.llm_tool:
+        if p and TOOL_CALL in p.expose:
             return [lambda: f"ok-{p.value}"]
         return []
 
@@ -69,10 +76,57 @@ def test_resolve_instance() -> None:
 
 
 def test_base_tool_param_defaults() -> None:
+    """BaseToolParam defaults: expose={TOOL_CALL}, instructions=None."""
     p = BaseToolParam()
     assert p.instructions is None
-    assert p.system_prompt is False
-    assert p.llm_tool is True
+    assert p.expose == {TOOL_CALL}
+
+
+def test_base_tool_param_subclass_defaults() -> None:
+    """Subclass inherits expose default from BaseToolParam."""
+    p = _DummyParam()
+    assert p.instructions is None
+    assert p.expose == {TOOL_CALL}
+
+
+def test_tool_factory_get_commands() -> None:
+    """ToolFactory.get_commands() aggregates from all tool cards."""
+
+    class _CommandParam(BaseToolParam):
+        expose: set[str] = {COMMAND}
+
+    class _CommandTool(ToolCard):
+        name: str = "cmd_tool"
+        description: str = "command tool"
+        cmd: _CommandParam | bool = True
+
+        def get_tools(self) -> list[Callable]:
+            return []
+
+        def get_commands(self) -> dict[type[BaseToolParam], Callable]:
+            p = _resolve(self.cmd, _CommandParam)
+            if p and COMMAND in p.expose:
+
+                def my_cmd() -> str:
+                    return "cmd-result"
+
+                return {_CommandParam: my_cmd}
+            return {}
+
+    card = _CommandTool()
+    factory = ToolFactory(tool_cards=[card])
+    commands = factory.get_commands()
+    assert len(commands) == 1
+    assert _CommandParam in commands
+    assert commands[_CommandParam]() == "cmd-result"
+
+
+def test_tool_factory_get_commands_empty() -> None:
+    """ToolFactory.get_commands() returns empty dict when no cards have commands."""
+    card = _DummyTool()
+    factory = ToolFactory(tool_cards=[card])
+    commands = factory.get_commands()
+    assert commands == {}
 
 
 def test_tool_factory_with_null_observer() -> None:

--- a/tests/test_planning_actor.py
+++ b/tests/test_planning_actor.py
@@ -50,6 +50,9 @@ class MockActorAddress(ActorAddress):
     def is_alive(self) -> bool:
         return True
 
+    def stop(self) -> None:
+        pass
+
     def handle_user_message(self) -> bool:
         return False
 

--- a/tests/test_planning_actor.py
+++ b/tests/test_planning_actor.py
@@ -132,7 +132,7 @@ def test_update_planning_with_update_errors() -> None:
 
 
 def test_update_planning_delete_not_found() -> None:
-    """Test deleting non-existent item raises ToolError."""
+    """Test deleting non-existent item raises RetriableError."""
     actor = PlanActor()
     actor.on_start()
     actor_addr = MockActorAddress("test-agent")

--- a/tests/test_planning_actor.py
+++ b/tests/test_planning_actor.py
@@ -7,7 +7,7 @@ import uuid
 import pytest
 from akgentic.core.actor_address import ActorAddress
 
-from akgentic.tool.errors import ToolError
+from akgentic.tool.errors import RetriableError
 from akgentic.tool.planning.planning_actor import (
     PlanActor,
     TaskCreate,
@@ -124,7 +124,7 @@ def test_update_planning_with_update_errors() -> None:
         delete_tasks=[],
     )
 
-    with pytest.raises(ToolError, match="Update error.*999"):
+    with pytest.raises(RetriableError, match="Update error.*999"):
         actor.update_planning(update_plan, actor_addr)
 
 
@@ -141,7 +141,7 @@ def test_update_planning_delete_not_found() -> None:
         delete_tasks=[999],
     )
 
-    with pytest.raises(ToolError, match="Delete error.*999"):
+    with pytest.raises(RetriableError, match="Delete error.*999"):
         actor.update_planning(update_plan, actor_addr)
 
 
@@ -195,7 +195,7 @@ def test_update_planning_mixed_operations_with_errors() -> None:
         delete_tasks=[1, 888],  # First succeeds, second fails
     )
 
-    with pytest.raises(ToolError) as exc_info:
+    with pytest.raises(RetriableError) as exc_info:
         actor.update_planning(update_plan, actor_addr)
 
     # Should report multiple errors

--- a/tests/test_team_tool.py
+++ b/tests/test_team_tool.py
@@ -141,7 +141,7 @@ def test_hire_members_tool_execution():
 
 
 def test_hire_members_empty_list():
-    """hire_members raises ToolError for empty roles list."""
+    """hire_members raises RetriableError for empty roles list."""
     tool = TeamTool()
     tool.observer(mock_observer())
     hire_members = tool.get_tools()[0]
@@ -151,7 +151,7 @@ def test_hire_members_empty_list():
 
 
 def test_fire_members_empty_list():
-    """fire_members raises ToolError for empty names list."""
+    """fire_members raises RetriableError for empty names list."""
     tool = TeamTool()
     tool.observer(mock_observer())
     fire_members = tool.get_tools()[1]
@@ -161,7 +161,7 @@ def test_fire_members_empty_list():
 
 
 def test_hire_members_invalid_role():
-    """hire_members raises ToolError for invalid role."""
+    """hire_members raises RetriableError for invalid role."""
     orchestrator_mock = Mock(spec=Orchestrator)
     orchestrator_mock.get_available_roles.return_value = ["Developer"]
     orchestrator_mock.get_agent_catalog.return_value = []  # Empty catalog
@@ -199,7 +199,7 @@ def test_hire_members_string_agent_class():
     tool.observer(observer_mock)
     hire_members = tool.get_tools()[0]
 
-    # ValueError (not ToolError) because LLM cannot fix configuration errors
+    # ValueError (not RetriableError) because LLM cannot fix configuration errors
     with pytest.raises(ValueError, match="is a string, not a type"):
         hire_members(["Developer"])
 
@@ -232,7 +232,7 @@ def test_fire_members_tool_execution():
 
 
 def test_fire_members_not_found():
-    """fire_members raises ToolError if member not found."""
+    """fire_members raises RetriableError if member not found."""
     orchestrator_mock = Mock(spec=Orchestrator)
     orchestrator_mock.get_team_member.return_value = None
     orchestrator_mock.get_team.return_value = [create_test_address("@Developer456", "Developer")]

--- a/tests/test_team_tool.py
+++ b/tests/test_team_tool.py
@@ -1,0 +1,475 @@
+"""Unit tests for TeamTool."""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import Mock
+
+import pytest
+from akgentic.core import ActorAddressProxy
+from akgentic.core.agent_card import AgentCard
+from akgentic.core.agent_config import BaseConfig
+from akgentic.core.orchestrator import Orchestrator
+
+from akgentic.tool.errors import ToolError
+from akgentic.tool.event import TeamManagementToolObserver
+from akgentic.tool.team import (
+    FireTeamMembers,
+    GetRoleProfiles,
+    GetTeamRoster,
+    HireTeamMembers,
+    TeamTool,
+)
+
+
+def create_test_address(name: str, role: str = "Agent") -> ActorAddressProxy:
+    """Create a mock ActorAddress for testing."""
+    return ActorAddressProxy(
+        {
+            "__actor_address__": True,
+            "__actor_type__": "test.Agent",
+            "agent_id": str(uuid.uuid4()),
+            "name": name,
+            "role": role,
+            "team_id": str(uuid.uuid4()),
+            "squad_id": str(uuid.uuid4()),
+            "user_message": True,
+        }
+    )
+
+
+def mock_observer() -> Mock:
+    """Create a mock TeamManagementToolObserver."""
+    observer = Mock(spec=TeamManagementToolObserver)
+    observer.orchestrator = create_test_address("@Orchestrator", "Orchestrator")
+    observer.myAddress = create_test_address("@Manager", "Manager")
+
+    # Mock orchestrator proxy
+    orchestrator_mock = Mock(spec=Orchestrator)
+    observer.proxy_ask.return_value = orchestrator_mock
+
+    return observer
+
+
+def test_team_tool_observer_attachment():
+    """TeamTool.observer() sets up orchestrator proxy."""
+    observer = mock_observer()
+
+    tool = TeamTool()
+    result = tool.observer(observer)
+
+    assert result is tool  # Method chaining
+    assert tool._observer is observer
+    observer.proxy_ask.assert_called_once_with(observer.orchestrator, Orchestrator)
+
+
+def test_team_tool_observer_requires_orchestrator():
+    """TeamTool.observer() raises ValueError if no orchestrator."""
+    observer = Mock(spec=TeamManagementToolObserver)
+    observer.orchestrator = None
+
+    tool = TeamTool()
+    with pytest.raises(ValueError, match="requires access to the orchestrator"):
+        tool.observer(observer)
+
+
+def test_team_tool_get_tools_default():
+    """TeamTool.get_tools() returns hire + fire by default."""
+    tool = TeamTool()
+    tool.observer(mock_observer())
+
+    tools = tool.get_tools()
+    assert len(tools) == 2
+    assert tools[0].__name__ == "hire_members"
+    assert tools[1].__name__ == "fire_members"
+
+
+def test_team_tool_get_tools_disabled():
+    """TeamTool.get_tools() excludes disabled capabilities."""
+    tool = TeamTool(hire_team_members=False, fire_team_members=False)
+    tool.observer(mock_observer())
+
+    tools = tool.get_tools()
+    assert len(tools) == 0
+
+
+def test_team_tool_get_tools_partial():
+    """TeamTool.get_tools() includes only enabled capabilities."""
+    tool = TeamTool(hire_team_members=True, fire_team_members=False)
+    tool.observer(mock_observer())
+
+    tools = tool.get_tools()
+    assert len(tools) == 1
+    assert tools[0].__name__ == "hire_members"
+
+
+def test_hire_members_tool_execution():
+    """hire_members validates role, creates actor, calls on_hire hook."""
+    # Mock AgentCard with agent_class
+    agent_card = Mock(spec=AgentCard)
+    agent_card.role = "Developer"
+    agent_card.agent_class = Mock  # Dynamic agent class (type)
+
+    config_mock = Mock(spec=BaseConfig)
+    agent_card.get_config_copy.return_value = config_mock
+
+    orchestrator_mock = Mock(spec=Orchestrator)
+    orchestrator_mock.get_available_roles.return_value = ["Developer"]
+    orchestrator_mock.get_agent_catalog.return_value = [agent_card]
+
+    observer_mock = Mock(spec=TeamManagementToolObserver)
+    observer_mock.orchestrator = create_test_address("@Orchestrator", "Orchestrator")
+    observer_mock.myAddress = create_test_address("@Manager", "Manager")
+    observer_mock.proxy_ask.return_value = orchestrator_mock
+    observer_mock.createActor.return_value = create_test_address("@Developer123", "Developer")
+
+    tool = TeamTool()
+    tool.observer(observer_mock)
+    hire_members = tool.get_tools()[0]
+
+    result = hire_members(["Developer"])
+
+    assert isinstance(result, str)
+    assert "Members hired:" in result
+    assert "@Developer" in result
+    observer_mock.createActor.assert_called_once()  # Agent primitive called
+    observer_mock.on_hire.assert_called_once()  # Hook called
+    observer_mock.notify_event.assert_called()
+
+
+def test_hire_members_invalid_role():
+    """hire_members raises ToolError for invalid role."""
+    orchestrator_mock = Mock(spec=Orchestrator)
+    orchestrator_mock.get_available_roles.return_value = ["Developer"]
+    orchestrator_mock.get_agent_catalog.return_value = []  # Empty catalog
+
+    observer_mock = Mock(spec=TeamManagementToolObserver)
+    observer_mock.orchestrator = create_test_address("@Orchestrator", "Orchestrator")
+    observer_mock.proxy_ask.return_value = orchestrator_mock
+
+    tool = TeamTool()
+    tool.observer(observer_mock)
+    hire_members = tool.get_tools()[0]
+
+    with pytest.raises(ToolError, match="cannot find agent card"):
+        hire_members(["InvalidRole"])
+
+
+def test_hire_members_string_agent_class():
+    """hire_members raises ValueError if agent_class is a string (non-recoverable config error)."""
+    # Mock AgentCard with string agent_class
+    agent_card = Mock(spec=AgentCard)
+    agent_card.role = "Developer"
+    agent_card.agent_class = "some.module.Agent"  # String instead of type
+
+    orchestrator_mock = Mock(spec=Orchestrator)
+    orchestrator_mock.get_available_roles.return_value = ["Developer"]
+    orchestrator_mock.get_agent_catalog.return_value = [agent_card]
+
+    observer_mock = Mock(spec=TeamManagementToolObserver)
+    observer_mock.orchestrator = create_test_address("@Orchestrator", "Orchestrator")
+    observer_mock.proxy_ask.return_value = orchestrator_mock
+
+    tool = TeamTool()
+    tool.observer(observer_mock)
+    hire_members = tool.get_tools()[0]
+
+    # ValueError (not ToolError) because LLM cannot fix configuration errors
+    with pytest.raises(ValueError, match="is a string, not a type"):
+        hire_members(["Developer"])
+
+
+def test_fire_members_tool_execution():
+    """fire_members looks up address, calls observer.stop(), calls on_fire hook."""
+    orchestrator_mock = Mock(spec=Orchestrator)
+    orchestrator_mock.get_team_member.return_value = create_test_address(
+        "@Developer123", "Developer"
+    )
+
+    observer_mock = Mock(spec=TeamManagementToolObserver)
+    observer_mock.orchestrator = create_test_address("@Orchestrator", "Orchestrator")
+    observer_mock.proxy_ask.return_value = orchestrator_mock
+
+    tool = TeamTool()
+    tool.observer(observer_mock)
+    fire_members = tool.get_tools()[1]
+
+    result = fire_members(["@Developer123"])
+
+    assert "Developer123" in result
+    assert "fired" in result.lower()
+    orchestrator_mock.get_team_member.assert_called_once_with("@Developer123")
+    observer_mock.stop.assert_called_once()  # Agent primitive called
+    observer_mock.on_fire.assert_called_once()  # Hook called
+    observer_mock.notify_event.assert_called()
+
+
+def test_fire_members_not_found():
+    """fire_members raises ToolError if member not found."""
+    orchestrator_mock = Mock(spec=Orchestrator)
+    orchestrator_mock.get_team_member.return_value = None
+    orchestrator_mock.get_team.return_value = [create_test_address("@Developer456", "Developer")]
+
+    observer_mock = Mock(spec=TeamManagementToolObserver)
+    observer_mock.orchestrator = create_test_address("@Orchestrator", "Orchestrator")
+    observer_mock.proxy_ask.return_value = orchestrator_mock
+
+    tool = TeamTool()
+    tool.observer(observer_mock)
+    fire_members = tool.get_tools()[1]
+
+    with pytest.raises(ToolError, match="Fire errors"):
+        fire_members(["@Developer123"])
+
+
+def test_team_tool_get_system_prompts_default():
+    """TeamTool.get_system_prompts() returns roster + profiles by default."""
+    tool = TeamTool()
+    tool.observer(mock_observer())
+
+    prompts = tool.get_system_prompts()
+    assert len(prompts) == 2
+    # Callables don't have __name__ reliably, check they're callable
+    assert all(callable(p) for p in prompts)
+
+
+def test_team_tool_get_system_prompts_disabled():
+    """TeamTool.get_system_prompts() excludes disabled prompts."""
+    tool = TeamTool(
+        get_team_roster=GetTeamRoster(system_prompt=False),
+        get_role_profiles=GetRoleProfiles(system_prompt=False),
+    )
+    tool.observer(mock_observer())
+
+    prompts = tool.get_system_prompts()
+    assert len(prompts) == 0
+
+
+def test_team_roster_prompt():
+    """team_roster_prompt returns formatted team members."""
+    orchestrator_mock = Mock(spec=Orchestrator)
+    orchestrator_mock.get_team.return_value = [
+        create_test_address("@Manager", "Manager"),
+        create_test_address("@Developer", "Developer"),
+        create_test_address("#PlanningTool", "ToolActor"),  # Should be excluded
+    ]
+
+    observer_mock = Mock(spec=TeamManagementToolObserver)
+    observer_mock.myAddress = create_test_address("@Manager", "Manager")
+    observer_mock.orchestrator = create_test_address("@Orchestrator", "Orchestrator")
+    observer_mock.proxy_ask.return_value = orchestrator_mock
+
+    tool = TeamTool()
+    tool.observer(observer_mock)
+    prompts = tool.get_system_prompts()
+    roster_prompt = prompts[0]
+
+    result = roster_prompt()
+
+    assert "Team members:" in result
+    assert "@Manager (role: Manager)" in result
+    assert "[you]" in result  # Current agent marked
+    assert "@Developer (role: Developer)" in result
+    assert "#PlanningTool" not in result  # Tool actors excluded
+
+
+def test_team_roster_prompt_empty():
+    """team_roster_prompt returns empty string if no members."""
+    orchestrator_mock = Mock(spec=Orchestrator)
+    orchestrator_mock.get_team.return_value = []
+
+    observer_mock = Mock(spec=TeamManagementToolObserver)
+    observer_mock.orchestrator = create_test_address("@Orchestrator", "Orchestrator")
+    observer_mock.proxy_ask.return_value = orchestrator_mock
+
+    tool = TeamTool()
+    tool.observer(observer_mock)
+    prompts = tool.get_system_prompts()
+    roster_prompt = prompts[0]
+
+    result = roster_prompt()
+    assert result == ""
+
+
+def test_role_profiles_prompt():
+    """role_profiles_prompt returns role descriptions + skills from agent catalog."""
+    card1 = Mock(spec=AgentCard)
+    card1.role = "Developer"
+    card1.description = "Writes code"
+    card1.skills = ["python", "testing"]
+
+    card2 = Mock(spec=AgentCard)
+    card2.role = "Tester"
+    card2.description = "Tests code"
+    card2.skills = ["selenium", "pytest"]
+
+    orchestrator_mock = Mock(spec=Orchestrator)
+    orchestrator_mock.get_agent_catalog.return_value = [card1, card2]
+
+    observer_mock = Mock(spec=TeamManagementToolObserver)
+    observer_mock.orchestrator = create_test_address("@Orchestrator", "Orchestrator")
+    observer_mock.proxy_ask.return_value = orchestrator_mock
+
+    tool = TeamTool()
+    tool.observer(observer_mock)
+    prompts = tool.get_system_prompts()
+    profiles_prompt = prompts[1]
+
+    result = profiles_prompt()
+
+    assert "Available team roles:" in result
+    assert "**Developer**: Writes code (Skills: python, testing)" in result
+    assert "**Tester**: Tests code (Skills: selenium, pytest)" in result
+
+
+def test_role_profiles_prompt_empty():
+    """role_profiles_prompt returns empty string if no roles."""
+    orchestrator_mock = Mock(spec=Orchestrator)
+    orchestrator_mock.get_agent_catalog.return_value = []
+
+    observer_mock = Mock(spec=TeamManagementToolObserver)
+    observer_mock.orchestrator = create_test_address("@Orchestrator", "Orchestrator")
+    observer_mock.proxy_ask.return_value = orchestrator_mock
+
+    tool = TeamTool()
+    tool.observer(observer_mock)
+    prompts = tool.get_system_prompts()
+    profiles_prompt = prompts[1]
+
+    result = profiles_prompt()
+    assert result == ""
+
+
+def test_hire_members_custom_instructions():
+    """HireTeamMembers.instructions appended to docstring."""
+    tool = TeamTool(
+        hire_team_members=HireTeamMembers(instructions="Only hire when explicitly requested.")
+    )
+    tool.observer(mock_observer())
+
+    hire_members = tool.get_tools()[0]
+    assert "Only hire when explicitly requested" in hire_members.__doc__
+
+
+def test_fire_members_custom_instructions():
+    """FireTeamMembers.instructions appended to docstring."""
+    tool = TeamTool(
+        fire_team_members=FireTeamMembers(instructions="Only fire when explicitly requested.")
+    )
+    tool.observer(mock_observer())
+
+    fire_members = tool.get_tools()[1]
+    assert "Only fire when explicitly requested" in fire_members.__doc__
+
+
+def test_hire_members_batch_with_multiple_errors():
+    """hire_members collects all errors before raising."""
+    orchestrator_mock = Mock(spec=Orchestrator)
+    orchestrator_mock.get_available_roles.return_value = ["Developer"]
+    orchestrator_mock.get_agent_catalog.return_value = []  # Empty catalog - no cards found
+
+    observer_mock = Mock(spec=TeamManagementToolObserver)
+    observer_mock.orchestrator = create_test_address("@Orchestrator", "Orchestrator")
+    observer_mock.proxy_ask.return_value = orchestrator_mock
+
+    tool = TeamTool()
+    tool.observer(observer_mock)
+    hire_members = tool.get_tools()[0]
+
+    # Try to hire multiple invalid roles
+    with pytest.raises(ToolError) as exc_info:
+        hire_members(["InvalidRole1", "InvalidRole2"])
+
+    # Should contain both errors
+    error_msg = str(exc_info.value)
+    assert "Hire errors" in error_msg
+    assert "InvalidRole1" in error_msg
+    assert "InvalidRole2" in error_msg
+
+
+def test_hire_members_batch_partial_success():
+    """hire_members continues on errors and hires valid roles."""
+    agent_card = Mock(spec=AgentCard)
+    agent_card.role = "Developer"
+    agent_card.agent_class = Mock
+    agent_card.get_config_copy.return_value = Mock(spec=BaseConfig)
+
+    orchestrator_mock = Mock(spec=Orchestrator)
+    orchestrator_mock.get_available_roles.return_value = ["Developer"]
+    orchestrator_mock.get_agent_catalog.return_value = [agent_card]
+
+    observer_mock = Mock(spec=TeamManagementToolObserver)
+    observer_mock.orchestrator = create_test_address("@Orchestrator", "Orchestrator")
+    observer_mock.myAddress = create_test_address("@Manager", "Manager")
+    observer_mock.proxy_ask.return_value = orchestrator_mock
+    observer_mock.createActor.return_value = create_test_address("@Developer123", "Developer")
+
+    tool = TeamTool()
+    tool.observer(observer_mock)
+    hire_members = tool.get_tools()[0]
+
+    # Mix valid and invalid roles
+    with pytest.raises(ToolError) as exc_info:
+        hire_members(["Developer", "InvalidRole"])
+
+    # Should have hired the valid one before failing
+    assert observer_mock.createActor.call_count == 1
+    # Error should mention partial success and the invalid role
+    assert "Partial success" in str(exc_info.value)
+    assert "InvalidRole" in str(exc_info.value)
+
+
+def test_fire_members_batch_with_multiple_errors():
+    """fire_members collects all errors before raising."""
+    orchestrator_mock = Mock(spec=Orchestrator)
+    orchestrator_mock.get_team_member.return_value = None
+    orchestrator_mock.get_team.return_value = []
+
+    observer_mock = Mock(spec=TeamManagementToolObserver)
+    observer_mock.orchestrator = create_test_address("@Orchestrator", "Orchestrator")
+    observer_mock.proxy_ask.return_value = orchestrator_mock
+
+    tool = TeamTool()
+    tool.observer(observer_mock)
+    fire_members = tool.get_tools()[1]
+
+    # Try to fire multiple non-existent members
+    with pytest.raises(ToolError) as exc_info:
+        fire_members(["@NonExistent1", "@NonExistent2"])
+
+    # Should contain both errors
+    error_msg = str(exc_info.value)
+    assert "Fire errors" in error_msg
+    assert "NonExistent1" in error_msg
+    assert "NonExistent2" in error_msg
+
+
+def test_fire_members_batch_partial_success():
+    """fire_members continues on errors and fires valid members."""
+    orchestrator_mock = Mock(spec=Orchestrator)
+
+    def get_member_side_effect(name):
+        if name == "@Valid123":
+            return create_test_address("@Valid123", "Developer")
+        return None
+
+    orchestrator_mock.get_team_member.side_effect = get_member_side_effect
+    orchestrator_mock.get_team.return_value = []
+
+    observer_mock = Mock(spec=TeamManagementToolObserver)
+    observer_mock.orchestrator = create_test_address("@Orchestrator", "Orchestrator")
+    observer_mock.proxy_ask.return_value = orchestrator_mock
+
+    tool = TeamTool()
+    tool.observer(observer_mock)
+    fire_members = tool.get_tools()[1]
+
+    # Mix valid and invalid members
+    with pytest.raises(ToolError) as exc_info:
+        fire_members(["@Valid123", "@NonExistent"])
+
+    # Should have stopped the valid one before failing
+    assert observer_mock.stop.call_count == 1
+    # Error should mention partial success and the invalid member
+    assert "Partial success" in str(exc_info.value)
+    assert "NonExistent" in str(exc_info.value)

--- a/tests/test_team_tool.py
+++ b/tests/test_team_tool.py
@@ -11,13 +11,14 @@ from akgentic.core.agent_card import AgentCard
 from akgentic.core.agent_config import BaseConfig
 from akgentic.core.orchestrator import Orchestrator
 
+from akgentic.tool.core import TOOL_CALL
 from akgentic.tool.errors import RetriableError
 from akgentic.tool.event import TeamManagementToolObserver
 from akgentic.tool.team import (
-    FireTeamMembers,
+    FireTeamMember,
     GetRoleProfiles,
     GetTeamRoster,
-    HireTeamMembers,
+    HireTeamMember,
     TeamTool,
 )
 
@@ -262,8 +263,8 @@ def test_team_tool_get_system_prompts_default():
 def test_team_tool_get_system_prompts_disabled():
     """TeamTool.get_system_prompts() excludes disabled prompts."""
     tool = TeamTool(
-        get_team_roster=GetTeamRoster(system_prompt=False),
-        get_role_profiles=GetRoleProfiles(system_prompt=False),
+        get_team_roster=GetTeamRoster(expose=set()),
+        get_role_profiles=GetRoleProfiles(expose=set()),
     )
     tool.observer(mock_observer())
 
@@ -369,7 +370,7 @@ def test_role_profiles_prompt_empty():
 def test_hire_members_custom_instructions():
     """HireTeamMembers.instructions appended to docstring."""
     tool = TeamTool(
-        hire_team_members=HireTeamMembers(instructions="Only hire when explicitly requested.")
+        hire_team_members=HireTeamMember(instructions="Only hire when explicitly requested.")
     )
     tool.observer(mock_observer())
 
@@ -380,7 +381,7 @@ def test_hire_members_custom_instructions():
 def test_fire_members_custom_instructions():
     """FireTeamMembers.instructions appended to docstring."""
     tool = TeamTool(
-        fire_team_members=FireTeamMembers(instructions="Only fire when explicitly requested.")
+        fire_team_members=FireTeamMember(instructions="Only fire when explicitly requested.")
     )
     tool.observer(mock_observer())
 
@@ -505,3 +506,178 @@ def test_fire_members_batch_partial_success():
     # Error should mention partial success and the invalid member
     assert "Partial success" in str(exc_info.value)
     assert "NonExistent" in str(exc_info.value)
+
+
+# ── Command tests ──────────────────────────────────────────────────────────
+
+
+def test_team_tool_get_commands_default():
+    """TeamTool.get_commands() returns dict keyed by param class with 4 commands."""
+    tool = TeamTool()
+    tool.observer(mock_observer())
+
+    commands = tool.get_commands()
+    assert len(commands) == 4
+    assert HireTeamMember in commands
+    assert FireTeamMember in commands
+    assert GetTeamRoster in commands
+    assert GetRoleProfiles in commands
+    assert all(callable(c) for c in commands.values())
+
+
+def test_team_tool_get_commands_disabled():
+    """TeamTool.get_commands() excludes fully disabled capabilities."""
+    tool = TeamTool(
+        hire_team_members=False,
+        fire_team_members=False,
+        get_team_roster=False,
+        get_role_profiles=False,
+    )
+    tool.observer(mock_observer())
+
+    commands = tool.get_commands()
+    assert commands == {}
+
+
+def test_team_tool_get_commands_partial():
+    """TeamTool.get_commands() respects per-capability expose sets."""
+    tool = TeamTool(
+        hire_team_members=HireTeamMember(expose={TOOL_CALL}),  # no command
+        fire_team_members=True,  # default includes command
+    )
+    tool.observer(mock_observer())
+
+    commands = tool.get_commands()
+    # hire excluded (no command in expose), fire + roster + profiles = 3
+    assert len(commands) == 3
+    assert HireTeamMember not in commands
+    assert FireTeamMember in commands
+
+
+def test_hire_member_command_execution():
+    """hire_member command hires a single member and returns (name, address)."""
+    agent_card = Mock(spec=AgentCard)
+    agent_card.role = "Developer"
+    agent_card.agent_class = Mock
+
+    config_mock = Mock(spec=BaseConfig)
+    agent_card.get_config_copy.return_value = config_mock
+
+    orchestrator_mock = Mock(spec=Orchestrator)
+    orchestrator_mock.get_agent_catalog.return_value = [agent_card]
+    orchestrator_mock.get_team.return_value = []
+
+    address = create_test_address("@Developer123", "Developer")
+
+    observer_mock = Mock(spec=TeamManagementToolObserver)
+    observer_mock.orchestrator = create_test_address("@Orchestrator", "Orchestrator")
+    observer_mock.myAddress = create_test_address("@Manager", "Manager")
+    observer_mock.proxy_ask.return_value = orchestrator_mock
+    observer_mock.createActor.return_value = address
+
+    tool = TeamTool()
+    tool.observer(observer_mock)
+    hire_member = tool.get_commands()[HireTeamMember]
+
+    result = hire_member("Developer")
+
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+    assert "@Developer" in result[0]
+    observer_mock.createActor.assert_called_once()
+    observer_mock.on_hire.assert_called_once()
+    observer_mock.notify_event.assert_called()
+
+
+def test_hire_member_command_with_name():
+    """hire_member command uses provided name."""
+    agent_card = Mock(spec=AgentCard)
+    agent_card.role = "Developer"
+    agent_card.agent_class = Mock
+
+    config_mock = Mock(spec=BaseConfig)
+    agent_card.get_config_copy.return_value = config_mock
+
+    orchestrator_mock = Mock(spec=Orchestrator)
+    orchestrator_mock.get_agent_catalog.return_value = [agent_card]
+    orchestrator_mock.get_team.return_value = []
+
+    address = create_test_address("@MyDev", "Developer")
+
+    observer_mock = Mock(spec=TeamManagementToolObserver)
+    observer_mock.orchestrator = create_test_address("@Orchestrator", "Orchestrator")
+    observer_mock.myAddress = create_test_address("@Manager", "Manager")
+    observer_mock.proxy_ask.return_value = orchestrator_mock
+    observer_mock.createActor.return_value = address
+
+    tool = TeamTool()
+    tool.observer(observer_mock)
+    hire_member = tool.get_commands()[HireTeamMember]
+
+    result = hire_member("Developer", "@MyDev")
+
+    assert result[0] == "@MyDev"
+    observer_mock.createActor.assert_called_once()
+
+
+def test_hire_member_command_invalid_role():
+    """hire_member command raises RetriableError for invalid role."""
+    orchestrator_mock = Mock(spec=Orchestrator)
+    orchestrator_mock.get_available_roles.return_value = ["Developer"]
+    orchestrator_mock.get_agent_catalog.return_value = []
+    orchestrator_mock.get_team.return_value = []
+
+    observer_mock = Mock(spec=TeamManagementToolObserver)
+    observer_mock.orchestrator = create_test_address("@Orchestrator", "Orchestrator")
+    observer_mock.proxy_ask.return_value = orchestrator_mock
+
+    tool = TeamTool()
+    tool.observer(observer_mock)
+    hire_member = tool.get_commands()[HireTeamMember]
+
+    with pytest.raises(RetriableError, match="cannot find agent card"):
+        hire_member("InvalidRole")
+
+
+def test_fire_member_command_execution():
+    """fire_member command fires a single member."""
+    member_address = Mock()
+    member_address.name = "@Developer123"
+    member_address.role = "Developer"
+
+    orchestrator_mock = Mock(spec=Orchestrator)
+    orchestrator_mock.get_team_member.return_value = member_address
+
+    observer_mock = Mock(spec=TeamManagementToolObserver)
+    observer_mock.orchestrator = create_test_address("@Orchestrator", "Orchestrator")
+    observer_mock.proxy_ask.return_value = orchestrator_mock
+
+    tool = TeamTool()
+    tool.observer(observer_mock)
+    fire_member = tool.get_commands()[FireTeamMember]
+
+    result = fire_member("@Developer123")
+
+    assert "Developer123" in result
+    assert "fired" in result.lower()
+    member_address.stop.assert_called_once()
+    observer_mock.on_fire.assert_called_once()
+    observer_mock.notify_event.assert_called()
+
+
+def test_fire_member_command_not_found():
+    """fire_member command raises RetriableError if member not found."""
+    orchestrator_mock = Mock(spec=Orchestrator)
+    orchestrator_mock.get_team_member.return_value = None
+    orchestrator_mock.get_team.return_value = [create_test_address("@Developer456", "Developer")]
+
+    observer_mock = Mock(spec=TeamManagementToolObserver)
+    observer_mock.orchestrator = create_test_address("@Orchestrator", "Orchestrator")
+    observer_mock.proxy_ask.return_value = orchestrator_mock
+
+    tool = TeamTool()
+    tool.observer(observer_mock)
+    fire_member = tool.get_commands()[FireTeamMember]
+
+    with pytest.raises(RetriableError, match="Fire error"):
+        fire_member("@Developer123")

--- a/tests/test_team_tool.py
+++ b/tests/test_team_tool.py
@@ -11,7 +11,7 @@ from akgentic.core.agent_card import AgentCard
 from akgentic.core.agent_config import BaseConfig
 from akgentic.core.orchestrator import Orchestrator
 
-from akgentic.tool.errors import ToolError
+from akgentic.tool.errors import RetriableError
 from akgentic.tool.event import TeamManagementToolObserver
 from akgentic.tool.team import (
     FireTeamMembers,
@@ -46,6 +46,7 @@ def mock_observer() -> Mock:
 
     # Mock orchestrator proxy
     orchestrator_mock = Mock(spec=Orchestrator)
+    orchestrator_mock.get_team.return_value = []
     observer.proxy_ask.return_value = orchestrator_mock
 
     return observer
@@ -116,6 +117,7 @@ def test_hire_members_tool_execution():
     orchestrator_mock = Mock(spec=Orchestrator)
     orchestrator_mock.get_available_roles.return_value = ["Developer"]
     orchestrator_mock.get_agent_catalog.return_value = [agent_card]
+    orchestrator_mock.get_team.return_value = []
 
     observer_mock = Mock(spec=TeamManagementToolObserver)
     observer_mock.orchestrator = create_test_address("@Orchestrator", "Orchestrator")
@@ -137,11 +139,32 @@ def test_hire_members_tool_execution():
     observer_mock.notify_event.assert_called()
 
 
+def test_hire_members_empty_list():
+    """hire_members raises ToolError for empty roles list."""
+    tool = TeamTool()
+    tool.observer(mock_observer())
+    hire_members = tool.get_tools()[0]
+
+    with pytest.raises(RetriableError, match="No roles provided"):
+        hire_members([])
+
+
+def test_fire_members_empty_list():
+    """fire_members raises ToolError for empty names list."""
+    tool = TeamTool()
+    tool.observer(mock_observer())
+    fire_members = tool.get_tools()[1]
+
+    with pytest.raises(RetriableError, match="No names provided"):
+        fire_members([])
+
+
 def test_hire_members_invalid_role():
     """hire_members raises ToolError for invalid role."""
     orchestrator_mock = Mock(spec=Orchestrator)
     orchestrator_mock.get_available_roles.return_value = ["Developer"]
     orchestrator_mock.get_agent_catalog.return_value = []  # Empty catalog
+    orchestrator_mock.get_team.return_value = []
 
     observer_mock = Mock(spec=TeamManagementToolObserver)
     observer_mock.orchestrator = create_test_address("@Orchestrator", "Orchestrator")
@@ -151,20 +174,21 @@ def test_hire_members_invalid_role():
     tool.observer(observer_mock)
     hire_members = tool.get_tools()[0]
 
-    with pytest.raises(ToolError, match="cannot find agent card"):
+    with pytest.raises(RetriableError, match="cannot find agent card"):
         hire_members(["InvalidRole"])
 
 
 def test_hire_members_string_agent_class():
-    """hire_members raises ValueError if agent_class is a string (non-recoverable config error)."""
-    # Mock AgentCard with string agent_class
+    """hire_members raises ValueError if get_agent_class() returns a string (non-recoverable config error)."""
+    # Mock AgentCard with get_agent_class returning a string
     agent_card = Mock(spec=AgentCard)
     agent_card.role = "Developer"
-    agent_card.agent_class = "some.module.Agent"  # String instead of type
+    agent_card.get_agent_class.return_value = "some.module.Agent"  # String instead of type
 
     orchestrator_mock = Mock(spec=Orchestrator)
     orchestrator_mock.get_available_roles.return_value = ["Developer"]
     orchestrator_mock.get_agent_catalog.return_value = [agent_card]
+    orchestrator_mock.get_team.return_value = []
 
     observer_mock = Mock(spec=TeamManagementToolObserver)
     observer_mock.orchestrator = create_test_address("@Orchestrator", "Orchestrator")
@@ -180,11 +204,13 @@ def test_hire_members_string_agent_class():
 
 
 def test_fire_members_tool_execution():
-    """fire_members looks up address, calls observer.stop(), calls on_fire hook."""
+    """fire_members looks up address, calls address.stop(), calls on_fire hook."""
+    member_address = Mock()
+    member_address.name = "@Developer123"
+    member_address.role = "Developer"
+
     orchestrator_mock = Mock(spec=Orchestrator)
-    orchestrator_mock.get_team_member.return_value = create_test_address(
-        "@Developer123", "Developer"
-    )
+    orchestrator_mock.get_team_member.return_value = member_address
 
     observer_mock = Mock(spec=TeamManagementToolObserver)
     observer_mock.orchestrator = create_test_address("@Orchestrator", "Orchestrator")
@@ -199,7 +225,7 @@ def test_fire_members_tool_execution():
     assert "Developer123" in result
     assert "fired" in result.lower()
     orchestrator_mock.get_team_member.assert_called_once_with("@Developer123")
-    observer_mock.stop.assert_called_once()  # Agent primitive called
+    member_address.stop.assert_called_once()  # address.stop() called
     observer_mock.on_fire.assert_called_once()  # Hook called
     observer_mock.notify_event.assert_called()
 
@@ -218,7 +244,7 @@ def test_fire_members_not_found():
     tool.observer(observer_mock)
     fire_members = tool.get_tools()[1]
 
-    with pytest.raises(ToolError, match="Fire errors"):
+    with pytest.raises(RetriableError, match="Fire errors"):
         fire_members(["@Developer123"])
 
 
@@ -367,6 +393,7 @@ def test_hire_members_batch_with_multiple_errors():
     orchestrator_mock = Mock(spec=Orchestrator)
     orchestrator_mock.get_available_roles.return_value = ["Developer"]
     orchestrator_mock.get_agent_catalog.return_value = []  # Empty catalog - no cards found
+    orchestrator_mock.get_team.return_value = []
 
     observer_mock = Mock(spec=TeamManagementToolObserver)
     observer_mock.orchestrator = create_test_address("@Orchestrator", "Orchestrator")
@@ -377,7 +404,7 @@ def test_hire_members_batch_with_multiple_errors():
     hire_members = tool.get_tools()[0]
 
     # Try to hire multiple invalid roles
-    with pytest.raises(ToolError) as exc_info:
+    with pytest.raises(RetriableError) as exc_info:
         hire_members(["InvalidRole1", "InvalidRole2"])
 
     # Should contain both errors
@@ -397,6 +424,7 @@ def test_hire_members_batch_partial_success():
     orchestrator_mock = Mock(spec=Orchestrator)
     orchestrator_mock.get_available_roles.return_value = ["Developer"]
     orchestrator_mock.get_agent_catalog.return_value = [agent_card]
+    orchestrator_mock.get_team.return_value = []
 
     observer_mock = Mock(spec=TeamManagementToolObserver)
     observer_mock.orchestrator = create_test_address("@Orchestrator", "Orchestrator")
@@ -409,7 +437,7 @@ def test_hire_members_batch_partial_success():
     hire_members = tool.get_tools()[0]
 
     # Mix valid and invalid roles
-    with pytest.raises(ToolError) as exc_info:
+    with pytest.raises(RetriableError) as exc_info:
         hire_members(["Developer", "InvalidRole"])
 
     # Should have hired the valid one before failing
@@ -434,7 +462,7 @@ def test_fire_members_batch_with_multiple_errors():
     fire_members = tool.get_tools()[1]
 
     # Try to fire multiple non-existent members
-    with pytest.raises(ToolError) as exc_info:
+    with pytest.raises(RetriableError) as exc_info:
         fire_members(["@NonExistent1", "@NonExistent2"])
 
     # Should contain both errors
@@ -446,11 +474,15 @@ def test_fire_members_batch_with_multiple_errors():
 
 def test_fire_members_batch_partial_success():
     """fire_members continues on errors and fires valid members."""
+    valid_address = Mock()
+    valid_address.name = "@Valid123"
+    valid_address.role = "Developer"
+
     orchestrator_mock = Mock(spec=Orchestrator)
 
     def get_member_side_effect(name):
         if name == "@Valid123":
-            return create_test_address("@Valid123", "Developer")
+            return valid_address
         return None
 
     orchestrator_mock.get_team_member.side_effect = get_member_side_effect
@@ -465,11 +497,11 @@ def test_fire_members_batch_partial_success():
     fire_members = tool.get_tools()[1]
 
     # Mix valid and invalid members
-    with pytest.raises(ToolError) as exc_info:
+    with pytest.raises(RetriableError) as exc_info:
         fire_members(["@Valid123", "@NonExistent"])
 
     # Should have stopped the valid one before failing
-    assert observer_mock.stop.call_count == 1
+    valid_address.stop.assert_called_once()
     # Error should mention partial success and the invalid member
     assert "Partial success" in str(exc_info.value)
     assert "NonExistent" in str(exc_info.value)


### PR DESCRIPTION
## Summary

Extract team management mechanics (hire/fire members, team roster, role profiles) from `BaseAgent` into a standalone `TeamTool` ToolCard in the `akgentic-tool` package. Introduce a Channel-based exposure model and a command API for programmatic inter-agent invocation.

## Key Changes

### Channel-based expose model (`core.py`)
- Add `Channels` enum with `TOOL_CALL`, `SYSTEM_PROMPT`, `COMMAND` members
- Replace `system_prompt: bool` / `llm_tool: bool` on `BaseToolParam` with `expose: set[Channels]`
- Add `get_commands()` to `ToolCard` and `ToolFactory` for programmatic invocation

### TeamTool (`team/team.py`) — new
- `HireTeamMember` / `FireTeamMember` — LLM tools **and** commands
- `GetTeamRoster` / `GetRoleProfiles` — system prompts **and** commands
- Extract `_hire_single_member()` / `_fire_single_member()` helpers for reuse by both batch tools and singular commands
- Full input validation, unique name generation, and `RetriableError` handling

### Error handling (`errors.py`, `core.py`)
- Add `RetriableError` exception for LLM-retriable failures
- `ToolFactory` wraps tools to catch `RetriableError` and convert to `ModelRetry`

### PlanningTool refactoring
- Migrate to Channel-based expose checks
- Add `get_commands()` for `GetPlanning` and `GetPlanningTask`
- Rename `PlanItem` to `Task` for consistency

### Other
- Rename `description` to `instructions` with append behaviour on `BaseToolParam`
- `SearchTool` migrated to Channel-based expose checks

## Files Changed (14 files, +1671 / -212)

| File | Change |
|------|--------|
| `src/akgentic/tool/core.py` | Channels enum, expose field, get_commands() |
| `src/akgentic/tool/team/team.py` | New — TeamTool with hire/fire/roster/profiles |
| `src/akgentic/tool/team/__init__.py` | New — public exports |
| `src/akgentic/tool/planning/planning.py` | Channel migration, get_commands() |
| `src/akgentic/tool/planning/planning_actor.py` | PlanItem to Task rename |
| `src/akgentic/tool/search/search.py` | Channel migration |
| `src/akgentic/tool/errors.py` | New — RetriableError |
| `src/akgentic/tool/event.py` | New — ToolCallEvent, observer protocols |
| `src/akgentic/tool/__init__.py` | Updated exports |
| `tests/test_team_tool.py` | New — 683 lines of TeamTool tests |
| `tests/test_core_factory.py` | Channel + command tests |
| `tests/test_planning_actor.py` | Task rename alignment |

## Merge Order

> **Merge this PR first** — `akgentic-team` PR depends on it.

1. **akgentic-tool** (this PR)
2. [akgentic-team#5](https://github.com/b12consulting/akgentic-team/pull/5)

## Testing

All tests pass: `pytest tests/ -v`
