### PR TITLE
refactor(tool): simplify hire/fire, error management, and dependency update

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "pydantic>=2.0.0",
     "tavily-python>=0.7.12",
     "pydantic-ai>=0.1.0",
-    "akgentic-core",
+    "akgentic",
     "httpx>=0.27.0",
 ]
 
@@ -26,12 +26,13 @@ dev = [
     "ruff>=0.1.0",
 ]
 
+
+[tool.uv.sources]
+akgentic = { workspace = true }
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-[tool.uv.sources]
-akgentic-core = { workspace = true }
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/akgentic"]

--- a/src/akgentic/tool/event.py
+++ b/src/akgentic/tool/event.py
@@ -95,7 +95,7 @@ class TeamManagementToolObserver(ActorToolObserver, Protocol):
         """
         ...
 
-    def on_hire(self, name: str, address: ActorAddress) -> None:
+    def on_hire(self, address: ActorAddress) -> None:
         """Hook called after hiring a team member.
 
         Handles agent-specific concerns such as:
@@ -104,12 +104,11 @@ class TeamManagementToolObserver(ActorToolObserver, Protocol):
         - Any agent-specific bookkeeping
 
         Args:
-            name: Name of hired agent (e.g., '@Developer123')
             address: ActorAddress of hired agent
         """
         ...
 
-    def on_fire(self, name: str, address: ActorAddress) -> None:
+    def on_fire(self, address: ActorAddress) -> None:
         """Hook called after firing a team member.
 
         Handles agent-specific concerns such as:
@@ -118,7 +117,6 @@ class TeamManagementToolObserver(ActorToolObserver, Protocol):
         - Any agent-specific cleanup
 
         Args:
-            name: Name of fired agent (e.g., '@Developer123')
             address: ActorAddress of fired agent
         """
         ...

--- a/src/akgentic/tool/planning/planning.py
+++ b/src/akgentic/tool/planning/planning.py
@@ -113,6 +113,7 @@ class PlanningTool(ToolCard):
 
         def planning_prompt() -> str:
             """Get the full team planning."""
+
             planning = planning_proxy.get_planning()
             if not planning:
                 return "No current Team planning."
@@ -149,10 +150,7 @@ class PlanningTool(ToolCard):
         def update_planning(update: UpdatePlan) -> str:
             """Update team tasks (create, update, delete).
 
-            When you start or complete a task from the planning,
-            do not forget to update the plan with the new status
-            and output of the task.
-            """
+            Keep the plan up to date: update task status when you make progress, record outputs when you complete work, and create sub-tasks when you delegate."""
             observer.notify_event(
                 ToolCallEvent(tool_name="Update planning", args=[update], kwargs={})
             )

--- a/src/akgentic/tool/team/team.py
+++ b/src/akgentic/tool/team/team.py
@@ -71,7 +71,7 @@ def _hire_single_member(
         agent_catalog: Pre-fetched catalog. If None, fetched from orchestrator.
 
     Returns:
-        child_address.
+        ActorAddress: Address of the newly hired child actor.
 
     Raises:
         RetriableError: If no agent card found for the role.

--- a/src/akgentic/tool/team/team.py
+++ b/src/akgentic/tool/team/team.py
@@ -303,7 +303,7 @@ class TeamTool(ToolCard):
 
             for role in roles:
                 try:
-                    child = _hire_single_member(
+                    child_address = _hire_single_member(
                         orchestrator_proxy,
                         observer,
                         role,
@@ -311,8 +311,8 @@ class TeamTool(ToolCard):
                         existing_names,
                         agent_catalog=agent_catalog,
                     )
-                    existing_names.add(child.name)
-                    hired_members.append(child.name)
+                    existing_names.add(child_address.name)
+                    hired_members.append(child_address.name)
                 except RetriableError:
                     errors.append(role)
 

--- a/src/akgentic/tool/team/team.py
+++ b/src/akgentic/tool/team/team.py
@@ -59,7 +59,7 @@ def _hire_single_member(
     name: str | None,
     existing_names: set[str],
     agent_catalog: list[AgentCard] | None = None,
-) -> tuple[str, ActorAddress]:
+) -> ActorAddress:
     """Core hire logic for a single member.
 
     Args:
@@ -71,7 +71,7 @@ def _hire_single_member(
         agent_catalog: Pre-fetched catalog. If None, fetched from orchestrator.
 
     Returns:
-        Tuple of (child_name, child_address).
+        child_address.
 
     Raises:
         RetriableError: If no agent card found for the role.
@@ -115,10 +115,10 @@ def _hire_single_member(
     agent_card_config.role = role
 
     child_address = observer.createActor(actor_class, config=agent_card_config)
-    observer.on_hire(child_name, child_address)
+    observer.on_hire(child_address)
 
     logger.info(f"Hired {role} agent: {child_name} at {child_address}")
-    return child_name, child_address
+    return child_address
 
 
 def _fire_single_member(
@@ -148,7 +148,7 @@ def _fire_single_member(
         )
 
     address.stop()
-    observer.on_fire(name, address)
+    observer.on_fire(address)
     logger.info(f"Fired team member: {name}")
     return name
 
@@ -303,7 +303,7 @@ class TeamTool(ToolCard):
 
             for role in roles:
                 try:
-                    child_name, _ = _hire_single_member(
+                    child = _hire_single_member(
                         orchestrator_proxy,
                         observer,
                         role,
@@ -311,8 +311,8 @@ class TeamTool(ToolCard):
                         existing_names,
                         agent_catalog=agent_catalog,
                     )
-                    existing_names.add(child_name)
-                    hired_members.append(child_name)
+                    existing_names.add(child.name)
+                    hired_members.append(child.name)
                 except RetriableError:
                     errors.append(role)
 


### PR DESCRIPTION
## Summary

Comprehensive tool improvements: error management, team tool enhancements, and dependency updates.

### Changes
- Dependency: change from akgentic-core to akgentic
- Simplify on_hire/on_fire observer hooks: remove name param, use address only
- _hire_single_member returns ActorAddress directly instead of tuple
- Replace ToolError with RetriableError across core and test files
- Add Channel-based expose model and command API
- Rename PlanItem to Task, condense update_planning docstring

### Related PRs
| Package | PR | Branch |
|---------|-----|--------|
| akgentic-core | [#2](https://github.com/b12consulting/akgentic-core/pull/2) | fix-init-to-in_start |
| **akgentic-tool** | **This PR (#7)** | feat/tool-error-management |
| akgentic-quick-start | [#7](https://github.com/b12consulting/akgentic-quick-start/pull/7) | dep_update |

### Merge Order
1. akgentic-core (no deps)
2. **akgentic-tool** (this PR - depends on core)
3. akgentic-quick-start (depends on all)
