### PR TITLE
feat: add knowledge graph module with actor, tool, and vector index

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+kg = [
+    "openai>=1.0.0",
+    "numpy>=1.26.0",
+]
 dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.23.0",

--- a/src/akgentic/tool/knowledge_graph/__init__.py
+++ b/src/akgentic/tool/knowledge_graph/__init__.py
@@ -1,0 +1,102 @@
+"""Knowledge Graph subsystem for akgentic-tool.
+
+Provides in-memory knowledge graph with entity/relation CRUD,
+backed by a Pykka actor (KnowledgeGraphActor) for thread safety.
+
+Requires the ``[kg]`` optional dependency group::
+
+    pip install akgentic-tool[kg]
+
+Public API
+----------
+Models:
+    Entity, Relation, KnowledgeGraph, KnowledgeGraphState,
+    EntityCreate, EntityUpdate, RelationCreate, RelationDelete, ManageGraph
+
+ToolCard:
+    KnowledgeGraphTool, GetGraph, UpdateGraph, SearchGraph
+
+Actor:
+    KnowledgeGraphActor, KG_ACTOR_NAME, KG_ACTOR_ROLE
+
+Utilities:
+    _check_kg_dependencies — validates optional deps are installed.
+"""
+
+from __future__ import annotations
+
+from akgentic.tool.knowledge_graph.kg_actor import (
+    KG_ACTOR_NAME,
+    KG_ACTOR_ROLE,
+    KnowledgeGraphActor,
+)
+from akgentic.tool.knowledge_graph.kg_tool import (
+    GetGraph,
+    KnowledgeGraphTool,
+    SearchGraph,
+    UpdateGraph,
+)
+from akgentic.tool.knowledge_graph.models import (
+    Entity,
+    EntityCreate,
+    EntityUpdate,
+    GetGraphQuery,
+    GraphView,
+    KnowledgeGraph,
+    KnowledgeGraphState,
+    ManageGraph,
+    Relation,
+    RelationCreate,
+    RelationDelete,
+    SearchHit,
+    SearchQuery,
+    SearchResult,
+)
+
+
+def _check_kg_dependencies() -> None:
+    """Validate that ``[kg]`` optional dependencies are installed.
+
+    Raises:
+        ImportError: With install instructions when ``numpy`` is missing.
+    """
+    try:
+        import numpy as _  # noqa: F811, F401
+    except ImportError as exc:
+        msg = (
+            "The knowledge_graph module requires extra dependencies. "
+            "Install them with: pip install akgentic-tool[kg]"
+        )
+        raise ImportError(msg) from exc
+
+
+__all__ = [
+    # Core domain models
+    "Entity",
+    "Relation",
+    "KnowledgeGraph",
+    "KnowledgeGraphState",
+    # CRUD request models
+    "EntityCreate",
+    "EntityUpdate",
+    "RelationCreate",
+    "RelationDelete",
+    "ManageGraph",
+    # Query & search models (Story 1.2)
+    "GetGraphQuery",
+    "GraphView",
+    "SearchQuery",
+    "SearchHit",
+    "SearchResult",
+    # ToolCard (Story 1.3)
+    "KnowledgeGraphTool",
+    "GetGraph",
+    "UpdateGraph",
+    "SearchGraph",
+    # Actor
+    "KnowledgeGraphActor",
+    "KG_ACTOR_NAME",
+    "KG_ACTOR_ROLE",
+    # Utilities
+    "_check_kg_dependencies",
+]

--- a/src/akgentic/tool/knowledge_graph/__init__.py
+++ b/src/akgentic/tool/knowledge_graph/__init__.py
@@ -58,16 +58,23 @@ def _check_kg_dependencies() -> None:
     """Validate that ``[kg]`` optional dependencies are installed.
 
     Raises:
-        ImportError: With install instructions when ``numpy`` is missing.
+        ImportError: With install instructions when ``numpy`` or ``openai`` is missing.
     """
+    missing: list[str] = []
     try:
         import numpy as _  # noqa: F811, F401
-    except ImportError as exc:
+    except ImportError:
+        missing.append("numpy")
+    try:
+        import openai as _  # noqa: F811, F401
+    except ImportError:
+        missing.append("openai")
+    if missing:
         msg = (
-            "The knowledge_graph module requires extra dependencies. "
+            f"The knowledge_graph module requires extra dependencies ({', '.join(missing)}). "
             "Install them with: pip install akgentic-tool[kg]"
         )
-        raise ImportError(msg) from exc
+        raise ImportError(msg)
 
 
 __all__ = [

--- a/src/akgentic/tool/knowledge_graph/kg_actor.py
+++ b/src/akgentic/tool/knowledge_graph/kg_actor.py
@@ -1,0 +1,440 @@
+"""KnowledgeGraph actor with batch CRUD operations.
+
+Mirrors the PlanActor pattern: Akgent subclass with typed state,
+error-collection semantics, and ``BaseState.notify_state_change()``
+for orchestrator integration.
+
+Source: V2 redesign of akgentic-framework KnowledgeGraphManager.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from akgentic.core.agent import Akgent
+from akgentic.core.agent_config import BaseConfig
+from akgentic.tool.errors import RetriableError
+from akgentic.tool.knowledge_graph.models import (
+    Entity,
+    EntityCreate,
+    EntityUpdate,
+    GetGraphQuery,
+    GraphView,
+    KnowledgeGraphState,
+    ManageGraph,
+    Relation,
+    RelationCreate,
+    RelationDelete,
+    SearchHit,
+    SearchQuery,
+    SearchResult,
+)
+
+KG_ACTOR_NAME: str = "#KnowledgeGraphTool"
+"""Singleton actor name registered with the orchestrator."""
+
+KG_ACTOR_ROLE: str = "ToolActor"
+"""Actor role constant for ToolCard integration."""
+
+
+class KnowledgeGraphActor(Akgent[BaseConfig, KnowledgeGraphState]):
+    """Centralized, thread-safe knowledge graph with batch CRUD.
+
+    All mutations flow through ``update_graph(ManageGraph)`` which
+    executes operations in a deterministic order, collects all errors,
+    notifies the orchestrator via ``state.notify_state_change()``, and
+    raises a single ``RetriableError`` when any errors occurred.
+
+    Operation order:
+        create_entities → create_relations → update_entities
+        → delete_relations → delete_entities
+    """
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def on_start(self) -> None:  # noqa: ANN201
+        """Initialize state and attach observer for orchestrator notifications."""
+        self.state = KnowledgeGraphState()
+        self.state.observer(self)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @property
+    def _graph(self) -> KnowledgeGraphState:
+        """Shortcut to the knowledge graph container inside state."""
+        return self.state
+
+    def _entity_map(self) -> dict[str, Entity]:
+        """Build a name → Entity lookup from current graph."""
+        return {e.name: e for e in self.state.knowledge_graph.entities}
+
+    # ------------------------------------------------------------------
+    # CRUD: Create
+    # ------------------------------------------------------------------
+
+    def _create_entities(self, entities: list[EntityCreate]) -> list[str]:
+        """Add new entities, skipping duplicates by name.
+
+        Returns:
+            List of error strings for duplicate names already in graph.
+        """
+        errors: list[str] = []
+        existing_names = {e.name for e in self.state.knowledge_graph.entities}
+
+        for ec in entities:
+            if ec.name in existing_names:
+                errors.append(f"Entity '{ec.name}' already exists")
+                continue
+            entity = Entity(
+                id=uuid.uuid4(),
+                name=ec.name,
+                entity_type=ec.entity_type,
+                description=ec.description,
+                observations=list(ec.observations),
+            )
+            self.state.knowledge_graph.entities.append(entity)
+            existing_names.add(ec.name)
+        return errors
+
+    def _create_relations(self, relations: list[RelationCreate]) -> list[str]:
+        """Add new relations, validating entity references and deduplicating.
+
+        Returns:
+            List of error strings for missing entity references or duplicates.
+        """
+        errors: list[str] = []
+        existing_names = {e.name for e in self.state.knowledge_graph.entities}
+        existing_triples = {
+            (r.from_entity, r.to_entity, r.relation_type)
+            for r in self.state.knowledge_graph.relations
+        }
+
+        for rc in relations:
+            if rc.from_entity not in existing_names:
+                errors.append(f"Relation references non-existent from_entity '{rc.from_entity}'")
+                continue
+            if rc.to_entity not in existing_names:
+                errors.append(f"Relation references non-existent to_entity '{rc.to_entity}'")
+                continue
+
+            triple = (rc.from_entity, rc.to_entity, rc.relation_type)
+            if triple in existing_triples:
+                # Silently skip duplicate relations (same as V1)
+                continue
+
+            relation = Relation(
+                id=uuid.uuid4(),
+                from_entity=rc.from_entity,
+                to_entity=rc.to_entity,
+                relation_type=rc.relation_type,
+                description=rc.description,
+            )
+            self.state.knowledge_graph.relations.append(relation)
+            existing_triples.add(triple)
+        return errors
+
+    # ------------------------------------------------------------------
+    # CRUD: Update
+    # ------------------------------------------------------------------
+
+    def _update_entities(self, updates: list[EntityUpdate]) -> list[str]:
+        """Apply partial updates to existing entities.
+
+        Only non-None fields are applied. ``add_observations`` appends,
+        ``remove_observations`` removes from the existing list.
+
+        Returns:
+            List of error strings for entities not found.
+        """
+        errors: list[str] = []
+        entity_map = self._entity_map()
+
+        for eu in updates:
+            entity = entity_map.get(eu.name)
+            if entity is None:
+                errors.append(f"Entity '{eu.name}' not found for update")
+                continue
+
+            if eu.description is not None:
+                entity.description = eu.description
+            if eu.entity_type is not None:
+                entity.entity_type = eu.entity_type
+            if eu.add_observations is not None:
+                entity.observations.extend(eu.add_observations)
+            if eu.remove_observations is not None:
+                to_remove = set(eu.remove_observations)
+                entity.observations = [o for o in entity.observations if o not in to_remove]
+        return errors
+
+    # ------------------------------------------------------------------
+    # CRUD: Delete
+    # ------------------------------------------------------------------
+
+    def _delete_entities(self, names: list[str]) -> list[str]:
+        """Remove entities by name with cascade deletion of relations.
+
+        Also removes any associated VectorEntry embeddings (no-op until Epic 2).
+
+        Returns:
+            List of error strings for entities not found.
+        """
+        errors: list[str] = []
+        existing_names = {e.name for e in self.state.knowledge_graph.entities}
+
+        for name in names:
+            if name not in existing_names:
+                errors.append(f"Entity '{name}' not found for deletion")
+
+        names_set = set(names) & existing_names
+
+        if names_set:
+            # Collect UUIDs of deleted entities for future embedding removal
+            _deleted_ids = [
+                e.id for e in self.state.knowledge_graph.entities if e.name in names_set
+            ]
+
+            # Collect UUIDs of cascade-deleted relations
+            _deleted_rel_ids = [
+                r.id
+                for r in self.state.knowledge_graph.relations
+                if r.from_entity in names_set or r.to_entity in names_set
+            ]
+
+            # Remove entities
+            self.state.knowledge_graph.entities = [
+                e for e in self.state.knowledge_graph.entities if e.name not in names_set
+            ]
+
+            # Cascade-delete relations referencing deleted entities
+            self.state.knowledge_graph.relations = [
+                r
+                for r in self.state.knowledge_graph.relations
+                if r.from_entity not in names_set and r.to_entity not in names_set
+            ]
+
+            # TODO(Epic 2): Remove associated VectorEntry embeddings by ref_id
+            # self._remove_embeddings(_deleted_ids + _deleted_rel_ids)
+
+        return errors
+
+    def _delete_relations(self, deletions: list[RelationDelete]) -> list[str]:
+        """Remove relations by ``(from_entity, to_entity, relation_type)`` triple.
+
+        Also removes any associated VectorEntry embeddings (no-op until Epic 2).
+
+        Returns:
+            List of error strings for relations not found.
+        """
+        errors: list[str] = []
+        existing_triples = {
+            (r.from_entity, r.to_entity, r.relation_type): r
+            for r in self.state.knowledge_graph.relations
+        }
+
+        triples_to_delete: set[tuple[str, str, str]] = set()
+        for rd in deletions:
+            triple = (rd.from_entity, rd.to_entity, rd.relation_type)
+            if triple not in existing_triples:
+                errors.append(
+                    f"Relation ({rd.from_entity} -> {rd.to_entity} [{rd.relation_type}]) not found"
+                )
+            else:
+                triples_to_delete.add(triple)
+
+        if triples_to_delete:
+            # Collect UUIDs for future embedding removal
+            _deleted_rel_ids = [
+                r.id
+                for r in self.state.knowledge_graph.relations
+                if (r.from_entity, r.to_entity, r.relation_type) in triples_to_delete
+            ]
+
+            self.state.knowledge_graph.relations = [
+                r
+                for r in self.state.knowledge_graph.relations
+                if (r.from_entity, r.to_entity, r.relation_type) not in triples_to_delete
+            ]
+
+            # TODO(Epic 2): Remove associated VectorEntry embeddings by ref_id
+            # self._remove_embeddings(_deleted_rel_ids)
+
+        return errors
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def update_graph(self, update: ManageGraph) -> str:
+        """Execute batch mutations in deterministic order.
+
+        Order: create_entities → create_relations → update_entities
+        → delete_relations → delete_entities.
+
+        All errors are collected across all operations. After mutations,
+        ``state.notify_state_change()`` is called regardless of errors.
+        A single ``RetriableError`` is raised if any errors occurred.
+
+        Args:
+            update: Batch mutation request.
+
+        Returns:
+            ``"Done"`` on success.
+
+        Raises:
+            RetriableError: With all collected error messages joined by "; ".
+        """
+        errors: list[str] = []
+
+        errors.extend(self._create_entities(update.create_entities))
+        errors.extend(self._create_relations(update.create_relations))
+        errors.extend(self._update_entities(update.update_entities))
+        errors.extend(self._delete_relations(update.delete_relations))
+        errors.extend(self._delete_entities(update.delete_entities))
+
+        self.state.notify_state_change()
+
+        if errors:
+            raise RetriableError("Update errors: " + "; ".join(errors))
+        return "Done"
+
+    def get_graph(self, query: GetGraphQuery | None = None) -> GraphView:
+        """Return a full or filtered subgraph view.
+
+        When ``query`` is None or has empty ``entity_names``, the full
+        graph is returned.  Otherwise BFS expansion is performed from
+        the root entities up to ``depth`` hops, optionally filtered by
+        ``relation_types``.
+
+        Args:
+            query: Subgraph query parameters.  Defaults to full graph.
+
+        Returns:
+            GraphView with discovered entities and connecting relations.
+        """
+        if query is None:
+            query = GetGraphQuery()
+
+        if not query.entity_names:
+            return GraphView(
+                entities=list(self.state.knowledge_graph.entities),
+                relations=list(self.state.knowledge_graph.relations),
+            )
+
+        return self._get_subgraph(
+            entity_names=query.entity_names,
+            depth=query.depth,
+            relation_types=query.relation_types,
+        )
+
+    # ------------------------------------------------------------------
+    # Subgraph BFS
+    # ------------------------------------------------------------------
+
+    def _get_subgraph(
+        self,
+        entity_names: list[str],
+        depth: int,
+        relation_types: list[str],
+    ) -> GraphView:
+        """BFS expansion from root entities.
+
+        At each hop, relations connecting a frontier entity to an
+        unvisited entity are traversed.  ``relation_types`` limits which
+        edge types are followed.  After expansion completes, only
+        relations whose **both** endpoints are in the visited set are
+        included in the result.
+        """
+        graph = self.state.knowledge_graph
+        entity_map = {e.name: e for e in graph.entities}
+
+        visited: set[str] = set()
+        frontier: set[str] = set()
+        for name in entity_names:
+            if name in entity_map:
+                frontier.add(name)
+
+        # BFS expansion: depth=0 means roots only (no expansion)
+        for _ in range(depth):
+            visited |= frontier
+            next_frontier: set[str] = set()
+            for rel in graph.relations:
+                if relation_types and rel.relation_type not in relation_types:
+                    continue
+                if rel.from_entity in frontier and rel.to_entity not in visited:
+                    next_frontier.add(rel.to_entity)
+                if rel.to_entity in frontier and rel.from_entity not in visited:
+                    next_frontier.add(rel.from_entity)
+            frontier = next_frontier
+
+        visited |= frontier
+
+        result_entities = [e for e in graph.entities if e.name in visited]
+        result_relations = [
+            r for r in graph.relations if r.from_entity in visited and r.to_entity in visited
+        ]
+        return GraphView(entities=result_entities, relations=result_relations)
+
+    # ------------------------------------------------------------------
+    # Keyword search
+    # ------------------------------------------------------------------
+
+    def search(self, query: SearchQuery) -> SearchResult:
+        """Search the knowledge graph by keyword, vector, or hybrid mode.
+
+        ``mode="keyword"``: case-insensitive substring matching across
+        entity and relation fields.  ``mode="vector"``: placeholder
+        returning empty results (Epic 2).  ``mode="hybrid"``: keyword
+        only for now (vector component added in Epic 2).
+
+        Args:
+            query: Search parameters.
+
+        Returns:
+            SearchResult with ranked hits.
+        """
+        if query.mode == "vector":
+            return SearchResult(hits=[])
+        # hybrid and keyword both use keyword-only search for now
+        return self._keyword_search(query.query, query.top_k)
+
+    def _keyword_search(self, query: str, top_k: int) -> SearchResult:
+        """Case-insensitive substring search across entity and relation fields."""
+        hits: list[SearchHit] = []
+        q = query.lower()
+
+        for entity in self.state.knowledge_graph.entities:
+            if (
+                q in entity.name.lower()
+                or q in entity.description.lower()
+                or q in entity.entity_type.lower()
+            ):
+                hits.append(
+                    SearchHit(
+                        ref_type="entity",
+                        ref_id=str(entity.id),
+                        score=1.0,
+                        entity=entity,
+                    )
+                )
+
+        for relation in self.state.knowledge_graph.relations:
+            if (
+                q in relation.relation_type.lower()
+                or q in relation.description.lower()
+                or q in relation.from_entity.lower()
+                or q in relation.to_entity.lower()
+            ):
+                hits.append(
+                    SearchHit(
+                        ref_type="relation",
+                        ref_id=str(relation.id),
+                        score=1.0,
+                        relation=relation,
+                    )
+                )
+
+        return SearchResult(hits=sorted(hits, key=lambda h: h.score, reverse=True)[:top_k])

--- a/src/akgentic/tool/knowledge_graph/kg_actor.py
+++ b/src/akgentic/tool/knowledge_graph/kg_actor.py
@@ -95,6 +95,7 @@ class KnowledgeGraphActor(Akgent[BaseConfig, KnowledgeGraphState]):
                 entity_type=ec.entity_type,
                 description=ec.description,
                 observations=list(ec.observations),
+                is_root=ec.is_root,
             )
             self.state.knowledge_graph.entities.append(entity)
             existing_names.add(ec.name)
@@ -163,6 +164,8 @@ class KnowledgeGraphActor(Akgent[BaseConfig, KnowledgeGraphState]):
                 entity.description = eu.description
             if eu.entity_type is not None:
                 entity.entity_type = eu.entity_type
+            if eu.is_root is not None:
+                entity.is_root = eu.is_root
             if eu.add_observations is not None:
                 entity.observations.extend(eu.add_observations)
             if eu.remove_observations is not None:
@@ -304,10 +307,14 @@ class KnowledgeGraphActor(Akgent[BaseConfig, KnowledgeGraphState]):
     def get_graph(self, query: GetGraphQuery | None = None) -> GraphView:
         """Return a full or filtered subgraph view.
 
-        When ``query`` is None or has empty ``entity_names``, the full
-        graph is returned.  Otherwise BFS expansion is performed from
-        the root entities up to ``depth`` hops, optionally filtered by
-        ``relation_types``.
+        When ``query`` is None or has empty ``entity_names`` (and
+        ``roots_only`` is False), the full graph is returned.  Otherwise
+        BFS expansion is performed from the seed entities up to
+        ``depth`` hops, optionally filtered by ``relation_types``.
+
+        When ``roots_only`` is True, entities with ``is_root=True`` are
+        used as BFS seeds and ``entity_names`` is ignored.  Depth
+        defaults to 0 (no expansion) for ``roots_only`` mode.
 
         Args:
             query: Subgraph query parameters.  Defaults to full graph.
@@ -318,15 +325,30 @@ class KnowledgeGraphActor(Akgent[BaseConfig, KnowledgeGraphState]):
         if query is None:
             query = GetGraphQuery()
 
+        # roots_only takes precedence over entity_names (AC-6)
+        if query.roots_only:
+            root_names = [e.name for e in self.state.knowledge_graph.entities if e.is_root]
+            if not root_names:
+                return GraphView()
+            # depth=None → 0 for roots_only (AC-4); explicit depth used as-is (AC-5)
+            effective_depth = query.depth if query.depth is not None else 0
+            return self._get_subgraph(
+                entity_names=root_names,
+                depth=effective_depth,
+                relation_types=query.relation_types,
+            )
+
         if not query.entity_names:
             return GraphView(
                 entities=list(self.state.knowledge_graph.entities),
                 relations=list(self.state.knowledge_graph.relations),
             )
 
+        # depth=None → 1 for entity_names mode (backward compat)
+        effective_depth = query.depth if query.depth is not None else 1
         return self._get_subgraph(
             entity_names=query.entity_names,
-            depth=query.depth,
+            depth=effective_depth,
             relation_types=query.relation_types,
         )
 

--- a/src/akgentic/tool/knowledge_graph/kg_tool.py
+++ b/src/akgentic/tool/knowledge_graph/kg_tool.py
@@ -1,0 +1,274 @@
+"""KnowledgeGraph ToolCard integration.
+
+Provides ``KnowledgeGraphTool`` — a ``ToolCard`` that exposes graph
+operations (get_graph, update_graph, search) through configurable channels,
+with read-only mode support.
+
+Follows the same pattern as ``PlanningTool`` in akgentic.tool.planning.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Callable, Literal
+
+from pydantic import Field
+
+from akgentic.core.agent_config import BaseConfig
+from akgentic.core.orchestrator import Orchestrator
+from akgentic.tool.core import (
+    COMMAND,
+    SYSTEM_PROMPT,
+    TOOL_CALL,
+    BaseToolParam,
+    Channels,
+    ToolCard,
+    _resolve,
+)
+from akgentic.tool.event import ActorToolObserver, ToolCallEvent
+from akgentic.tool.knowledge_graph.kg_actor import (
+    KG_ACTOR_NAME,
+    KG_ACTOR_ROLE,
+    KnowledgeGraphActor,
+)
+from akgentic.tool.knowledge_graph.models import (
+    GetGraphQuery,
+    ManageGraph,
+    SearchQuery,
+)
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+# ---------------------------------------------------------------------------
+# BaseToolParam subclasses (Task 1)
+# ---------------------------------------------------------------------------
+
+
+class GetGraph(BaseToolParam):
+    """Get the full knowledge graph — as system prompt and/or command."""
+
+    expose: set[Channels] = {SYSTEM_PROMPT, COMMAND}
+
+
+class UpdateGraph(BaseToolParam):
+    """Update the knowledge graph (create/update/delete entities & relations)."""
+
+    expose: set[Channels] = {TOOL_CALL}
+
+
+class SearchGraph(BaseToolParam):
+    """Search the knowledge graph by keyword, vector, or hybrid mode."""
+
+    expose: set[Channels] = {TOOL_CALL, COMMAND}
+
+
+# ---------------------------------------------------------------------------
+# KnowledgeGraphTool ToolCard (Task 2)
+# ---------------------------------------------------------------------------
+
+
+class KnowledgeGraphTool(ToolCard):
+    """Knowledge graph tool exposing graph operations through configurable channels.
+
+    Follows the same actor-based pattern as ``PlanningTool``: a singleton
+    ``KnowledgeGraphActor`` is created/retrieved via the orchestrator,
+    and tool factories delegate to the actor proxy.
+    """
+
+    name: str = "KnowledgeGraph"
+    description: str = "Knowledge graph tool for structured knowledge with semantic search"
+
+    get_graph: GetGraph | bool = Field(
+        default=True,
+        description="Get the full graph — SYSTEM_PROMPT + COMMAND by default",
+    )
+    update_graph: UpdateGraph | bool = Field(
+        default=True,
+        description="Update graph — TOOL_CALL by default",
+    )
+    search: SearchGraph | bool = Field(
+        default=True,
+        description="Search graph — TOOL_CALL + COMMAND by default",
+    )
+
+    embedding_model: str = "text-embedding-3-small"
+    embedding_provider: Literal["openai", "azure"] = "openai"
+    read_only: bool = False
+
+    # ------------------------------------------------------------------
+    # Observer / actor wiring (2.2)
+    # ------------------------------------------------------------------
+
+    def observer(self, observer: ActorToolObserver) -> None:  # type: ignore[override]
+        """Attach observer and set up the KG actor proxy.
+
+        Creates/retrieves the singleton ``KnowledgeGraphActor`` via the
+        orchestrator, identical to PlanningTool's observer pattern.
+        """
+        from akgentic.tool.knowledge_graph import _check_kg_dependencies
+
+        _check_kg_dependencies()
+        self._observer = observer
+
+        if observer.orchestrator is None:
+            raise ValueError("KnowledgeGraphTool requires access to the orchestrator.")
+
+        orchestrator_proxy = observer.proxy_ask(observer.orchestrator, Orchestrator)
+        kg_addr = orchestrator_proxy.get_team_member(KG_ACTOR_NAME)
+
+        if kg_addr is None:
+            logger.info("KnowledgeGraphTool: creating singleton %s.", KG_ACTOR_NAME)
+            kg_addr = orchestrator_proxy.createActor(
+                KnowledgeGraphActor,
+                config=BaseConfig(name=KG_ACTOR_NAME, role=KG_ACTOR_ROLE),
+            )
+
+        self._kg_proxy = observer.proxy_ask(kg_addr, KnowledgeGraphActor)
+
+    # ------------------------------------------------------------------
+    # System prompts (2.3)
+    # ------------------------------------------------------------------
+
+    def get_system_prompts(self) -> list[Callable]:
+        """Return prompt callables when get_graph is exposed on SYSTEM_PROMPT."""
+        gp = _resolve(self.get_graph, GetGraph)
+        if gp and SYSTEM_PROMPT in gp.expose:
+            return [self._get_graph_prompt_factory()]
+        return []
+
+    def _get_graph_prompt_factory(self) -> Callable:
+        """Create a closure that returns the current graph as a prompt string."""
+        kg_proxy = self._kg_proxy
+
+        def graph_prompt() -> str:
+            """Get the current knowledge graph state."""
+            view = kg_proxy.get_graph(GetGraphQuery())
+            if not view.entities:
+                return "Knowledge graph is empty."
+            lines = ["Knowledge Graph:"]
+            lines.append("Entities:")
+            for e in view.entities:
+                lines.append(f"  - {e.name} ({e.entity_type}): {e.description}")
+            lines.append("Relations:")
+            for r in view.relations:
+                desc = f" — {r.description}" if r.description else ""
+                lines.append(f"  - {r.from_entity} --[{r.relation_type}]--> {r.to_entity}{desc}")
+            return "\n".join(lines)
+
+        return graph_prompt
+
+    # ------------------------------------------------------------------
+    # Tools (2.4)
+    # ------------------------------------------------------------------
+
+    def get_tools(self) -> list[Callable]:
+        """Return callable tool functions for LLM agents."""
+        tools: list[Callable] = []
+
+        gp = _resolve(self.get_graph, GetGraph)
+        if gp and TOOL_CALL in gp.expose:
+            tools.append(self._get_graph_factory(gp))
+
+        if not self.read_only:
+            up = _resolve(self.update_graph, UpdateGraph)
+            if up and TOOL_CALL in up.expose:
+                tools.append(self._update_graph_factory(up))
+
+        sp = _resolve(self.search, SearchGraph)
+        if sp and TOOL_CALL in sp.expose:
+            tools.append(self._search_factory(sp))
+
+        return tools
+
+    # ------------------------------------------------------------------
+    # Commands (2.5)
+    # ------------------------------------------------------------------
+
+    def get_commands(self) -> dict[type[BaseToolParam], Callable]:
+        """Return command mappings for inter-agent orchestration."""
+        commands: dict[type[BaseToolParam], Callable] = {}
+
+        gp = _resolve(self.get_graph, GetGraph)
+        if gp and COMMAND in gp.expose:
+            commands[GetGraph] = self._get_graph_factory(gp)
+
+        sp = _resolve(self.search, SearchGraph)
+        if sp and COMMAND in sp.expose:
+            commands[SearchGraph] = self._search_factory(sp)
+
+        return commands
+
+    # ------------------------------------------------------------------
+    # Factory closures (2.6, 2.7, 2.8)
+    # ------------------------------------------------------------------
+
+    def _get_graph_factory(self, params: GetGraph) -> Callable:
+        """Return a closure that fetches and formats the graph."""
+        kg_proxy = self._kg_proxy
+        observer = self._observer
+
+        def get_graph() -> str:
+            """Get the current knowledge graph."""
+            observer.notify_event(ToolCallEvent(tool_name="Get graph", args=[], kwargs={}))
+            view = kg_proxy.get_graph(GetGraphQuery())
+            if not view.entities:
+                return "Knowledge graph is empty."
+            lines = ["Knowledge Graph:"]
+            lines.append("Entities:")
+            for e in view.entities:
+                lines.append(f"  - {e.name} ({e.entity_type}): {e.description}")
+            lines.append("Relations:")
+            for r in view.relations:
+                desc = f" — {r.description}" if r.description else ""
+                lines.append(f"  - {r.from_entity} --[{r.relation_type}]--> {r.to_entity}{desc}")
+            return "\n".join(lines)
+
+        get_graph.__doc__ = params.format_docstring(get_graph.__doc__)
+        return get_graph
+
+    def _update_graph_factory(self, params: UpdateGraph) -> Callable:
+        """Return a closure that applies graph mutations."""
+        kg_proxy = self._kg_proxy
+        observer = self._observer
+
+        def update_graph(update: ManageGraph) -> str:
+            """Update the knowledge graph (create/update/delete entities & relations).
+
+            Use this tool to add new entities, update existing ones, create or
+            remove relations, and delete entities from the knowledge graph."""
+            observer.notify_event(ToolCallEvent(tool_name="Update graph", args=[update], kwargs={}))
+            return kg_proxy.update_graph(update)
+
+        update_graph.__doc__ = params.format_docstring(update_graph.__doc__)
+        return update_graph
+
+    def _search_factory(self, params: SearchGraph) -> Callable:
+        """Return a closure that searches the graph."""
+        kg_proxy = self._kg_proxy
+        observer = self._observer
+
+        def search_graph(query: SearchQuery) -> str:
+            """Search the knowledge graph by keyword, vector, or hybrid mode."""
+            observer.notify_event(ToolCallEvent(tool_name="Search graph", args=[query], kwargs={}))
+            result = kg_proxy.search(query)
+            if not result.hits:
+                return "No results found."
+            lines = ["Search Results:"]
+            for hit in result.hits:
+                if hit.entity:
+                    lines.append(
+                        f"  - [entity] {hit.entity.name} ({hit.entity.entity_type}): "
+                        f"{hit.entity.description} (score: {hit.score:.2f})"
+                    )
+                elif hit.relation:
+                    r = hit.relation
+                    lines.append(
+                        f"  - [relation] {r.from_entity} --[{r.relation_type}]--> "
+                        f"{r.to_entity} (score: {hit.score:.2f})"
+                    )
+            return "\n".join(lines)
+
+        search_graph.__doc__ = params.format_docstring(search_graph.__doc__)
+        return search_graph

--- a/src/akgentic/tool/knowledge_graph/kg_tool.py
+++ b/src/akgentic/tool/knowledge_graph/kg_tool.py
@@ -33,8 +33,10 @@ from akgentic.tool.knowledge_graph.kg_actor import (
 )
 from akgentic.tool.knowledge_graph.models import (
     GetGraphQuery,
+    GraphView,
     ManageGraph,
     SearchQuery,
+    SearchResult,
 )
 
 logger = logging.getLogger(__name__)
@@ -128,6 +130,45 @@ class KnowledgeGraphTool(ToolCard):
         self._kg_proxy = observer.proxy_ask(kg_addr, KnowledgeGraphActor)
 
     # ------------------------------------------------------------------
+    # Formatting helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _format_graph_view(view: GraphView) -> str:
+        """Format a ``GraphView`` as a human-readable string."""
+        if not view.entities:
+            return "Knowledge graph is empty."
+        lines = ["Knowledge Graph:"]
+        lines.append("Entities:")
+        for e in view.entities:
+            lines.append(f"  - {e.name} ({e.entity_type}): {e.description}")
+        lines.append("Relations:")
+        for r in view.relations:
+            desc = f" — {r.description}" if r.description else ""
+            lines.append(f"  - {r.from_entity} --[{r.relation_type}]--> {r.to_entity}{desc}")
+        return "\n".join(lines)
+
+    @staticmethod
+    def _format_search_result(result: SearchResult) -> str:
+        """Format a ``SearchResult`` as a human-readable string."""
+        if not result.hits:
+            return "No results found."
+        lines = ["Search Results:"]
+        for hit in result.hits:
+            if hit.entity:
+                lines.append(
+                    f"  - [entity] {hit.entity.name} ({hit.entity.entity_type}): "
+                    f"{hit.entity.description} (score: {hit.score:.2f})"
+                )
+            elif hit.relation:
+                r = hit.relation
+                lines.append(
+                    f"  - [relation] {r.from_entity} --[{r.relation_type}]--> "
+                    f"{r.to_entity} (score: {hit.score:.2f})"
+                )
+        return "\n".join(lines)
+
+    # ------------------------------------------------------------------
     # System prompts (2.3)
     # ------------------------------------------------------------------
 
@@ -141,21 +182,12 @@ class KnowledgeGraphTool(ToolCard):
     def _get_graph_prompt_factory(self) -> Callable:
         """Create a closure that returns the current graph as a prompt string."""
         kg_proxy = self._kg_proxy
+        format_view = self._format_graph_view
 
         def graph_prompt() -> str:
             """Get the current knowledge graph state."""
             view = kg_proxy.get_graph(GetGraphQuery())
-            if not view.entities:
-                return "Knowledge graph is empty."
-            lines = ["Knowledge Graph:"]
-            lines.append("Entities:")
-            for e in view.entities:
-                lines.append(f"  - {e.name} ({e.entity_type}): {e.description}")
-            lines.append("Relations:")
-            for r in view.relations:
-                desc = f" — {r.description}" if r.description else ""
-                lines.append(f"  - {r.from_entity} --[{r.relation_type}]--> {r.to_entity}{desc}")
-            return "\n".join(lines)
+            return format_view(view)
 
         return graph_prompt
 
@@ -208,22 +240,13 @@ class KnowledgeGraphTool(ToolCard):
         """Return a closure that fetches and formats the graph."""
         kg_proxy = self._kg_proxy
         observer = self._observer
+        format_view = self._format_graph_view
 
         def get_graph() -> str:
             """Get the current knowledge graph."""
             observer.notify_event(ToolCallEvent(tool_name="Get graph", args=[], kwargs={}))
             view = kg_proxy.get_graph(GetGraphQuery())
-            if not view.entities:
-                return "Knowledge graph is empty."
-            lines = ["Knowledge Graph:"]
-            lines.append("Entities:")
-            for e in view.entities:
-                lines.append(f"  - {e.name} ({e.entity_type}): {e.description}")
-            lines.append("Relations:")
-            for r in view.relations:
-                desc = f" — {r.description}" if r.description else ""
-                lines.append(f"  - {r.from_entity} --[{r.relation_type}]--> {r.to_entity}{desc}")
-            return "\n".join(lines)
+            return format_view(view)
 
         get_graph.__doc__ = params.format_docstring(get_graph.__doc__)
         return get_graph
@@ -248,27 +271,13 @@ class KnowledgeGraphTool(ToolCard):
         """Return a closure that searches the graph."""
         kg_proxy = self._kg_proxy
         observer = self._observer
+        format_result = self._format_search_result
 
         def search_graph(query: SearchQuery) -> str:
             """Search the knowledge graph by keyword, vector, or hybrid mode."""
             observer.notify_event(ToolCallEvent(tool_name="Search graph", args=[query], kwargs={}))
             result = kg_proxy.search(query)
-            if not result.hits:
-                return "No results found."
-            lines = ["Search Results:"]
-            for hit in result.hits:
-                if hit.entity:
-                    lines.append(
-                        f"  - [entity] {hit.entity.name} ({hit.entity.entity_type}): "
-                        f"{hit.entity.description} (score: {hit.score:.2f})"
-                    )
-                elif hit.relation:
-                    r = hit.relation
-                    lines.append(
-                        f"  - [relation] {r.from_entity} --[{r.relation_type}]--> "
-                        f"{r.to_entity} (score: {hit.score:.2f})"
-                    )
-            return "\n".join(lines)
+            return format_result(result)
 
         search_graph.__doc__ = params.format_docstring(search_graph.__doc__)
         return search_graph

--- a/src/akgentic/tool/knowledge_graph/kg_tool.py
+++ b/src/akgentic/tool/knowledge_graph/kg_tool.py
@@ -52,6 +52,14 @@ class GetGraph(BaseToolParam):
     """Get the full knowledge graph — as system prompt and/or command."""
 
     expose: set[Channels] = {SYSTEM_PROMPT, COMMAND}
+    prompt_include_schema: bool = Field(
+        default=True,
+        description="Include entity/relation type schema in system prompt.",
+    )
+    prompt_include_roots: bool = Field(
+        default=True,
+        description="Include root entities listing in system prompt.",
+    )
 
 
 class UpdateGraph(BaseToolParam):
@@ -149,6 +157,40 @@ class KnowledgeGraphTool(ToolCard):
         return "\n".join(lines)
 
     @staticmethod
+    def _format_graph_summary(
+        view: GraphView,
+        include_schema: bool = True,
+        include_roots: bool = True,
+    ) -> str:
+        """Format a compact system prompt summary of the graph.
+
+        Output scales as O(types + roots), not O(entities + relations).
+        """
+        if not view.entities:
+            return "Knowledge graph is empty."
+
+        lines = ["**Knowledge Graph Summary:**"]
+        lines.append(f"Entities: {len(view.entities)} | Relations: {len(view.relations)}")
+
+        if include_schema:
+            entity_types = sorted({e.entity_type for e in view.entities})
+            relation_types = sorted({r.relation_type for r in view.relations})
+            lines.append(f"Entity types: {', '.join(entity_types)}")
+            if relation_types:
+                lines.append(f"Relation types: {', '.join(relation_types)}")
+
+        if include_roots:
+            root_entities = sorted((e for e in view.entities if e.is_root), key=lambda e: e.name)
+            if root_entities:
+                lines.append("Root entities:")
+                for e in root_entities:
+                    lines.append(f"- {e.name} ({e.entity_type}): {e.description}")
+
+        lines.append("")
+        lines.append("Use the get_graph tool to explore the full graph or subgraphs.")
+        return "\n".join(lines)
+
+    @staticmethod
     def _format_search_result(result: SearchResult) -> str:
         """Format a ``SearchResult`` as a human-readable string."""
         if not result.hits:
@@ -180,14 +222,17 @@ class KnowledgeGraphTool(ToolCard):
         return []
 
     def _get_graph_prompt_factory(self) -> Callable:
-        """Create a closure that returns the current graph as a prompt string."""
+        """Create a closure that returns a compact graph summary as a prompt string."""
         kg_proxy = self._kg_proxy
-        format_view = self._format_graph_view
+        format_summary = self._format_graph_summary
+        gp = _resolve(self.get_graph, GetGraph)
+        include_schema = gp.prompt_include_schema if gp else True
+        include_roots = gp.prompt_include_roots if gp else True
 
         def graph_prompt() -> str:
             """Get the current knowledge graph state."""
             view = kg_proxy.get_graph(GetGraphQuery())
-            return format_view(view)
+            return format_summary(view, include_schema=include_schema, include_roots=include_roots)
 
         return graph_prompt
 

--- a/src/akgentic/tool/knowledge_graph/models.py
+++ b/src/akgentic/tool/knowledge_graph/models.py
@@ -1,0 +1,246 @@
+"""Data models for the Knowledge Graph subsystem.
+
+Defines entity, relation, CRUD request models, query/search models,
+and state containers for the KnowledgeGraphActor. All models extend
+SerializableBaseModel for proper actor message serialization.
+
+Source: V2 redesign of akgentic-framework/libs/tools/tools/knowledge_graph.py
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Literal
+
+from pydantic import Field
+
+from akgentic.core.agent_state import BaseState
+from akgentic.core.utils.serializer import SerializableBaseModel
+
+# ---------------------------------------------------------------------------
+# Core domain models
+# ---------------------------------------------------------------------------
+
+
+class Entity(SerializableBaseModel):
+    """An entity node in the knowledge graph.
+
+    Attributes:
+        id: Auto-generated UUID for stable vector index referencing.
+        name: Human-facing unique key (deduplication key).
+        entity_type: Classification label (e.g. "Person", "Concept").
+        description: Free-text or Markdown description.
+        observations: Incremental observations attached to the entity.
+    """
+
+    id: uuid.UUID = Field(default_factory=uuid.uuid4, description="Stable unique identifier.")
+    name: str = Field(..., description="Human-facing unique name (deduplication key).")
+    entity_type: str = Field(..., description="Classification label for the entity.")
+    description: str = Field(..., description="Free-text or Markdown description.")
+    observations: list[str] = Field(
+        default_factory=list, description="Incremental observations attached to the entity."
+    )
+
+
+class Relation(SerializableBaseModel):
+    """A directed edge between two entities in the knowledge graph.
+
+    Attributes:
+        id: Auto-generated UUID for stable vector index referencing.
+        from_entity: Source entity name.
+        to_entity: Target entity name.
+        relation_type: Label describing the relationship.
+        description: Optional free-text description (enables embedding in Epic 2).
+    """
+
+    id: uuid.UUID = Field(default_factory=uuid.uuid4, description="Stable unique identifier.")
+    from_entity: str = Field(..., description="Source entity name.")
+    to_entity: str = Field(..., description="Target entity name.")
+    relation_type: str = Field(..., description="Label describing the relationship.")
+    description: str = Field(default="", description="Optional description of the relation.")
+
+
+# ---------------------------------------------------------------------------
+# CRUD request models
+# ---------------------------------------------------------------------------
+
+
+class EntityCreate(SerializableBaseModel):
+    """Request to create a new entity.
+
+    Mirrors Entity fields minus ``id`` (auto-generated on creation).
+    """
+
+    name: str = Field(..., description="Unique entity name.")
+    entity_type: str = Field(..., description="Classification label.")
+    description: str = Field(..., description="Free-text description.")
+    observations: list[str] = Field(default_factory=list, description="Initial observations.")
+
+
+class EntityUpdate(SerializableBaseModel):
+    """Partial update for an existing entity.
+
+    Only ``name`` is required (lookup key). All other fields are optional;
+    only non-None values are applied.
+    """
+
+    name: str = Field(..., description="Entity name to update (lookup key).")
+    description: str | None = Field(default=None, description="New description.")
+    entity_type: str | None = Field(default=None, description="New entity type.")
+    add_observations: list[str] | None = Field(default=None, description="Observations to append.")
+    remove_observations: list[str] | None = Field(
+        default=None, description="Observations to remove."
+    )
+
+
+class RelationCreate(SerializableBaseModel):
+    """Request to create a new relation."""
+
+    from_entity: str = Field(..., description="Source entity name.")
+    to_entity: str = Field(..., description="Target entity name.")
+    relation_type: str = Field(..., description="Relation label.")
+    description: str = Field(default="", description="Optional relation description.")
+
+
+class RelationDelete(SerializableBaseModel):
+    """Request to delete a relation by its unique triple."""
+
+    from_entity: str = Field(..., description="Source entity name.")
+    to_entity: str = Field(..., description="Target entity name.")
+    relation_type: str = Field(..., description="Relation label.")
+
+
+# ---------------------------------------------------------------------------
+# Batch mutation model
+# ---------------------------------------------------------------------------
+
+
+class ManageGraph(SerializableBaseModel):
+    """Batch mutation request processed by ``KnowledgeGraphActor.update_graph``.
+
+    Operation order: create_entities → create_relations → update_entities
+    → delete_relations → delete_entities.
+    """
+
+    create_entities: list[EntityCreate] = Field(
+        default_factory=list, description="Entities to add."
+    )
+    update_entities: list[EntityUpdate] = Field(
+        default_factory=list, description="Partial entity updates."
+    )
+    delete_entities: list[str] = Field(
+        default_factory=list, description="Entity names to remove (cascade deletes relations)."
+    )
+    create_relations: list[RelationCreate] = Field(
+        default_factory=list, description="Relations to add."
+    )
+    delete_relations: list[RelationDelete] = Field(
+        default_factory=list, description="Relations to remove by triple."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Container & state models
+# ---------------------------------------------------------------------------
+
+
+class KnowledgeGraph(SerializableBaseModel):
+    """In-memory container for the full knowledge graph."""
+
+    entities: list[Entity] = Field(default_factory=list, description="All entities.")
+    relations: list[Relation] = Field(default_factory=list, description="All relations.")
+
+
+class KnowledgeGraphState(BaseState):
+    """Actor state wrapping a ``KnowledgeGraph`` instance.
+
+    Inherits observer pattern from ``BaseState`` for automatic
+    ``StateChangedMessage`` propagation to the orchestrator.
+    """
+
+    knowledge_graph: KnowledgeGraph = Field(default_factory=KnowledgeGraph)
+
+
+# ---------------------------------------------------------------------------
+# Query & search models (Story 1.2)
+# ---------------------------------------------------------------------------
+
+
+class GetGraphQuery(SerializableBaseModel):
+    """Parameters for subgraph retrieval via ``KnowledgeGraphActor.get_graph``.
+
+    When ``entity_names`` is empty the full graph is returned.
+    ``depth`` controls BFS expansion hops from root entities.
+    ``relation_types`` limits which edges are traversed during expansion.
+
+    Note: ``path: list[PathStep]`` is planned for Epic 3, Story 3.1 —
+    do NOT add it here.
+    """
+
+    entity_names: list[str] = Field(
+        default_factory=list,
+        description="Root entity names to start subgraph from (empty = full graph).",
+    )
+    relation_types: list[str] = Field(
+        default_factory=list,
+        description="Only traverse these relation types during BFS (empty = all).",
+    )
+    depth: int = Field(default=1, description="Max BFS hops from root entities.")
+
+
+class GraphView(SerializableBaseModel):
+    """Read-only snapshot of a (sub)graph returned by ``get_graph``.
+
+    Attributes:
+        entities: Entities in the view.
+        relations: Relations connecting entities in the view.
+    """
+
+    entities: list[Entity] = Field(default_factory=list, description="Entities in the view.")
+    relations: list[Relation] = Field(default_factory=list, description="Relations in the view.")
+
+
+class SearchQuery(SerializableBaseModel):
+    """Parameters for ``KnowledgeGraphActor.search``.
+
+    Note: ``include_neighbors``, ``include_edges``, ``find_paths`` are
+    planned for Epic 3 — do NOT add them here.
+    """
+
+    query: str = Field(..., description="Search query string.")
+    top_k: int = Field(default=10, description="Maximum number of hits to return.")
+    mode: Literal["hybrid", "vector", "keyword"] = Field(
+        default="hybrid", description="Search mode: hybrid, vector, or keyword."
+    )
+
+
+class SearchHit(SerializableBaseModel):
+    """A single search result entry.
+
+    Attributes:
+        ref_type: Whether the hit is an entity or relation.
+        ref_id: UUID string of the matched entity/relation.
+        score: Match score (1.0 for keyword binary match).
+        entity: Populated when ref_type is "entity".
+        relation: Populated when ref_type is "relation".
+    """
+
+    ref_type: Literal["entity", "relation"] = Field(
+        ..., description="Type of the referenced object."
+    )
+    ref_id: str = Field(..., description="UUID string of the matched object.")
+    score: float = Field(..., description="Match score.")
+    entity: Entity | None = Field(default=None, description="Matched entity (if ref_type=entity).")
+    relation: Relation | None = Field(
+        default=None, description="Matched relation (if ref_type=relation)."
+    )
+
+
+class SearchResult(SerializableBaseModel):
+    """Container for search results.
+
+    Note: ``neighbors``, ``connected_relations``, ``paths`` fields are
+    planned for Epic 3 — do NOT add them here.
+    """
+
+    hits: list[SearchHit] = Field(default_factory=list, description="Ranked search hits.")

--- a/src/akgentic/tool/knowledge_graph/models.py
+++ b/src/akgentic/tool/knowledge_graph/models.py
@@ -40,6 +40,10 @@ class Entity(SerializableBaseModel):
     observations: list[str] = Field(
         default_factory=list, description="Incremental observations attached to the entity."
     )
+    is_root: bool = Field(
+        default=False,
+        description="Marks entry-point/anchor entities for system prompt and roots_only queries.",
+    )
 
 
 class Relation(SerializableBaseModel):
@@ -75,6 +79,7 @@ class EntityCreate(SerializableBaseModel):
     entity_type: str = Field(..., description="Classification label.")
     description: str = Field(..., description="Free-text description.")
     observations: list[str] = Field(default_factory=list, description="Initial observations.")
+    is_root: bool = Field(default=False, description="Mark as root/entry-point entity.")
 
 
 class EntityUpdate(SerializableBaseModel):
@@ -91,6 +96,7 @@ class EntityUpdate(SerializableBaseModel):
     remove_observations: list[str] | None = Field(
         default=None, description="Observations to remove."
     )
+    is_root: bool | None = Field(default=None, description="Toggle root status.")
 
 
 class RelationCreate(SerializableBaseModel):
@@ -169,9 +175,14 @@ class KnowledgeGraphState(BaseState):
 class GetGraphQuery(SerializableBaseModel):
     """Parameters for subgraph retrieval via ``KnowledgeGraphActor.get_graph``.
 
-    When ``entity_names`` is empty the full graph is returned.
-    ``depth`` controls BFS expansion hops from root entities.
-    ``relation_types`` limits which edges are traversed during expansion.
+    When ``entity_names`` is empty and ``roots_only`` is False the full
+    graph is returned.  ``depth`` controls BFS expansion hops from root
+    entities.  ``relation_types`` limits which edges are traversed.
+
+    When ``roots_only`` is True, only entities with ``is_root=True`` are
+    used as BFS seeds (``entity_names`` is ignored).  ``depth`` defaults
+    to None which means: 0 for roots_only mode (no expansion), 1 for
+    entity_names mode (1-hop expansion).  Explicit depth always wins.
 
     Note: ``path: list[PathStep]`` is planned for Epic 3, Story 3.1 —
     do NOT add it here.
@@ -185,7 +196,15 @@ class GetGraphQuery(SerializableBaseModel):
         default_factory=list,
         description="Only traverse these relation types during BFS (empty = all).",
     )
-    depth: int = Field(default=1, description="Max BFS hops from root entities.")
+    depth: int | None = Field(
+        default=None,
+        ge=0,
+        description="Max BFS hops. None = context default (0 for roots_only, 1 for entity_names).",
+    )
+    roots_only: bool = Field(
+        default=False,
+        description="Return only is_root=True entities + inter-root relations.",
+    )
 
 
 class GraphView(SerializableBaseModel):

--- a/src/akgentic/tool/knowledge_graph/vector_index.py
+++ b/src/akgentic/tool/knowledge_graph/vector_index.py
@@ -1,0 +1,4 @@
+"""Vector index for knowledge graph embeddings.
+
+Placeholder for Epic 2 — will implement EmbeddingService and VectorIndex.
+"""

--- a/src/akgentic/tool/planning/planning.py
+++ b/src/akgentic/tool/planning/planning.py
@@ -117,7 +117,7 @@ class PlanningTool(ToolCard):
             planning = planning_proxy.get_planning()
             if not planning:
                 return "No current Team planning."
-            return "Team planning:\n" + "\n".join(
+            return "**Team planning:**\n" + "\n".join(
                 [
                     f"- ID {task.id} [{task.status}] {task.description} "
                     f"{task.output and f'\u2014 Output: {task.output} '}"
@@ -148,9 +148,7 @@ class PlanningTool(ToolCard):
         observer = self._observer
 
         def update_planning(update: UpdatePlan) -> str:
-            """Update team tasks (create, update, delete).
-
-            Keep the plan up to date: update task status when you make progress, record outputs when you complete work, and create sub-tasks when you delegate."""
+            """Update team tasks (create, update, delete)."""
             observer.notify_event(
                 ToolCallEvent(tool_name="Update planning", args=[update], kwargs={})
             )

--- a/src/akgentic/tool/team/team.py
+++ b/src/akgentic/tool/team/team.py
@@ -492,7 +492,7 @@ class TeamTool(ToolCard):
                 if not team_members_names:
                     return ""
 
-                return "Team members:\n" + "\n".join(team_members_names)
+                return "**Team members:**\n" + "\n".join(team_members_names)
             except Exception:
                 logger.error("Failed to get team roster", exc_info=True)
                 return "Cannot get team roster..."
@@ -527,12 +527,12 @@ class TeamTool(ToolCard):
                 profiles = []
                 for card in agent_catalog:
                     skills_str = ", ".join(card.skills) if card.skills else "none"
-                    profiles.append(f"**{card.role}**: {card.description} (Skills: {skills_str})")
+                    profiles.append(f"{card.role}: {card.description} (Skills: {skills_str})")
 
                 if not profiles:
                     return ""
 
-                return "Available team roles:\n" + "\n".join(profiles)
+                return "**Available team roles:**\n" + "\n".join(profiles)
             except Exception:
                 logger.error("Failed to get role profiles", exc_info=True)
                 return "Cannot get role profiles..."

--- a/tests/test_kg_actor.py
+++ b/tests/test_kg_actor.py
@@ -1,0 +1,518 @@
+"""Tests for KnowledgeGraphActor CRUD operations.
+
+Covers: all CRUD ops, cascade deletion, error collection, partial updates,
+state change notification, deduplication logic, singleton constants (Task 2.9).
+
+Pattern: Instantiate KnowledgeGraphActor() directly, call on_start(),
+test methods. Same pattern as test_planning_actor.py.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from akgentic.core.actor_address import ActorAddress
+
+from akgentic.tool.errors import RetriableError
+from akgentic.tool.knowledge_graph.kg_actor import (
+    KG_ACTOR_NAME,
+    KG_ACTOR_ROLE,
+    KnowledgeGraphActor,
+)
+from akgentic.tool.knowledge_graph.models import (
+    EntityCreate,
+    EntityUpdate,
+    GraphView,
+    ManageGraph,
+    RelationCreate,
+    RelationDelete,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+class MockActorAddress(ActorAddress):
+    """Mock ActorAddress for testing (mirrors test_planning_actor.py)."""
+
+    def __init__(self, name: str = "test-agent", role: str = "test-role") -> None:
+        self._name = name
+        self._role = role
+        self._agent_id = uuid.uuid4()
+
+    @property
+    def agent_id(self) -> uuid.UUID:
+        return self._agent_id
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def role(self) -> str:
+        return self._role
+
+    @property
+    def team_id(self) -> uuid.UUID | None:
+        return None
+
+    @property
+    def squad_id(self) -> uuid.UUID | None:
+        return None
+
+    def send(self, recipient, message):  # type: ignore[no-untyped-def]
+        pass
+
+    def is_alive(self) -> bool:
+        return True
+
+    def stop(self) -> None:
+        pass
+
+    def handle_user_message(self) -> bool:
+        return False
+
+    def serialize(self):  # type: ignore[no-untyped-def]
+        return {"name": self._name, "role": self._role, "agent_id": str(self._agent_id)}
+
+    def __repr__(self) -> str:
+        return f"MockActorAddress(name={self._name})"
+
+
+def _actor() -> KnowledgeGraphActor:
+    """Create and initialize a KnowledgeGraphActor for testing."""
+    actor = KnowledgeGraphActor()
+    actor.on_start()
+    return actor
+
+
+def _seed_entities(actor: KnowledgeGraphActor) -> None:
+    """Seed actor with two entities: Alice (Person) and Bob (Person)."""
+    actor.update_graph(
+        ManageGraph(
+            create_entities=[
+                EntityCreate(name="Alice", entity_type="Person", description="Engineer"),
+                EntityCreate(name="Bob", entity_type="Person", description="Designer"),
+            ]
+        )
+    )
+
+
+def _seed_with_relation(actor: KnowledgeGraphActor) -> None:
+    """Seed actor with two entities and a relation between them."""
+    actor.update_graph(
+        ManageGraph(
+            create_entities=[
+                EntityCreate(name="Alice", entity_type="Person", description="Engineer"),
+                EntityCreate(name="Bob", entity_type="Person", description="Designer"),
+            ],
+            create_relations=[
+                RelationCreate(from_entity="Alice", to_entity="Bob", relation_type="knows"),
+            ],
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Constants (AC-4)
+# ---------------------------------------------------------------------------
+
+
+class TestConstants:
+    def test_actor_name(self) -> None:
+        assert KG_ACTOR_NAME == "#KnowledgeGraphTool"
+
+    def test_actor_role(self) -> None:
+        assert KG_ACTOR_ROLE == "ToolActor"
+
+
+# ---------------------------------------------------------------------------
+# on_start / get_graph (Task 2.1, 2.8)
+# ---------------------------------------------------------------------------
+
+
+class TestLifecycle:
+    def test_on_start_initializes_empty_graph(self) -> None:
+        actor = _actor()
+        gv = actor.get_graph()
+        entities, relations = gv.entities, gv.relations
+        assert entities == []
+        assert relations == []
+
+    def test_get_graph_returns_graph_view(self) -> None:
+        actor = _actor()
+        result = actor.get_graph()
+        assert isinstance(result, GraphView)
+
+
+# ---------------------------------------------------------------------------
+# Create entities (AC-5, Task 2.2)
+# ---------------------------------------------------------------------------
+
+
+class TestCreateEntities:
+    def test_create_single_entity(self) -> None:
+        actor = _actor()
+        result = actor.update_graph(
+            ManageGraph(
+                create_entities=[
+                    EntityCreate(name="Alice", entity_type="Person", description="Engineer")
+                ]
+            )
+        )
+        assert result == "Done"
+        entities = actor.get_graph().entities
+        assert len(entities) == 1
+        assert entities[0].name == "Alice"
+        assert isinstance(entities[0].id, uuid.UUID)
+
+    def test_create_multiple_entities(self) -> None:
+        actor = _actor()
+        _seed_entities(actor)
+        entities = actor.get_graph().entities
+        assert len(entities) == 2
+
+    def test_duplicate_entity_name_raises_error(self) -> None:
+        actor = _actor()
+        _seed_entities(actor)
+        with pytest.raises(RetriableError, match="already exists"):
+            actor.update_graph(
+                ManageGraph(
+                    create_entities=[
+                        EntityCreate(name="Alice", entity_type="Person", description="dup")
+                    ]
+                )
+            )
+
+    def test_entity_gets_uuid(self) -> None:
+        actor = _actor()
+        actor.update_graph(
+            ManageGraph(create_entities=[EntityCreate(name="X", entity_type="T", description="d")])
+        )
+        entities = actor.get_graph().entities
+        assert isinstance(entities[0].id, uuid.UUID)
+
+
+# ---------------------------------------------------------------------------
+# Create relations (AC-5, Task 2.3)
+# ---------------------------------------------------------------------------
+
+
+class TestCreateRelations:
+    def test_create_relation_success(self) -> None:
+        actor = _actor()
+        _seed_with_relation(actor)
+        relations = actor.get_graph().relations
+        assert len(relations) == 1
+        assert relations[0].from_entity == "Alice"
+        assert relations[0].to_entity == "Bob"
+
+    def test_relation_missing_from_entity(self) -> None:
+        actor = _actor()
+        _seed_entities(actor)
+        with pytest.raises(RetriableError, match="non-existent from_entity"):
+            actor.update_graph(
+                ManageGraph(
+                    create_relations=[
+                        RelationCreate(from_entity="Nobody", to_entity="Bob", relation_type="knows")
+                    ]
+                )
+            )
+
+    def test_relation_missing_to_entity(self) -> None:
+        actor = _actor()
+        _seed_entities(actor)
+        with pytest.raises(RetriableError, match="non-existent to_entity"):
+            actor.update_graph(
+                ManageGraph(
+                    create_relations=[
+                        RelationCreate(
+                            from_entity="Alice", to_entity="Nobody", relation_type="knows"
+                        )
+                    ]
+                )
+            )
+
+    def test_duplicate_relation_silently_skipped(self) -> None:
+        actor = _actor()
+        _seed_with_relation(actor)
+        # Add same relation again — no error, just skipped
+        result = actor.update_graph(
+            ManageGraph(
+                create_relations=[
+                    RelationCreate(from_entity="Alice", to_entity="Bob", relation_type="knows"),
+                ]
+            )
+        )
+        assert result == "Done"
+        relations = actor.get_graph().relations
+        assert len(relations) == 1
+
+
+# ---------------------------------------------------------------------------
+# Update entities (AC-6, Task 2.4)
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateEntities:
+    def test_partial_update_description(self) -> None:
+        actor = _actor()
+        _seed_entities(actor)
+        actor.update_graph(
+            ManageGraph(update_entities=[EntityUpdate(name="Alice", description="Senior Engineer")])
+        )
+        entities = actor.get_graph().entities
+        alice = next(e for e in entities if e.name == "Alice")
+        assert alice.description == "Senior Engineer"
+        assert alice.entity_type == "Person"  # unchanged
+
+    def test_partial_update_entity_type(self) -> None:
+        actor = _actor()
+        _seed_entities(actor)
+        actor.update_graph(
+            ManageGraph(update_entities=[EntityUpdate(name="Alice", entity_type="Engineer")])
+        )
+        entities = actor.get_graph().entities
+        alice = next(e for e in entities if e.name == "Alice")
+        assert alice.entity_type == "Engineer"
+        assert alice.description == "Engineer"  # unchanged (original value)
+
+    def test_add_observations(self) -> None:
+        actor = _actor()
+        _seed_entities(actor)
+        actor.update_graph(
+            ManageGraph(
+                update_entities=[EntityUpdate(name="Alice", add_observations=["friendly", "smart"])]
+            )
+        )
+        entities = actor.get_graph().entities
+        alice = next(e for e in entities if e.name == "Alice")
+        assert alice.observations == ["friendly", "smart"]
+
+    def test_remove_observations(self) -> None:
+        actor = _actor()
+        actor.update_graph(
+            ManageGraph(
+                create_entities=[
+                    EntityCreate(
+                        name="Alice",
+                        entity_type="Person",
+                        description="d",
+                        observations=["a", "b", "c"],
+                    )
+                ]
+            )
+        )
+        actor.update_graph(
+            ManageGraph(update_entities=[EntityUpdate(name="Alice", remove_observations=["b"])])
+        )
+        entities = actor.get_graph().entities
+        alice = next(e for e in entities if e.name == "Alice")
+        assert alice.observations == ["a", "c"]
+
+    def test_update_entity_not_found(self) -> None:
+        actor = _actor()
+        with pytest.raises(RetriableError, match="not found for update"):
+            actor.update_graph(
+                ManageGraph(update_entities=[EntityUpdate(name="Nobody", description="x")])
+            )
+
+
+# ---------------------------------------------------------------------------
+# Delete entities with cascade (AC-7, Task 2.5)
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteEntities:
+    def test_delete_entity(self) -> None:
+        actor = _actor()
+        _seed_entities(actor)
+        actor.update_graph(ManageGraph(delete_entities=["Alice"]))
+        entities = actor.get_graph().entities
+        assert len(entities) == 1
+        assert entities[0].name == "Bob"
+
+    def test_cascade_delete_relations(self) -> None:
+        actor = _actor()
+        _seed_with_relation(actor)
+        actor.update_graph(ManageGraph(delete_entities=["Alice"]))
+        gv = actor.get_graph()
+        entities, relations = gv.entities, gv.relations
+        assert len(entities) == 1
+        assert len(relations) == 0  # relation cascade-deleted
+
+    def test_delete_entity_not_found(self) -> None:
+        actor = _actor()
+        with pytest.raises(RetriableError, match="not found for deletion"):
+            actor.update_graph(ManageGraph(delete_entities=["Nobody"]))
+
+
+# ---------------------------------------------------------------------------
+# Delete relations (Task 2.6)
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteRelations:
+    def test_delete_relation_success(self) -> None:
+        actor = _actor()
+        _seed_with_relation(actor)
+        actor.update_graph(
+            ManageGraph(
+                delete_relations=[
+                    RelationDelete(from_entity="Alice", to_entity="Bob", relation_type="knows")
+                ]
+            )
+        )
+        relations = actor.get_graph().relations
+        assert len(relations) == 0
+
+    def test_delete_relation_not_found(self) -> None:
+        actor = _actor()
+        _seed_entities(actor)
+        with pytest.raises(RetriableError, match="not found"):
+            actor.update_graph(
+                ManageGraph(
+                    delete_relations=[
+                        RelationDelete(from_entity="Alice", to_entity="Bob", relation_type="knows")
+                    ]
+                )
+            )
+
+
+# ---------------------------------------------------------------------------
+# Error collection across operations (AC-8, Task 2.7)
+# ---------------------------------------------------------------------------
+
+
+class TestErrorCollection:
+    def test_multiple_errors_collected_single_raise(self) -> None:
+        """All errors across operations collected into one RetriableError."""
+        actor = _actor()
+        with pytest.raises(RetriableError) as exc_info:
+            actor.update_graph(
+                ManageGraph(
+                    update_entities=[EntityUpdate(name="X", description="d")],
+                    delete_entities=["Y"],
+                )
+            )
+        msg = str(exc_info.value)
+        assert "X" in msg
+        assert "Y" in msg
+
+    def test_errors_from_mixed_operations(self) -> None:
+        """Mix of successful and failing operations — errors collected, successes applied."""
+        actor = _actor()
+        _seed_entities(actor)
+
+        with pytest.raises(RetriableError) as exc_info:
+            actor.update_graph(
+                ManageGraph(
+                    create_entities=[
+                        EntityCreate(name="Charlie", entity_type="T", description="d"),
+                    ],
+                    create_relations=[
+                        RelationCreate(from_entity="Ghost", to_entity="Alice", relation_type="x"),
+                    ],
+                )
+            )
+        # Charlie was created successfully before the relation error
+        entities = actor.get_graph().entities
+        names = {e.name for e in entities}
+        assert "Charlie" in names
+        assert "Ghost" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# State change notification (AC-9, Task 2.7)
+# ---------------------------------------------------------------------------
+
+
+class TestStateNotification:
+    def test_notify_called_on_update(self) -> None:
+        """state.notify_state_change() is called after mutations."""
+        actor = _actor()
+        # Attach a mock observer to track calls
+        call_count = 0
+
+        class Observer:
+            def notify_state_change(self, state: object) -> None:
+                nonlocal call_count
+                call_count += 1
+
+        actor.state.observer(Observer())  # type: ignore[arg-type]
+        # observer() itself calls notify once
+        initial_count = call_count
+
+        actor.update_graph(
+            ManageGraph(create_entities=[EntityCreate(name="A", entity_type="T", description="d")])
+        )
+        assert call_count > initial_count
+
+    def test_notify_called_even_on_error(self) -> None:
+        """notify_state_change() fires even when errors are raised."""
+        actor = _actor()
+        call_count = 0
+
+        class Observer:
+            def notify_state_change(self, state: object) -> None:
+                nonlocal call_count
+                call_count += 1
+
+        actor.state.observer(Observer())  # type: ignore[arg-type]
+        initial_count = call_count
+
+        with pytest.raises(RetriableError):
+            actor.update_graph(ManageGraph(delete_entities=["Ghost"]))
+
+        assert call_count > initial_count
+
+
+# ---------------------------------------------------------------------------
+# Operation order (Task 2.7 design decision)
+# ---------------------------------------------------------------------------
+
+
+class TestOperationOrder:
+    def test_create_before_relations(self) -> None:
+        """Entities created in same batch can be referenced by relations."""
+        actor = _actor()
+        result = actor.update_graph(
+            ManageGraph(
+                create_entities=[
+                    EntityCreate(name="A", entity_type="T", description="d"),
+                    EntityCreate(name="B", entity_type="T", description="d"),
+                ],
+                create_relations=[
+                    RelationCreate(from_entity="A", to_entity="B", relation_type="links"),
+                ],
+            )
+        )
+        assert result == "Done"
+        gv = actor.get_graph()
+        entities, relations = gv.entities, gv.relations
+        assert len(entities) == 2
+        assert len(relations) == 1
+
+    def test_delete_last(self) -> None:
+        """Deletes happen after creates/updates so cascade works on full graph."""
+        actor = _actor()
+        _seed_with_relation(actor)
+
+        # Delete Alice (cascade removes relation) in same batch as relation create
+        # The new relation should be created before the delete cascade
+        actor.update_graph(
+            ManageGraph(
+                create_relations=[
+                    RelationCreate(from_entity="Bob", to_entity="Alice", relation_type="respects"),
+                ],
+                delete_entities=["Alice"],
+            )
+        )
+        gv = actor.get_graph()
+        entities, relations = gv.entities, gv.relations
+        assert len(entities) == 1
+        assert entities[0].name == "Bob"
+        # Both relations (original + new) should be cascade-deleted
+        assert len(relations) == 0

--- a/tests/test_kg_actor.py
+++ b/tests/test_kg_actor.py
@@ -516,3 +516,92 @@ class TestOperationOrder:
         assert entities[0].name == "Bob"
         # Both relations (original + new) should be cascade-deleted
         assert len(relations) == 0
+
+
+# ---------------------------------------------------------------------------
+# is_root wiring (Story 1.4, AC-2, AC-3)
+# ---------------------------------------------------------------------------
+
+
+class TestIsRootWiring:
+    """Verify is_root flows through create and update operations."""
+
+    def test_create_entity_with_is_root_true(self) -> None:
+        actor = _actor()
+        actor.update_graph(
+            ManageGraph(
+                create_entities=[
+                    EntityCreate(
+                        name="Root", entity_type="Concept", description="entry point", is_root=True
+                    )
+                ]
+            )
+        )
+        entities = actor.get_graph().entities
+        assert len(entities) == 1
+        assert entities[0].is_root is True
+
+    def test_create_entity_without_is_root_defaults_false(self) -> None:
+        actor = _actor()
+        actor.update_graph(
+            ManageGraph(
+                create_entities=[
+                    EntityCreate(name="Leaf", entity_type="Concept", description="not root")
+                ]
+            )
+        )
+        entities = actor.get_graph().entities
+        assert entities[0].is_root is False
+
+    def test_update_entity_toggle_is_root_true(self) -> None:
+        actor = _actor()
+        _seed_entities(actor)
+        actor.update_graph(ManageGraph(update_entities=[EntityUpdate(name="Alice", is_root=True)]))
+        alice = next(e for e in actor.get_graph().entities if e.name == "Alice")
+        assert alice.is_root is True
+
+    def test_update_entity_toggle_is_root_false(self) -> None:
+        actor = _actor()
+        actor.update_graph(
+            ManageGraph(
+                create_entities=[
+                    EntityCreate(name="Root", entity_type="T", description="d", is_root=True)
+                ]
+            )
+        )
+        actor.update_graph(ManageGraph(update_entities=[EntityUpdate(name="Root", is_root=False)]))
+        root = actor.get_graph().entities[0]
+        assert root.is_root is False
+
+    def test_is_root_survives_other_partial_updates(self) -> None:
+        actor = _actor()
+        actor.update_graph(
+            ManageGraph(
+                create_entities=[
+                    EntityCreate(name="Root", entity_type="T", description="d", is_root=True)
+                ]
+            )
+        )
+        # Update description only — is_root should remain True
+        actor.update_graph(
+            ManageGraph(update_entities=[EntityUpdate(name="Root", description="updated")])
+        )
+        root = actor.get_graph().entities[0]
+        assert root.is_root is True
+        assert root.description == "updated"
+
+    def test_update_is_root_none_is_noop(self) -> None:
+        actor = _actor()
+        actor.update_graph(
+            ManageGraph(
+                create_entities=[
+                    EntityCreate(name="Root", entity_type="T", description="d", is_root=True)
+                ]
+            )
+        )
+        # is_root=None (default) means no change
+        actor.update_graph(
+            ManageGraph(update_entities=[EntityUpdate(name="Root", description="x")])
+        )
+        root = actor.get_graph().entities[0]
+        assert root.is_root is True

--- a/tests/test_kg_imports.py
+++ b/tests/test_kg_imports.py
@@ -1,0 +1,82 @@
+"""Tests for knowledge_graph package structure and dependency guard (Task 3.6).
+
+Covers:
+- Import from akgentic.tool.knowledge_graph works
+- akgentic.tool import does NOT trigger knowledge_graph import
+- Dependency guard behavior
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+
+class TestPackageImports:
+    def test_import_knowledge_graph_module(self) -> None:
+        """akgentic.tool.knowledge_graph is importable."""
+        from akgentic.tool.knowledge_graph import Entity, KnowledgeGraphActor
+
+        assert Entity is not None
+        assert KnowledgeGraphActor is not None
+
+    def test_public_api_exports(self) -> None:
+        """All public symbols listed in __all__ are importable."""
+        from akgentic.tool import knowledge_graph
+
+        expected = [
+            "Entity",
+            "Relation",
+            "KnowledgeGraph",
+            "KnowledgeGraphState",
+            "EntityCreate",
+            "EntityUpdate",
+            "RelationCreate",
+            "RelationDelete",
+            "ManageGraph",
+            "KnowledgeGraphActor",
+            "KG_ACTOR_NAME",
+            "KG_ACTOR_ROLE",
+            "_check_kg_dependencies",
+        ]
+        for name in expected:
+            assert hasattr(knowledge_graph, name), f"Missing export: {name}"
+
+    def test_tool_import_does_not_trigger_kg_import(self) -> None:
+        """Importing akgentic.tool does NOT eagerly import knowledge_graph."""
+        # Remove knowledge_graph from cache if present
+        kg_modules = [k for k in sys.modules if "knowledge_graph" in k]
+        saved = {k: sys.modules.pop(k) for k in kg_modules}
+
+        try:
+            # Re-import akgentic.tool — should NOT pull in knowledge_graph
+            if "akgentic.tool" in sys.modules:
+                # Already loaded — check that knowledge_graph wasn't loaded alongside
+                importlib.reload(sys.modules["akgentic.tool"])
+
+            # knowledge_graph submodule should NOT be in sys.modules now
+            assert "akgentic.tool.knowledge_graph" not in sys.modules
+        finally:
+            # Restore cached modules
+            sys.modules.update(saved)
+
+
+class TestDependencyGuard:
+    def test_check_kg_dependencies_succeeds_when_numpy_installed(self) -> None:
+        """_check_kg_dependencies passes when numpy is available."""
+        from akgentic.tool.knowledge_graph import _check_kg_dependencies
+
+        # numpy is installed in our test env
+        _check_kg_dependencies()  # Should not raise
+
+    def test_check_kg_dependencies_error_message(self) -> None:
+        """Verify the ImportError message mentions pip install."""
+        import unittest.mock
+
+        from akgentic.tool.knowledge_graph import _check_kg_dependencies
+
+        with unittest.mock.patch.dict(sys.modules, {"numpy": None}):
+            # When numpy import fails, _check_kg_dependencies wraps it
+            # We can't easily force import failure with module patching alone,
+            # so we test the function exists and is callable
+            assert callable(_check_kg_dependencies)

--- a/tests/test_kg_integration.py
+++ b/tests/test_kg_integration.py
@@ -174,13 +174,15 @@ class TestEndToEndUpdateGetSearch:
             )
         )
 
-        # Get via system prompt
+        # Get via system prompt — compact summary shows counts + types
         prompts = tool.get_system_prompts()
         result = prompts[0]()
-        assert "Python" in result
-        assert "FastAPI" in result
+        assert "Knowledge Graph Summary:" in result
+        assert "Entities: 2" in result
+        assert "Relations: 1" in result
         assert "BUILT_WITH" in result
         assert "Language" in result
+        assert "Framework" in result
 
     def test_update_then_search(self) -> None:
         tool, observer = self._make_tool()
@@ -300,10 +302,11 @@ class TestEndToEndUpdateGetSearch:
             )
         )
 
-        # Read
+        # Read — compact summary shows counts + types
         prompts = tool.get_system_prompts()
         prompt_result = prompts[0]()
-        assert "Go" in prompt_result
+        assert "Entities: 1" in prompt_result
+        assert "Language" in prompt_result
 
         # Search
         search_result = search_fn(SearchQuery(query="Go"))

--- a/tests/test_kg_integration.py
+++ b/tests/test_kg_integration.py
@@ -1,0 +1,317 @@
+"""Integration tests: KnowledgeGraphTool ↔ KnowledgeGraphActor end-to-end.
+
+Covers AC-5 integration: create tool, wire with mock observer,
+verify update_graph → get_graph → search round-trip through the ToolCard.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from akgentic.core.actor_address import ActorAddress
+from akgentic.core.agent import AkgentType
+from akgentic.core.orchestrator import Orchestrator
+from akgentic.tool.event import ActorToolObserver, ToolCallEvent
+from akgentic.tool.knowledge_graph.kg_actor import (
+    KG_ACTOR_NAME,
+    KG_ACTOR_ROLE,
+    KnowledgeGraphActor,
+)
+from akgentic.tool.knowledge_graph.kg_tool import (
+    GetGraph,
+    KnowledgeGraphTool,
+    SearchGraph,
+    UpdateGraph,
+)
+from akgentic.tool.knowledge_graph.models import (
+    EntityCreate,
+    ManageGraph,
+    RelationCreate,
+    SearchQuery,
+)
+from akgentic.tool.core import TOOL_CALL
+
+
+# ---------------------------------------------------------------------------
+# Shared mock infrastructure
+# ---------------------------------------------------------------------------
+
+
+class MockActorAddress(ActorAddress):
+    """Minimal ActorAddress mock for integration tests."""
+
+    def __init__(self, name: str = "test-agent", role: str = "test-role") -> None:
+        self._name = name
+        self._role = role
+        self._agent_id = uuid.uuid4()
+
+    @property
+    def agent_id(self) -> uuid.UUID:
+        return self._agent_id
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def role(self) -> str:
+        return self._role
+
+    @property
+    def team_id(self) -> uuid.UUID | None:
+        return None
+
+    @property
+    def squad_id(self) -> uuid.UUID | None:
+        return None
+
+    def send(self, recipient: Any, message: Any) -> None:
+        pass
+
+    def is_alive(self) -> bool:
+        return True
+
+    def stop(self) -> None:
+        pass
+
+    def handle_user_message(self) -> bool:
+        return False
+
+    def serialize(self) -> dict[str, Any]:
+        return {"name": self._name, "role": self._role, "agent_id": str(self._agent_id)}
+
+    def __repr__(self) -> str:
+        return f"MockActorAddress(name={self._name})"
+
+
+class IntegrationObserver:
+    """Mock observer wiring a real KnowledgeGraphActor for integration testing."""
+
+    def __init__(self) -> None:
+        self.events: list[ToolCallEvent] = []
+        self._address = MockActorAddress("test-agent")
+        self._orchestrator_addr = MockActorAddress("orchestrator")
+        self._kg_actor = KnowledgeGraphActor()
+        self._kg_actor.on_start()
+        self._kg_addr = MockActorAddress(KG_ACTOR_NAME, KG_ACTOR_ROLE)
+
+    @property
+    def myAddress(self) -> ActorAddress:  # noqa: N802
+        return self._address
+
+    @property
+    def orchestrator(self) -> ActorAddress:
+        return self._orchestrator_addr
+
+    def notify_event(self, event: object) -> None:
+        if isinstance(event, ToolCallEvent):
+            self.events.append(event)
+
+    def proxy_ask(
+        self,
+        actor: ActorAddress,
+        actor_type: type[AkgentType] | None = None,
+        timeout: int | None = None,
+    ) -> Any:
+        if actor == self._orchestrator_addr:
+            return _OrchestratorStub(self._kg_addr)
+        return self._kg_actor
+
+
+class _OrchestratorStub:
+    """Minimal orchestrator stub that returns a known KG address."""
+
+    def __init__(self, kg_addr: MockActorAddress) -> None:
+        self._kg_addr = kg_addr
+
+    def get_team_member(self, name: str) -> ActorAddress | None:
+        if name == KG_ACTOR_NAME:
+            return self._kg_addr
+        return None
+
+    def createActor(self, *args: Any, **kwargs: Any) -> ActorAddress:  # noqa: N802
+        return self._kg_addr
+
+
+# ===========================================================================
+# Integration tests
+# ===========================================================================
+
+
+class TestEndToEndUpdateGetSearch:
+    """Full round-trip: update_graph → get_graph → search via ToolCard."""
+
+    def _make_tool(self) -> tuple[KnowledgeGraphTool, IntegrationObserver]:
+        observer = IntegrationObserver()
+        tool = KnowledgeGraphTool()
+        tool.observer(observer)
+        return tool, observer
+
+    def test_update_then_get_graph_prompt(self) -> None:
+        tool, observer = self._make_tool()
+
+        # Update via tool factory
+        tools = tool.get_tools()
+        update_fn = [t for t in tools if t.__name__ == "update_graph"][0]
+        update_fn(
+            ManageGraph(
+                create_entities=[
+                    EntityCreate(
+                        name="Python", entity_type="Language", description="Programming lang"
+                    ),
+                    EntityCreate(
+                        name="FastAPI", entity_type="Framework", description="Web framework"
+                    ),
+                ],
+                create_relations=[
+                    RelationCreate(
+                        from_entity="FastAPI",
+                        to_entity="Python",
+                        relation_type="BUILT_WITH",
+                    ),
+                ],
+            )
+        )
+
+        # Get via system prompt
+        prompts = tool.get_system_prompts()
+        result = prompts[0]()
+        assert "Python" in result
+        assert "FastAPI" in result
+        assert "BUILT_WITH" in result
+        assert "Language" in result
+
+    def test_update_then_search(self) -> None:
+        tool, observer = self._make_tool()
+
+        tools = tool.get_tools()
+        update_fn = [t for t in tools if t.__name__ == "update_graph"][0]
+        search_fn = [t for t in tools if t.__name__ == "search_graph"][0]
+
+        update_fn(
+            ManageGraph(
+                create_entities=[
+                    EntityCreate(
+                        name="Django", entity_type="Framework", description="Full-stack web"
+                    ),
+                ]
+            )
+        )
+
+        result = search_fn(SearchQuery(query="Django"))
+        assert "Django" in result
+        assert "Framework" in result
+
+    def test_event_emission_across_operations(self) -> None:
+        tool, observer = self._make_tool()
+
+        tools = tool.get_tools()
+        update_fn = [t for t in tools if t.__name__ == "update_graph"][0]
+        search_fn = [t for t in tools if t.__name__ == "search_graph"][0]
+
+        update_fn(
+            ManageGraph(
+                create_entities=[
+                    EntityCreate(name="Rust", entity_type="Language", description="Systems lang"),
+                ]
+            )
+        )
+        search_fn(SearchQuery(query="Rust"))
+
+        assert len(observer.events) == 2
+        assert observer.events[0].tool_name == "Update graph"
+        assert observer.events[1].tool_name == "Search graph"
+
+    def test_read_only_blocks_update(self) -> None:
+        observer = IntegrationObserver()
+        tool = KnowledgeGraphTool(read_only=True)
+        tool.observer(observer)
+
+        tools = tool.get_tools()
+        tool_names = [t.__name__ for t in tools]
+        assert "update_graph" not in tool_names
+        assert "search_graph" in tool_names
+
+    def test_get_graph_command_returns_string(self) -> None:
+        tool, observer = self._make_tool()
+
+        # Seed data via actor directly
+        observer._kg_actor.update_graph(
+            ManageGraph(
+                create_entities=[
+                    EntityCreate(name="Node", entity_type="Runtime", description="JS runtime"),
+                ]
+            )
+        )
+
+        commands = tool.get_commands()
+        get_graph_cmd = commands[GetGraph]
+        result = get_graph_cmd()
+        assert "Node" in result
+
+    def test_search_command_returns_string(self) -> None:
+        tool, observer = self._make_tool()
+        observer._kg_actor.update_graph(
+            ManageGraph(
+                create_entities=[
+                    EntityCreate(name="TypeScript", entity_type="Language", description="Typed JS"),
+                ]
+            )
+        )
+
+        commands = tool.get_commands()
+        search_cmd = commands[SearchGraph]
+        result = search_cmd(SearchQuery(query="TypeScript"))
+        assert "TypeScript" in result
+
+    def test_get_graph_with_tool_call_channel(self) -> None:
+        """When get_graph exposes TOOL_CALL, it appears in get_tools()."""
+        observer = IntegrationObserver()
+        tool = KnowledgeGraphTool(get_graph=GetGraph(expose={TOOL_CALL}))
+        tool.observer(observer)
+
+        tools = tool.get_tools()
+        tool_names = [t.__name__ for t in tools]
+        assert "get_graph" in tool_names
+
+    def test_empty_graph_search_returns_no_results(self) -> None:
+        tool, observer = self._make_tool()
+
+        tools = tool.get_tools()
+        search_fn = [t for t in tools if t.__name__ == "search_graph"][0]
+        result = search_fn(SearchQuery(query="nonexistent"))
+        assert "No results" in result
+
+    def test_full_lifecycle_update_get_search_delete(self) -> None:
+        """Full lifecycle: create → read → search → delete → verify empty."""
+        tool, observer = self._make_tool()
+
+        tools = tool.get_tools()
+        update_fn = [t for t in tools if t.__name__ == "update_graph"][0]
+        search_fn = [t for t in tools if t.__name__ == "search_graph"][0]
+
+        # Create
+        update_fn(
+            ManageGraph(
+                create_entities=[
+                    EntityCreate(name="Go", entity_type="Language", description="Compiled lang"),
+                ]
+            )
+        )
+
+        # Read
+        prompts = tool.get_system_prompts()
+        prompt_result = prompts[0]()
+        assert "Go" in prompt_result
+
+        # Search
+        search_result = search_fn(SearchQuery(query="Go"))
+        assert "Go" in search_result
+
+        # Delete
+        update_fn(ManageGraph(delete_entities=["Go"]))
+
+        # Verify empty
+        prompt_after = prompts[0]()
+        assert "empty" in prompt_after.lower()

--- a/tests/test_kg_models.py
+++ b/tests/test_kg_models.py
@@ -80,6 +80,19 @@ class TestEntity:
         # UUID survives round-trip (as string in dump, parsed back)
         assert str(restored.id) == str(e.id)
 
+    def test_is_root_defaults_false(self) -> None:
+        e = Entity(name="Alice", entity_type="Person", description="A person")
+        assert e.is_root is False
+
+    def test_is_root_set_true(self) -> None:
+        e = Entity(name="Alice", entity_type="Person", description="A person", is_root=True)
+        assert e.is_root is True
+
+    def test_is_root_survives_serialization(self) -> None:
+        e = Entity(name="R", entity_type="T", description="d", is_root=True)
+        restored = Entity.model_validate(e.model_dump())
+        assert restored.is_root is True
+
 
 # ---------------------------------------------------------------------------
 # Relation model (AC-3, Task 1.2)
@@ -132,6 +145,14 @@ class TestEntityCreate:
         ec = EntityCreate(name="X", entity_type="Concept", description="desc", observations=["a"])
         assert ec.observations == ["a"]
 
+    def test_is_root_defaults_false(self) -> None:
+        ec = EntityCreate(name="X", entity_type="Concept", description="desc")
+        assert ec.is_root is False
+
+    def test_is_root_set_true(self) -> None:
+        ec = EntityCreate(name="X", entity_type="Concept", description="desc", is_root=True)
+        assert ec.is_root is True
+
 
 class TestEntityUpdate:
     def test_all_optional_fields_default_none(self) -> None:
@@ -140,11 +161,24 @@ class TestEntityUpdate:
         assert eu.entity_type is None
         assert eu.add_observations is None
         assert eu.remove_observations is None
+        assert eu.is_root is None
 
     def test_partial_fields(self) -> None:
         eu = EntityUpdate(name="X", description="new desc")
         assert eu.description == "new desc"
         assert eu.entity_type is None
+
+    def test_is_root_none_is_noop(self) -> None:
+        eu = EntityUpdate(name="X")
+        assert eu.is_root is None
+
+    def test_is_root_set_true(self) -> None:
+        eu = EntityUpdate(name="X", is_root=True)
+        assert eu.is_root is True
+
+    def test_is_root_set_false(self) -> None:
+        eu = EntityUpdate(name="X", is_root=False)
+        assert eu.is_root is False
 
 
 class TestRelationCreate:

--- a/tests/test_kg_models.py
+++ b/tests/test_kg_models.py
@@ -1,0 +1,232 @@
+"""Tests for Knowledge Graph data models.
+
+Covers: UUID auto-generation, defaults, Pydantic validation,
+serialization round-trip for all models (Task 1.7).
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from akgentic.tool.knowledge_graph.models import (
+    Entity,
+    EntityCreate,
+    EntityUpdate,
+    KnowledgeGraph,
+    KnowledgeGraphState,
+    ManageGraph,
+    Relation,
+    RelationCreate,
+    RelationDelete,
+)
+
+# ---------------------------------------------------------------------------
+# Entity model (AC-2, Task 1.1)
+# ---------------------------------------------------------------------------
+
+
+class TestEntity:
+    """Tests for Entity model."""
+
+    def test_auto_generated_uuid(self) -> None:
+        """Entity.id is a UUID auto-generated on creation."""
+        e = Entity(name="Alice", entity_type="Person", description="A person")
+        assert isinstance(e.id, uuid.UUID)
+
+    def test_two_entities_have_different_uuids(self) -> None:
+        e1 = Entity(name="Alice", entity_type="Person", description="A person")
+        e2 = Entity(name="Bob", entity_type="Person", description="Another person")
+        assert e1.id != e2.id
+
+    def test_observations_default_empty(self) -> None:
+        e = Entity(name="Alice", entity_type="Person", description="A person")
+        assert e.observations == []
+
+    def test_observations_set_explicitly(self) -> None:
+        e = Entity(
+            name="Alice",
+            entity_type="Person",
+            description="A person",
+            observations=["friendly", "tall"],
+        )
+        assert e.observations == ["friendly", "tall"]
+
+    def test_required_fields_enforced(self) -> None:
+        with pytest.raises(Exception):  # noqa: B017
+            Entity()  # type: ignore[call-arg]
+
+    def test_all_fields_type_checked(self) -> None:
+        e = Entity(name="Alice", entity_type="Person", description="A person")
+        assert isinstance(e.name, str)
+        assert isinstance(e.entity_type, str)
+        assert isinstance(e.description, str)
+        assert isinstance(e.observations, list)
+
+    def test_serialization_round_trip(self) -> None:
+        e = Entity(
+            name="Alice",
+            entity_type="Person",
+            description="A person",
+            observations=["friendly"],
+        )
+        data = e.model_dump()
+        restored = Entity.model_validate(data)
+        assert restored.name == e.name
+        assert restored.entity_type == e.entity_type
+        assert restored.description == e.description
+        assert restored.observations == e.observations
+        # UUID survives round-trip (as string in dump, parsed back)
+        assert str(restored.id) == str(e.id)
+
+
+# ---------------------------------------------------------------------------
+# Relation model (AC-3, Task 1.2)
+# ---------------------------------------------------------------------------
+
+
+class TestRelation:
+    """Tests for Relation model."""
+
+    def test_auto_generated_uuid(self) -> None:
+        r = Relation(from_entity="A", to_entity="B", relation_type="knows")
+        assert isinstance(r.id, uuid.UUID)
+
+    def test_description_defaults_empty(self) -> None:
+        r = Relation(from_entity="A", to_entity="B", relation_type="knows")
+        assert r.description == ""
+
+    def test_description_set_explicitly(self) -> None:
+        r = Relation(
+            from_entity="A", to_entity="B", relation_type="knows", description="since 2020"
+        )
+        assert r.description == "since 2020"
+
+    def test_required_fields_enforced(self) -> None:
+        with pytest.raises(Exception):  # noqa: B017
+            Relation()  # type: ignore[call-arg]
+
+    def test_serialization_round_trip(self) -> None:
+        r = Relation(from_entity="A", to_entity="B", relation_type="knows", description="well")
+        data = r.model_dump()
+        restored = Relation.model_validate(data)
+        assert restored.from_entity == r.from_entity
+        assert restored.to_entity == r.to_entity
+        assert restored.relation_type == r.relation_type
+        assert restored.description == r.description
+        assert str(restored.id) == str(r.id)
+
+
+# ---------------------------------------------------------------------------
+# CRUD request models (Task 1.3)
+# ---------------------------------------------------------------------------
+
+
+class TestEntityCreate:
+    def test_defaults(self) -> None:
+        ec = EntityCreate(name="X", entity_type="Concept", description="desc")
+        assert ec.observations == []
+
+    def test_with_observations(self) -> None:
+        ec = EntityCreate(name="X", entity_type="Concept", description="desc", observations=["a"])
+        assert ec.observations == ["a"]
+
+
+class TestEntityUpdate:
+    def test_all_optional_fields_default_none(self) -> None:
+        eu = EntityUpdate(name="X")
+        assert eu.description is None
+        assert eu.entity_type is None
+        assert eu.add_observations is None
+        assert eu.remove_observations is None
+
+    def test_partial_fields(self) -> None:
+        eu = EntityUpdate(name="X", description="new desc")
+        assert eu.description == "new desc"
+        assert eu.entity_type is None
+
+
+class TestRelationCreate:
+    def test_defaults(self) -> None:
+        rc = RelationCreate(from_entity="A", to_entity="B", relation_type="knows")
+        assert rc.description == ""
+
+    def test_with_description(self) -> None:
+        rc = RelationCreate(
+            from_entity="A", to_entity="B", relation_type="knows", description="well"
+        )
+        assert rc.description == "well"
+
+
+class TestRelationDelete:
+    def test_fields(self) -> None:
+        rd = RelationDelete(from_entity="A", to_entity="B", relation_type="knows")
+        assert rd.from_entity == "A"
+        assert rd.to_entity == "B"
+        assert rd.relation_type == "knows"
+
+
+# ---------------------------------------------------------------------------
+# ManageGraph batch model (Task 1.4)
+# ---------------------------------------------------------------------------
+
+
+class TestManageGraph:
+    def test_all_defaults_empty(self) -> None:
+        mg = ManageGraph()
+        assert mg.create_entities == []
+        assert mg.update_entities == []
+        assert mg.delete_entities == []
+        assert mg.create_relations == []
+        assert mg.delete_relations == []
+
+    def test_with_data(self) -> None:
+        mg = ManageGraph(
+            create_entities=[EntityCreate(name="A", entity_type="T", description="d")],
+            delete_entities=["B"],
+        )
+        assert len(mg.create_entities) == 1
+        assert mg.delete_entities == ["B"]
+
+
+# ---------------------------------------------------------------------------
+# KnowledgeGraph container (Task 1.5)
+# ---------------------------------------------------------------------------
+
+
+class TestKnowledgeGraph:
+    def test_defaults_empty(self) -> None:
+        kg = KnowledgeGraph()
+        assert kg.entities == []
+        assert kg.relations == []
+
+    def test_with_data(self) -> None:
+        e = Entity(name="A", entity_type="T", description="d")
+        r = Relation(from_entity="A", to_entity="B", relation_type="knows")
+        kg = KnowledgeGraph(entities=[e], relations=[r])
+        assert len(kg.entities) == 1
+        assert len(kg.relations) == 1
+
+
+# ---------------------------------------------------------------------------
+# KnowledgeGraphState (Task 1.6)
+# ---------------------------------------------------------------------------
+
+
+class TestKnowledgeGraphState:
+    def test_default_knowledge_graph(self) -> None:
+        state = KnowledgeGraphState()
+        assert isinstance(state.knowledge_graph, KnowledgeGraph)
+        assert state.knowledge_graph.entities == []
+
+    def test_inherits_base_state(self) -> None:
+        from akgentic.core.agent_state import BaseState
+
+        state = KnowledgeGraphState()
+        assert isinstance(state, BaseState)
+
+    def test_notify_state_change_without_observer(self) -> None:
+        """notify_state_change should be a no-op without observer."""
+        state = KnowledgeGraphState()
+        state.notify_state_change()  # Should not raise

--- a/tests/test_kg_query.py
+++ b/tests/test_kg_query.py
@@ -136,7 +136,8 @@ class TestGetGraphQuery:
         q = GetGraphQuery()
         assert q.entity_names == []
         assert q.relation_types == []
-        assert q.depth == 1
+        assert q.depth is None
+        assert q.roots_only is False
 
     def test_explicit_values(self) -> None:
         q = GetGraphQuery(entity_names=["A"], relation_types=["R"], depth=3)
@@ -524,3 +525,179 @@ class TestSearchModeRouting:
         result = actor.search(SearchQuery(query="test", mode="vector"))
         assert isinstance(result, SearchResult)
         assert result.hits == []
+
+
+# ===========================================================================
+# Task 4 — roots_only query tests (Story 1.4, subtask 3.4)
+# ===========================================================================
+
+
+def _seed_graph_with_roots(actor: KnowledgeGraphActor) -> None:
+    """Populate a test graph with root entities for roots_only tests.
+
+    Root entities: Product, AuthService
+    Non-root: Library, Algorithm, Team
+    Relations:
+        Product --DEPENDS_ON--> Library
+        Product --CONNECTS_TO--> AuthService  (inter-root)
+        Library --USES--> Algorithm
+        AuthService --MAINTAINED_BY--> Team
+    """
+    actor.update_graph(
+        ManageGraph(
+            create_entities=[
+                EntityCreate(
+                    name="Product",
+                    entity_type="Software",
+                    description="Main product",
+                    is_root=True,
+                ),
+                EntityCreate(
+                    name="AuthService",
+                    entity_type="Service",
+                    description="Authentication service",
+                    is_root=True,
+                ),
+                EntityCreate(
+                    name="Library",
+                    entity_type="Software",
+                    description="Math utility library",
+                ),
+                EntityCreate(
+                    name="Algorithm",
+                    entity_type="Concept",
+                    description="FFT algorithm",
+                ),
+                EntityCreate(
+                    name="Team",
+                    entity_type="Organization",
+                    description="Engineering team",
+                ),
+            ],
+            create_relations=[
+                RelationCreate(
+                    from_entity="Product",
+                    to_entity="Library",
+                    relation_type="DEPENDS_ON",
+                ),
+                RelationCreate(
+                    from_entity="Product",
+                    to_entity="AuthService",
+                    relation_type="CONNECTS_TO",
+                ),
+                RelationCreate(
+                    from_entity="Library",
+                    to_entity="Algorithm",
+                    relation_type="USES",
+                ),
+                RelationCreate(
+                    from_entity="AuthService",
+                    to_entity="Team",
+                    relation_type="MAINTAINED_BY",
+                ),
+            ],
+        )
+    )
+
+
+class TestRootsOnly:
+    """Story 1.4, AC-4: roots_only=True returns root entities + inter-root relations."""
+
+    def test_roots_only_returns_root_entities(self) -> None:
+        actor = _actor()
+        _seed_graph_with_roots(actor)
+        result = actor.get_graph(GetGraphQuery(roots_only=True))
+        entity_names = {e.name for e in result.entities}
+        assert entity_names == {"Product", "AuthService"}
+
+    def test_roots_only_returns_inter_root_relations(self) -> None:
+        actor = _actor()
+        _seed_graph_with_roots(actor)
+        result = actor.get_graph(GetGraphQuery(roots_only=True))
+        # Only Product→AuthService (inter-root) should be included
+        assert len(result.relations) == 1
+        assert result.relations[0].from_entity == "Product"
+        assert result.relations[0].to_entity == "AuthService"
+
+    def test_roots_only_depth_1_expands_neighbors(self) -> None:
+        """AC-5: roots_only + depth=1 expands from roots to direct neighbors."""
+        actor = _actor()
+        _seed_graph_with_roots(actor)
+        result = actor.get_graph(GetGraphQuery(roots_only=True, depth=1))
+        entity_names = {e.name for e in result.entities}
+        # Product→Library, Product→AuthService, AuthService→Team
+        assert "Product" in entity_names
+        assert "AuthService" in entity_names
+        assert "Library" in entity_names
+        assert "Team" in entity_names
+        # Algorithm is 2 hops from roots
+        assert "Algorithm" not in entity_names
+
+    def test_roots_only_ignores_entity_names(self) -> None:
+        """AC-6: entity_names ignored when roots_only=True."""
+        actor = _actor()
+        _seed_graph_with_roots(actor)
+        result = actor.get_graph(
+            GetGraphQuery(roots_only=True, entity_names=["Library"])
+        )
+        entity_names = {e.name for e in result.entities}
+        # Should return root entities, not Library
+        assert "Product" in entity_names
+        assert "AuthService" in entity_names
+        # Library is NOT returned because entity_names is ignored
+        assert "Library" not in entity_names
+
+    def test_roots_only_empty_graph(self) -> None:
+        actor = _actor()
+        result = actor.get_graph(GetGraphQuery(roots_only=True))
+        assert result.entities == []
+        assert result.relations == []
+
+    def test_roots_only_no_root_entities(self) -> None:
+        """Graph with entities but none marked is_root → empty result."""
+        actor = _actor()
+        _seed_graph(actor)  # Uses original seed without is_root
+        result = actor.get_graph(GetGraphQuery(roots_only=True))
+        assert result.entities == []
+        assert result.relations == []
+
+    def test_roots_only_with_relation_types_filter(self) -> None:
+        """roots_only + relation_types limits BFS edge traversal."""
+        actor = _actor()
+        _seed_graph_with_roots(actor)
+        result = actor.get_graph(
+            GetGraphQuery(roots_only=True, depth=1, relation_types=["DEPENDS_ON"])
+        )
+        entity_names = {e.name for e in result.entities}
+        # Only DEPENDS_ON edges traversed: Product→Library
+        assert "Product" in entity_names
+        assert "AuthService" in entity_names  # Root entity itself
+        assert "Library" in entity_names
+        # Team not reached (MAINTAINED_BY not in filter)
+        assert "Team" not in entity_names
+
+    def test_roots_only_explicit_depth_0(self) -> None:
+        """AC-4: roots_only + explicit depth=0 returns only roots + inter-root relations."""
+        actor = _actor()
+        _seed_graph_with_roots(actor)
+        result = actor.get_graph(GetGraphQuery(roots_only=True, depth=0))
+        entity_names = {e.name for e in result.entities}
+        assert entity_names == {"Product", "AuthService"}
+        # Only inter-root relation
+        assert len(result.relations) == 1
+        assert result.relations[0].relation_type == "CONNECTS_TO"
+
+    def test_roots_only_depth_2_full_expansion(self) -> None:
+        """roots_only + depth=2 reaches 2-hop neighbors from roots."""
+        actor = _actor()
+        _seed_graph_with_roots(actor)
+        result = actor.get_graph(GetGraphQuery(roots_only=True, depth=2))
+        entity_names = {e.name for e in result.entities}
+        # All entities reachable within 2 hops from roots
+        assert entity_names == {"Product", "AuthService", "Library", "Algorithm", "Team"}
+
+    def test_negative_depth_rejected(self) -> None:
+        """L-1: Negative depth values are rejected by validation."""
+        import pytest
+        with pytest.raises(Exception):  # noqa: B017
+            GetGraphQuery(depth=-1)

--- a/tests/test_kg_query.py
+++ b/tests/test_kg_query.py
@@ -1,0 +1,526 @@
+"""Tests for Knowledge Graph query and search models and operations.
+
+Covers Story 1.2: GetGraphQuery, GraphView, SearchQuery, SearchHit,
+SearchResult models; get_graph() subgraph retrieval; keyword search.
+
+Pattern: Instantiate KnowledgeGraphActor() directly, call on_start(),
+populate graph via update_graph(), then test get_graph() and search().
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from akgentic.tool.knowledge_graph.kg_actor import KnowledgeGraphActor
+from akgentic.tool.knowledge_graph.models import (
+    Entity,
+    EntityCreate,
+    GetGraphQuery,
+    GraphView,
+    ManageGraph,
+    Relation,
+    RelationCreate,
+    SearchHit,
+    SearchQuery,
+    SearchResult,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _actor() -> KnowledgeGraphActor:
+    """Create and initialize a KnowledgeGraphActor for testing."""
+    actor = KnowledgeGraphActor()
+    actor.on_start()
+    return actor
+
+
+def _seed_graph(actor: KnowledgeGraphActor) -> None:
+    """Populate a test graph with ~5 entities and ~6 relations of varied types.
+
+    Graph topology:
+        Product --DEPENDS_ON--> Library
+        Product --DEPENDS_ON--> Framework
+        Library --USES--> Algorithm
+        Framework --USES--> Algorithm
+        Algorithm --DESCRIBED_IN--> Paper
+        Product --MAINTAINED_BY--> Team
+    """
+    actor.update_graph(
+        ManageGraph(
+            create_entities=[
+                EntityCreate(
+                    name="Product",
+                    entity_type="Software",
+                    description="Signal processing toolkit",
+                ),
+                EntityCreate(
+                    name="Library",
+                    entity_type="Software",
+                    description="Math utility library",
+                ),
+                EntityCreate(
+                    name="Framework",
+                    entity_type="Software",
+                    description="Web framework for APIs",
+                ),
+                EntityCreate(
+                    name="Algorithm",
+                    entity_type="Concept",
+                    description="FFT signal processing algorithm",
+                ),
+                EntityCreate(
+                    name="Paper",
+                    entity_type="Document",
+                    description="Research paper on signal processing",
+                ),
+                EntityCreate(
+                    name="Team",
+                    entity_type="Organization",
+                    description="Core engineering team",
+                ),
+            ],
+            create_relations=[
+                RelationCreate(
+                    from_entity="Product",
+                    to_entity="Library",
+                    relation_type="DEPENDS_ON",
+                    description="runtime dependency",
+                ),
+                RelationCreate(
+                    from_entity="Product",
+                    to_entity="Framework",
+                    relation_type="DEPENDS_ON",
+                    description="API layer dependency",
+                ),
+                RelationCreate(
+                    from_entity="Library",
+                    to_entity="Algorithm",
+                    relation_type="USES",
+                    description="implements algorithm",
+                ),
+                RelationCreate(
+                    from_entity="Framework",
+                    to_entity="Algorithm",
+                    relation_type="USES",
+                    description="uses for processing",
+                ),
+                RelationCreate(
+                    from_entity="Algorithm",
+                    to_entity="Paper",
+                    relation_type="DESCRIBED_IN",
+                    description="original publication",
+                ),
+                RelationCreate(
+                    from_entity="Product",
+                    to_entity="Team",
+                    relation_type="MAINTAINED_BY",
+                    description="owned by team",
+                ),
+            ],
+        )
+    )
+
+
+# ===========================================================================
+# Task 1 — Model tests (subtasks 1.1–1.6)
+# ===========================================================================
+
+
+class TestGetGraphQuery:
+    """Subtask 1.1: GetGraphQuery model."""
+
+    def test_defaults(self) -> None:
+        q = GetGraphQuery()
+        assert q.entity_names == []
+        assert q.relation_types == []
+        assert q.depth == 1
+
+    def test_explicit_values(self) -> None:
+        q = GetGraphQuery(entity_names=["A"], relation_types=["R"], depth=3)
+        assert q.entity_names == ["A"]
+        assert q.relation_types == ["R"]
+        assert q.depth == 3
+
+    def test_serialization_round_trip(self) -> None:
+        q = GetGraphQuery(entity_names=["X"], depth=2)
+        restored = GetGraphQuery.model_validate(q.model_dump())
+        assert restored.entity_names == q.entity_names
+        assert restored.depth == q.depth
+
+
+class TestGraphView:
+    """Subtask 1.2: GraphView model."""
+
+    def test_defaults_empty(self) -> None:
+        gv = GraphView()
+        assert gv.entities == []
+        assert gv.relations == []
+
+    def test_with_data(self) -> None:
+        e = Entity(name="A", entity_type="T", description="d")
+        r = Relation(from_entity="A", to_entity="B", relation_type="R")
+        gv = GraphView(entities=[e], relations=[r])
+        assert len(gv.entities) == 1
+        assert len(gv.relations) == 1
+
+    def test_serialization_round_trip(self) -> None:
+        e = Entity(name="A", entity_type="T", description="d")
+        gv = GraphView(entities=[e])
+        restored = GraphView.model_validate(gv.model_dump())
+        assert restored.entities[0].name == "A"
+
+
+class TestSearchQuery:
+    """Subtask 1.3: SearchQuery model."""
+
+    def test_defaults(self) -> None:
+        sq = SearchQuery(query="test")
+        assert sq.query == "test"
+        assert sq.top_k == 10
+        assert sq.mode == "hybrid"
+
+    def test_keyword_mode(self) -> None:
+        sq = SearchQuery(query="test", mode="keyword")
+        assert sq.mode == "keyword"
+
+    def test_vector_mode(self) -> None:
+        sq = SearchQuery(query="test", mode="vector")
+        assert sq.mode == "vector"
+
+    def test_invalid_mode_rejected(self) -> None:
+        with pytest.raises(Exception):  # noqa: B017
+            SearchQuery(query="test", mode="invalid")  # type: ignore[arg-type]
+
+    def test_query_required(self) -> None:
+        with pytest.raises(Exception):  # noqa: B017
+            SearchQuery()  # type: ignore[call-arg]
+
+    def test_serialization_round_trip(self) -> None:
+        sq = SearchQuery(query="hello", top_k=5, mode="keyword")
+        restored = SearchQuery.model_validate(sq.model_dump())
+        assert restored.query == "hello"
+        assert restored.top_k == 5
+        assert restored.mode == "keyword"
+
+
+class TestSearchHit:
+    """Subtask 1.4: SearchHit model."""
+
+    def test_entity_hit(self) -> None:
+        e = Entity(name="A", entity_type="T", description="d")
+        hit = SearchHit(ref_type="entity", ref_id=str(e.id), score=1.0, entity=e)
+        assert hit.ref_type == "entity"
+        assert hit.entity is not None
+        assert hit.relation is None
+
+    def test_relation_hit(self) -> None:
+        r = Relation(from_entity="A", to_entity="B", relation_type="R")
+        hit = SearchHit(ref_type="relation", ref_id=str(r.id), score=0.5, relation=r)
+        assert hit.ref_type == "relation"
+        assert hit.relation is not None
+        assert hit.entity is None
+
+    def test_defaults_none(self) -> None:
+        hit = SearchHit(ref_type="entity", ref_id="abc", score=1.0)
+        assert hit.entity is None
+        assert hit.relation is None
+
+    def test_invalid_ref_type_rejected(self) -> None:
+        with pytest.raises(Exception):  # noqa: B017
+            SearchHit(ref_type="unknown", ref_id="x", score=1.0)  # type: ignore[arg-type]
+
+    def test_serialization_round_trip(self) -> None:
+        hit = SearchHit(ref_type="entity", ref_id="123", score=0.9)
+        restored = SearchHit.model_validate(hit.model_dump())
+        assert restored.ref_type == "entity"
+        assert restored.score == 0.9
+
+
+class TestSearchResult:
+    """Subtask 1.5: SearchResult model."""
+
+    def test_defaults_empty(self) -> None:
+        sr = SearchResult()
+        assert sr.hits == []
+
+    def test_with_hits(self) -> None:
+        hit = SearchHit(ref_type="entity", ref_id="x", score=1.0)
+        sr = SearchResult(hits=[hit])
+        assert len(sr.hits) == 1
+
+    def test_serialization_round_trip(self) -> None:
+        hit = SearchHit(ref_type="entity", ref_id="x", score=1.0)
+        sr = SearchResult(hits=[hit])
+        restored = SearchResult.model_validate(sr.model_dump())
+        assert len(restored.hits) == 1
+        assert restored.hits[0].ref_id == "x"
+
+
+# ===========================================================================
+# Task 2 — get_graph() subgraph tests (subtasks 2.1–2.6)
+# ===========================================================================
+
+
+class TestGetGraphFullGraph:
+    """Subtask 2.1: Full graph return when entity_names is empty."""
+
+    def test_empty_query_returns_full_graph(self) -> None:
+        actor = _actor()
+        _seed_graph(actor)
+        result = actor.get_graph(GetGraphQuery())
+        assert isinstance(result, GraphView)
+        assert len(result.entities) == 6
+        assert len(result.relations) == 6
+
+    def test_empty_graph_returns_empty_view(self) -> None:
+        actor = _actor()
+        result = actor.get_graph(GetGraphQuery())
+        assert result.entities == []
+        assert result.relations == []
+
+
+class TestGetGraphSubgraph:
+    """Subtasks 2.2–2.4: BFS subgraph filtering."""
+
+    def test_single_entity_depth_1(self) -> None:
+        """Product at depth=1 reaches Library, Framework, Team (direct neighbors)."""
+        actor = _actor()
+        _seed_graph(actor)
+        result = actor.get_graph(GetGraphQuery(entity_names=["Product"], depth=1))
+        entity_names = {e.name for e in result.entities}
+        assert "Product" in entity_names
+        assert "Library" in entity_names
+        assert "Framework" in entity_names
+        assert "Team" in entity_names
+        # Algorithm is 2 hops away via DEPENDS_ON→USES, should NOT be here
+        assert "Algorithm" not in entity_names
+
+    def test_multi_hop_depth_2(self) -> None:
+        """Product at depth=2 reaches Algorithm (2 hops) but not Paper (3 hops)."""
+        actor = _actor()
+        _seed_graph(actor)
+        result = actor.get_graph(GetGraphQuery(entity_names=["Product"], depth=2))
+        entity_names = {e.name for e in result.entities}
+        assert "Product" in entity_names
+        assert "Algorithm" in entity_names
+        # Paper is 3 hops away (Product→Library→Algorithm→Paper)
+        assert "Paper" not in entity_names
+
+    def test_depth_3_reaches_paper(self) -> None:
+        """Product at depth=3 reaches Paper (3 hops)."""
+        actor = _actor()
+        _seed_graph(actor)
+        result = actor.get_graph(GetGraphQuery(entity_names=["Product"], depth=3))
+        entity_names = {e.name for e in result.entities}
+        assert "Paper" in entity_names
+        assert len(entity_names) == 6  # All entities reachable
+
+    def test_relation_types_filtering(self) -> None:
+        """Only DEPENDS_ON edges traversed: Product→Library, Product→Framework."""
+        actor = _actor()
+        _seed_graph(actor)
+        result = actor.get_graph(
+            GetGraphQuery(
+                entity_names=["Product"],
+                relation_types=["DEPENDS_ON"],
+                depth=3,
+            )
+        )
+        entity_names = {e.name for e in result.entities}
+        assert "Product" in entity_names
+        assert "Library" in entity_names
+        assert "Framework" in entity_names
+        # USES and other edge types are NOT traversed
+        assert "Algorithm" not in entity_names
+        assert "Paper" not in entity_names
+
+    def test_depth_plus_relation_types_combined(self) -> None:
+        """DEPENDS_ON at depth=1: Product + Library + Framework only."""
+        actor = _actor()
+        _seed_graph(actor)
+        result = actor.get_graph(
+            GetGraphQuery(
+                entity_names=["Product"],
+                relation_types=["DEPENDS_ON"],
+                depth=1,
+            )
+        )
+        entity_names = {e.name for e in result.entities}
+        assert entity_names == {"Product", "Library", "Framework"}
+
+    def test_entity_not_found_returns_empty(self) -> None:
+        """Requesting a non-existent entity returns empty GraphView."""
+        actor = _actor()
+        _seed_graph(actor)
+        result = actor.get_graph(GetGraphQuery(entity_names=["NonExistent"]))
+        assert result.entities == []
+        assert result.relations == []
+
+    def test_relations_only_between_visited_entities(self) -> None:
+        """Returned relations connect only entities within the discovered set."""
+        actor = _actor()
+        _seed_graph(actor)
+        result = actor.get_graph(GetGraphQuery(entity_names=["Product"], depth=1))
+        entity_names = {e.name for e in result.entities}
+        for rel in result.relations:
+            assert rel.from_entity in entity_names
+            assert rel.to_entity in entity_names
+
+    def test_multiple_root_entities(self) -> None:
+        """Starting from Algorithm and Team at depth=0 returns just those two."""
+        actor = _actor()
+        _seed_graph(actor)
+        result = actor.get_graph(
+            GetGraphQuery(entity_names=["Algorithm", "Team"], depth=0)
+        )
+        entity_names = {e.name for e in result.entities}
+        assert entity_names == {"Algorithm", "Team"}
+
+    def test_depth_0_returns_only_root(self) -> None:
+        """Depth=0 returns only the root entity, no expansion."""
+        actor = _actor()
+        _seed_graph(actor)
+        result = actor.get_graph(
+            GetGraphQuery(entity_names=["Product"], depth=0)
+        )
+        entity_names = {e.name for e in result.entities}
+        assert entity_names == {"Product"}
+
+
+class TestGetGraphBackwardCompat:
+    """Subtask 2.5: Backward compatibility — default GetGraphQuery returns full graph."""
+
+    def test_default_query_matches_full_graph(self) -> None:
+        actor = _actor()
+        _seed_graph(actor)
+        result = actor.get_graph(GetGraphQuery())
+        assert len(result.entities) == 6
+        assert len(result.relations) == 6
+
+
+# ===========================================================================
+# Task 3 — search() keyword tests (subtasks 3.1–3.4)
+# ===========================================================================
+
+
+class TestKeywordSearchEntity:
+    """Subtask 3.1: Keyword search matching entity fields."""
+
+    def test_match_entity_name(self) -> None:
+        actor = _actor()
+        _seed_graph(actor)
+        result = actor.search(SearchQuery(query="Product", mode="keyword"))
+        entity_hits = [h for h in result.hits if h.ref_type == "entity"]
+        assert any(h.entity and h.entity.name == "Product" for h in entity_hits)
+
+    def test_match_entity_description(self) -> None:
+        actor = _actor()
+        _seed_graph(actor)
+        result = actor.search(SearchQuery(query="signal processing", mode="keyword"))
+        entity_hits = [h for h in result.hits if h.ref_type == "entity"]
+        matched_names = {h.entity.name for h in entity_hits if h.entity}
+        assert "Product" in matched_names  # "Signal processing toolkit"
+        assert "Algorithm" in matched_names  # "FFT signal processing algorithm"
+
+    def test_match_entity_type(self) -> None:
+        actor = _actor()
+        _seed_graph(actor)
+        result = actor.search(SearchQuery(query="Software", mode="keyword"))
+        entity_hits = [h for h in result.hits if h.ref_type == "entity"]
+        matched_names = {h.entity.name for h in entity_hits if h.entity}
+        assert "Product" in matched_names
+        assert "Library" in matched_names
+        assert "Framework" in matched_names
+
+
+class TestKeywordSearchRelation:
+    """Subtask 3.1 continued: Keyword search matching relation fields."""
+
+    def test_match_relation_type(self) -> None:
+        actor = _actor()
+        _seed_graph(actor)
+        result = actor.search(SearchQuery(query="DEPENDS_ON", mode="keyword"))
+        rel_hits = [h for h in result.hits if h.ref_type == "relation"]
+        assert len(rel_hits) == 2  # Product→Library, Product→Framework
+
+    def test_match_relation_description(self) -> None:
+        actor = _actor()
+        _seed_graph(actor)
+        result = actor.search(SearchQuery(query="runtime dependency", mode="keyword"))
+        rel_hits = [h for h in result.hits if h.ref_type == "relation"]
+        assert len(rel_hits) >= 1
+
+    def test_match_relation_from_entity(self) -> None:
+        actor = _actor()
+        _seed_graph(actor)
+        result = actor.search(SearchQuery(query="Product", mode="keyword"))
+        rel_hits = [h for h in result.hits if h.ref_type == "relation"]
+        # Product appears as from_entity in several relations
+        assert len(rel_hits) >= 1
+
+
+class TestKeywordSearchBehavior:
+    """Subtasks 3.1–3.4: Case insensitivity, empty results, top_k, mode routing."""
+
+    def test_case_insensitive(self) -> None:
+        actor = _actor()
+        _seed_graph(actor)
+        result_lower = actor.search(SearchQuery(query="product", mode="keyword"))
+        result_upper = actor.search(SearchQuery(query="PRODUCT", mode="keyword"))
+        result_mixed = actor.search(SearchQuery(query="Product", mode="keyword"))
+        assert len(result_lower.hits) == len(result_upper.hits) == len(result_mixed.hits)
+        assert len(result_lower.hits) > 0
+
+    def test_no_match_returns_empty(self) -> None:
+        actor = _actor()
+        _seed_graph(actor)
+        result = actor.search(SearchQuery(query="zzz_nonexistent_zzz", mode="keyword"))
+        assert result.hits == []
+
+    def test_top_k_limit_applied(self) -> None:
+        actor = _actor()
+        _seed_graph(actor)
+        result = actor.search(SearchQuery(query="Product", mode="keyword", top_k=2))
+        assert len(result.hits) <= 2
+
+    def test_search_empty_graph_returns_empty(self) -> None:
+        actor = _actor()
+        result = actor.search(SearchQuery(query="anything", mode="keyword"))
+        assert result.hits == []
+
+    def test_hit_score_is_1(self) -> None:
+        """Keyword matches produce binary score=1.0."""
+        actor = _actor()
+        _seed_graph(actor)
+        result = actor.search(SearchQuery(query="Product", mode="keyword"))
+        for hit in result.hits:
+            assert hit.score == 1.0
+
+
+class TestSearchModeRouting:
+    """Subtask 3.2: Mode routing — vector returns empty, hybrid falls back to keyword."""
+
+    def test_vector_mode_returns_empty(self) -> None:
+        actor = _actor()
+        _seed_graph(actor)
+        result = actor.search(SearchQuery(query="Product", mode="vector"))
+        assert result.hits == []
+
+    def test_hybrid_mode_falls_back_to_keyword(self) -> None:
+        actor = _actor()
+        _seed_graph(actor)
+        result_hybrid = actor.search(SearchQuery(query="Product", mode="hybrid"))
+        result_keyword = actor.search(SearchQuery(query="Product", mode="keyword"))
+        # hybrid == keyword-only for now
+        assert len(result_hybrid.hits) == len(result_keyword.hits)
+        assert len(result_hybrid.hits) > 0
+
+    def test_vector_mode_no_external_calls(self) -> None:
+        """AC-5/AC-6: vector mode returns empty without any external API calls."""
+        actor = _actor()
+        result = actor.search(SearchQuery(query="test", mode="vector"))
+        assert isinstance(result, SearchResult)
+        assert result.hits == []

--- a/tests/test_kg_tool.py
+++ b/tests/test_kg_tool.py
@@ -1,0 +1,538 @@
+"""Tests for KnowledgeGraphTool ToolCard.
+
+Covers:
+- BaseToolParam subclass defaults and channel exposure (Task 1)
+- KnowledgeGraphTool config, read_only, get_graph=False (Task 2)
+- Observer wiring, singleton actor proxy (Task 2)
+- Factory closures: get_graph, update_graph, search (Task 2)
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from akgentic.core.actor_address import ActorAddress
+from akgentic.core.agent import AkgentType
+from akgentic.core.orchestrator import Orchestrator
+
+from akgentic.tool.core import COMMAND, SYSTEM_PROMPT, TOOL_CALL, BaseToolParam, _resolve
+from akgentic.tool.event import ToolCallEvent
+from akgentic.tool.knowledge_graph.kg_actor import (
+    KG_ACTOR_NAME,
+    KG_ACTOR_ROLE,
+    KnowledgeGraphActor,
+)
+from akgentic.tool.knowledge_graph.kg_tool import (
+    GetGraph,
+    KnowledgeGraphTool,
+    SearchGraph,
+    UpdateGraph,
+)
+from akgentic.tool.knowledge_graph.models import (
+    EntityCreate,
+    ManageGraph,
+    RelationCreate,
+    SearchQuery,
+)
+
+# ---------------------------------------------------------------------------
+# Mock helpers
+# ---------------------------------------------------------------------------
+
+
+class MockActorAddress(ActorAddress):
+    """Mock ActorAddress for ToolCard tests."""
+
+    def __init__(self, name: str = "test-agent", role: str = "test-role") -> None:
+        self._name = name
+        self._role = role
+        self._agent_id = uuid.uuid4()
+
+    @property
+    def agent_id(self) -> uuid.UUID:
+        return self._agent_id
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def role(self) -> str:
+        return self._role
+
+    @property
+    def team_id(self) -> uuid.UUID | None:
+        return None
+
+    @property
+    def squad_id(self) -> uuid.UUID | None:
+        return None
+
+    def send(self, recipient: Any, message: Any) -> None:
+        pass
+
+    def is_alive(self) -> bool:
+        return True
+
+    def stop(self) -> None:
+        pass
+
+    def handle_user_message(self) -> bool:
+        return False
+
+    def serialize(self) -> dict[str, Any]:
+        return {"name": self._name, "role": self._role, "agent_id": str(self._agent_id)}
+
+    def __repr__(self) -> str:
+        return f"MockActorAddress(name={self._name})"
+
+
+class MockActorToolObserver:
+    """Mock implementing ActorToolObserver protocol for ToolCard tests."""
+
+    def __init__(self) -> None:
+        self.events: list[ToolCallEvent] = []
+        self._address = MockActorAddress("test-agent")
+        self._orchestrator = MockActorAddress("orchestrator")
+        self._kg_actor: KnowledgeGraphActor | None = None
+        self._orchestrator_proxy = MagicMock(spec=Orchestrator)
+
+    @property
+    def myAddress(self) -> ActorAddress:  # noqa: N802
+        return self._address
+
+    @property
+    def orchestrator(self) -> ActorAddress:
+        return self._orchestrator
+
+    def notify_event(self, event: object) -> None:
+        if isinstance(event, ToolCallEvent):
+            self.events.append(event)
+
+    def proxy_ask(
+        self,
+        actor: ActorAddress,
+        actor_type: type[AkgentType] | None = None,
+        timeout: int | None = None,
+    ) -> Any:
+        if actor == self._orchestrator:
+            return self._orchestrator_proxy
+        # Return the real KG actor for KG actor address
+        if self._kg_actor is not None:
+            return self._kg_actor
+        return MagicMock()
+
+    def setup_kg_actor(self) -> KnowledgeGraphActor:
+        """Create a real KG actor and wire it for proxy_ask."""
+        actor = KnowledgeGraphActor()
+        actor.on_start()
+        self._kg_actor = actor
+        kg_addr = MockActorAddress(KG_ACTOR_NAME, KG_ACTOR_ROLE)
+        self._orchestrator_proxy.get_team_member.return_value = kg_addr
+        return actor
+
+
+# ===========================================================================
+# Task 1: BaseToolParam subclasses — channel exposure defaults
+# ===========================================================================
+
+
+class TestGetGraphParam:
+    """GetGraph exposes on SYSTEM_PROMPT + COMMAND by default."""
+
+    def test_default_channels(self) -> None:
+        param = GetGraph()
+        assert param.expose == {SYSTEM_PROMPT, COMMAND}
+
+    def test_is_base_tool_param(self) -> None:
+        assert issubclass(GetGraph, BaseToolParam)
+
+
+class TestUpdateGraphParam:
+    """UpdateGraph exposes on TOOL_CALL by default."""
+
+    def test_default_channels(self) -> None:
+        param = UpdateGraph()
+        assert param.expose == {TOOL_CALL}
+
+    def test_is_base_tool_param(self) -> None:
+        assert issubclass(UpdateGraph, BaseToolParam)
+
+
+class TestSearchGraphParam:
+    """SearchGraph exposes on TOOL_CALL + COMMAND by default."""
+
+    def test_default_channels(self) -> None:
+        param = SearchGraph()
+        assert param.expose == {TOOL_CALL, COMMAND}
+
+    def test_is_base_tool_param(self) -> None:
+        assert issubclass(SearchGraph, BaseToolParam)
+
+
+class TestParamResolve:
+    """_resolve() works with KG param types."""
+
+    def test_resolve_true_returns_default_instance(self) -> None:
+        result = _resolve(True, GetGraph)
+        assert isinstance(result, GetGraph)
+        assert result.expose == {SYSTEM_PROMPT, COMMAND}
+
+    def test_resolve_false_returns_none(self) -> None:
+        result = _resolve(False, GetGraph)
+        assert result is None
+
+    def test_resolve_instance_returns_same(self) -> None:
+        custom = GetGraph(expose={COMMAND})
+        result = _resolve(custom, GetGraph)
+        assert result is custom
+        assert result is not None
+        assert result.expose == {COMMAND}
+
+
+# ===========================================================================
+# Task 2: KnowledgeGraphTool — default config, observer, factories
+# ===========================================================================
+
+
+class TestKnowledgeGraphToolDefaults:
+    """KnowledgeGraphTool field defaults (2.1)."""
+
+    def test_default_name(self) -> None:
+        tool = KnowledgeGraphTool()
+        assert tool.name == "KnowledgeGraph"
+
+    def test_default_description(self) -> None:
+        tool = KnowledgeGraphTool()
+        assert "knowledge graph" in tool.description.lower()
+
+    def test_default_get_graph_is_true(self) -> None:
+        tool = KnowledgeGraphTool()
+        assert tool.get_graph is True
+
+    def test_default_update_graph_is_true(self) -> None:
+        tool = KnowledgeGraphTool()
+        assert tool.update_graph is True
+
+    def test_default_search_is_true(self) -> None:
+        tool = KnowledgeGraphTool()
+        assert tool.search is True
+
+    def test_default_read_only_is_false(self) -> None:
+        tool = KnowledgeGraphTool()
+        assert tool.read_only is False
+
+    def test_default_embedding_model(self) -> None:
+        tool = KnowledgeGraphTool()
+        assert tool.embedding_model == "text-embedding-3-small"
+
+    def test_default_embedding_provider(self) -> None:
+        tool = KnowledgeGraphTool()
+        assert tool.embedding_provider == "openai"
+
+
+class TestKnowledgeGraphToolObserver:
+    """observer() wiring — singleton actor creation (2.2)."""
+
+    def test_observer_requires_orchestrator(self) -> None:
+        tool = KnowledgeGraphTool()
+        observer = MockActorToolObserver()
+        observer._orchestrator = None  # type: ignore[assignment]
+        with pytest.raises(ValueError, match="orchestrator"):
+            tool.observer(observer)
+
+    def test_observer_creates_actor_when_none(self) -> None:
+        tool = KnowledgeGraphTool()
+        observer = MockActorToolObserver()
+        # get_team_member returns None → must createActor
+        observer._orchestrator_proxy.get_team_member.return_value = None
+        kg_addr = MockActorAddress(KG_ACTOR_NAME, KG_ACTOR_ROLE)
+        observer._orchestrator_proxy.createActor.return_value = kg_addr
+
+        tool.observer(observer)
+
+        observer._orchestrator_proxy.get_team_member.assert_called_once_with(KG_ACTOR_NAME)
+        observer._orchestrator_proxy.createActor.assert_called_once()
+
+    def test_observer_reuses_existing_actor(self) -> None:
+        tool = KnowledgeGraphTool()
+        observer = MockActorToolObserver()
+        existing_addr = MockActorAddress(KG_ACTOR_NAME, KG_ACTOR_ROLE)
+        observer._orchestrator_proxy.get_team_member.return_value = existing_addr
+
+        tool.observer(observer)
+
+        observer._orchestrator_proxy.get_team_member.assert_called_once_with(KG_ACTOR_NAME)
+        observer._orchestrator_proxy.createActor.assert_not_called()
+
+
+class TestKnowledgeGraphToolReadOnly:
+    """read_only=True disables update_graph (2.9)."""
+
+    def test_read_only_disables_update_in_get_tools(self) -> None:
+        tool = KnowledgeGraphTool(read_only=True)
+        observer = MockActorToolObserver()
+        observer.setup_kg_actor()
+        tool.observer(observer)
+
+        tools = tool.get_tools()
+        tool_names = [t.__name__ for t in tools]
+        assert "update_graph" not in tool_names
+
+    def test_read_only_still_exposes_search(self) -> None:
+        tool = KnowledgeGraphTool(read_only=True)
+        observer = MockActorToolObserver()
+        observer.setup_kg_actor()
+        tool.observer(observer)
+
+        tools = tool.get_tools()
+        tool_names = [t.__name__ for t in tools]
+        assert "search_graph" in tool_names
+
+
+class TestKnowledgeGraphToolGetGraphFalse:
+    """get_graph=False removes all get_graph exposure (2.10)."""
+
+    def test_get_graph_false_no_system_prompts(self) -> None:
+        tool = KnowledgeGraphTool(get_graph=False)
+        observer = MockActorToolObserver()
+        observer.setup_kg_actor()
+        tool.observer(observer)
+
+        prompts = tool.get_system_prompts()
+        assert len(prompts) == 0
+
+    def test_get_graph_false_no_commands_for_get_graph(self) -> None:
+        tool = KnowledgeGraphTool(get_graph=False)
+        observer = MockActorToolObserver()
+        observer.setup_kg_actor()
+        tool.observer(observer)
+
+        commands = tool.get_commands()
+        assert GetGraph not in commands
+
+
+class TestGetSystemPrompts:
+    """get_system_prompts() returns graph prompt callable (2.3)."""
+
+    def test_returns_prompt_when_get_graph_enabled(self) -> None:
+        tool = KnowledgeGraphTool()
+        observer = MockActorToolObserver()
+        observer.setup_kg_actor()
+        tool.observer(observer)
+
+        prompts = tool.get_system_prompts()
+        assert len(prompts) == 1
+        assert callable(prompts[0])
+
+    def test_prompt_returns_empty_graph_message(self) -> None:
+        tool = KnowledgeGraphTool()
+        observer = MockActorToolObserver()
+        observer.setup_kg_actor()
+        tool.observer(observer)
+
+        prompts = tool.get_system_prompts()
+        result = prompts[0]()
+        assert "empty" in result.lower()
+
+    def test_prompt_contains_entities(self) -> None:
+        tool = KnowledgeGraphTool()
+        observer = MockActorToolObserver()
+        actor = observer.setup_kg_actor()
+        # Seed data
+        actor.update_graph(
+            ManageGraph(
+                create_entities=[
+                    EntityCreate(name="Alice", entity_type="Person", description="Engineer"),
+                ]
+            )
+        )
+        tool.observer(observer)
+
+        prompts = tool.get_system_prompts()
+        result = prompts[0]()
+        assert "Alice" in result
+        assert "Person" in result
+        assert "Engineer" in result
+
+
+class TestGetTools:
+    """get_tools() returns correct factories based on channel config (2.4)."""
+
+    def test_default_config_returns_update_and_search(self) -> None:
+        tool = KnowledgeGraphTool()
+        observer = MockActorToolObserver()
+        observer.setup_kg_actor()
+        tool.observer(observer)
+
+        tools = tool.get_tools()
+        tool_names = [t.__name__ for t in tools]
+        # update_graph has TOOL_CALL, search has TOOL_CALL
+        assert "update_graph" in tool_names
+        assert "search_graph" in tool_names
+
+    def test_default_config_no_get_graph_in_tools(self) -> None:
+        """get_graph defaults to SYSTEM_PROMPT + COMMAND, NOT TOOL_CALL."""
+        tool = KnowledgeGraphTool()
+        observer = MockActorToolObserver()
+        observer.setup_kg_actor()
+        tool.observer(observer)
+
+        tools = tool.get_tools()
+        tool_names = [t.__name__ for t in tools]
+        assert "get_graph" not in tool_names
+
+    def test_get_graph_with_tool_call_channel(self) -> None:
+        """When get_graph includes TOOL_CALL, it appears in get_tools()."""
+        tool = KnowledgeGraphTool(get_graph=GetGraph(expose={TOOL_CALL, COMMAND}))
+        observer = MockActorToolObserver()
+        observer.setup_kg_actor()
+        tool.observer(observer)
+
+        tools = tool.get_tools()
+        tool_names = [t.__name__ for t in tools]
+        assert "get_graph" in tool_names
+
+
+class TestGetCommands:
+    """get_commands() returns correct command mappings (2.5)."""
+
+    def test_default_config_has_get_graph_and_search_commands(self) -> None:
+        tool = KnowledgeGraphTool()
+        observer = MockActorToolObserver()
+        observer.setup_kg_actor()
+        tool.observer(observer)
+
+        commands = tool.get_commands()
+        assert GetGraph in commands
+        assert SearchGraph in commands
+
+    def test_no_update_graph_command_by_default(self) -> None:
+        """update_graph defaults to TOOL_CALL only, not COMMAND."""
+        tool = KnowledgeGraphTool()
+        observer = MockActorToolObserver()
+        observer.setup_kg_actor()
+        tool.observer(observer)
+
+        commands = tool.get_commands()
+        assert UpdateGraph not in commands
+
+
+class TestGetGraphFactory:
+    """_get_graph_factory closure behavior (2.6)."""
+
+    def test_get_graph_returns_formatted_string(self) -> None:
+        tool = KnowledgeGraphTool(get_graph=GetGraph(expose={TOOL_CALL}))
+        observer = MockActorToolObserver()
+        actor = observer.setup_kg_actor()
+        actor.update_graph(
+            ManageGraph(
+                create_entities=[
+                    EntityCreate(name="Alice", entity_type="Person", description="Engineer"),
+                    EntityCreate(name="Bob", entity_type="Person", description="Designer"),
+                ],
+                create_relations=[
+                    RelationCreate(from_entity="Alice", to_entity="Bob", relation_type="KNOWS"),
+                ],
+            )
+        )
+        tool.observer(observer)
+
+        tools = tool.get_tools()
+        get_graph_fn = [t for t in tools if t.__name__ == "get_graph"][0]
+        result = get_graph_fn()
+        assert "Alice" in result
+        assert "Bob" in result
+        assert "KNOWS" in result
+
+    def test_get_graph_emits_tool_call_event(self) -> None:
+        tool = KnowledgeGraphTool(get_graph=GetGraph(expose={TOOL_CALL}))
+        observer = MockActorToolObserver()
+        observer.setup_kg_actor()
+        tool.observer(observer)
+
+        tools = tool.get_tools()
+        get_graph_fn = [t for t in tools if t.__name__ == "get_graph"][0]
+        get_graph_fn()
+
+        assert len(observer.events) == 1
+        assert observer.events[0].tool_name == "Get graph"
+
+
+class TestUpdateGraphFactory:
+    """_update_graph_factory closure behavior (2.7)."""
+
+    def test_update_graph_calls_actor(self) -> None:
+        tool = KnowledgeGraphTool()
+        observer = MockActorToolObserver()
+        actor = observer.setup_kg_actor()
+        tool.observer(observer)
+
+        tools = tool.get_tools()
+        update_fn = [t for t in tools if t.__name__ == "update_graph"][0]
+        result = update_fn(
+            ManageGraph(
+                create_entities=[
+                    EntityCreate(name="Alice", entity_type="Person", description="Engineer"),
+                ]
+            )
+        )
+        assert result == "Done"
+        assert len(actor.state.knowledge_graph.entities) == 1
+
+    def test_update_graph_emits_tool_call_event(self) -> None:
+        tool = KnowledgeGraphTool()
+        observer = MockActorToolObserver()
+        observer.setup_kg_actor()
+        tool.observer(observer)
+
+        tools = tool.get_tools()
+        update_fn = [t for t in tools if t.__name__ == "update_graph"][0]
+        update_fn(
+            ManageGraph(
+                create_entities=[
+                    EntityCreate(name="X", entity_type="T", description="D"),
+                ]
+            )
+        )
+
+        assert len(observer.events) == 1
+        assert observer.events[0].tool_name == "Update graph"
+
+
+class TestSearchFactory:
+    """_search_factory closure behavior (2.8)."""
+
+    def test_search_returns_formatted_string(self) -> None:
+        tool = KnowledgeGraphTool()
+        observer = MockActorToolObserver()
+        actor = observer.setup_kg_actor()
+        actor.update_graph(
+            ManageGraph(
+                create_entities=[
+                    EntityCreate(name="Alice", entity_type="Person", description="Engineer"),
+                ]
+            )
+        )
+        tool.observer(observer)
+
+        tools = tool.get_tools()
+        search_fn = [t for t in tools if t.__name__ == "search_graph"][0]
+        result = search_fn(SearchQuery(query="Alice"))
+        assert "Alice" in result
+
+    def test_search_emits_tool_call_event(self) -> None:
+        tool = KnowledgeGraphTool()
+        observer = MockActorToolObserver()
+        observer.setup_kg_actor()
+        tool.observer(observer)
+
+        tools = tool.get_tools()
+        search_fn = [t for t in tools if t.__name__ == "search_graph"][0]
+        search_fn(SearchQuery(query="nonexistent"))
+
+        assert len(observer.events) == 1
+        assert observer.events[0].tool_name == "Search graph"

--- a/tests/test_kg_tool.py
+++ b/tests/test_kg_tool.py
@@ -33,6 +33,7 @@ from akgentic.tool.knowledge_graph.kg_tool import (
 )
 from akgentic.tool.knowledge_graph.models import (
     EntityCreate,
+    GraphView,
     ManageGraph,
     RelationCreate,
     SearchQuery,
@@ -336,17 +337,21 @@ class TestGetSystemPrompts:
 
         prompts = tool.get_system_prompts()
         result = prompts[0]()
-        assert "empty" in result.lower()
+        assert result == "Knowledge graph is empty."
 
-    def test_prompt_contains_entities(self) -> None:
+    def test_prompt_contains_compact_summary(self) -> None:
         tool = KnowledgeGraphTool()
         observer = MockActorToolObserver()
         actor = observer.setup_kg_actor()
-        # Seed data
         actor.update_graph(
             ManageGraph(
                 create_entities=[
-                    EntityCreate(name="Alice", entity_type="Person", description="Engineer"),
+                    EntityCreate(
+                        name="Alice",
+                        entity_type="Person",
+                        description="Engineer",
+                        is_root=True,
+                    ),
                 ]
             )
         )
@@ -354,9 +359,12 @@ class TestGetSystemPrompts:
 
         prompts = tool.get_system_prompts()
         result = prompts[0]()
-        assert "Alice" in result
-        assert "Person" in result
-        assert "Engineer" in result
+        assert "Knowledge Graph Summary:" in result
+        assert "Entities: 1" in result
+        assert "Entity types: Person" in result
+        assert "Root entities:" in result
+        assert "Alice (Person): Engineer" in result
+        assert "Use the get_graph tool" in result
 
 
 class TestGetTools:
@@ -536,3 +544,183 @@ class TestSearchFactory:
 
         assert len(observer.events) == 1
         assert observer.events[0].tool_name == "Search graph"
+
+
+# ===========================================================================
+# Story 1.4 — _format_graph_summary and prompt config tests
+# ===========================================================================
+
+
+def _build_summary_view() -> GraphView:
+    """Build a GraphView with varied types and root entities for summary tests."""
+    from akgentic.tool.knowledge_graph.models import Entity, Relation
+
+    entities = [
+        Entity(
+            name="Product", entity_type="Component", description="Main product platform",
+            is_root=True,
+        ),
+        Entity(
+            name="AuthService", entity_type="Service",
+            description="Central authentication service", is_root=True,
+        ),
+        Entity(
+            name="UserDB", entity_type="Database",
+            description="Primary user data store", is_root=True,
+        ),
+        Entity(name="Cache", entity_type="Component", description="Redis cache layer"),
+        Entity(name="Logger", entity_type="Service", description="Logging service"),
+    ]
+    relations = [
+        Relation(
+            from_entity="Product", to_entity="AuthService", relation_type="DEPENDS_ON",
+        ),
+        Relation(
+            from_entity="AuthService", to_entity="UserDB", relation_type="STORES_IN",
+        ),
+        Relation(
+            from_entity="Product", to_entity="Cache", relation_type="CONNECTS_TO",
+        ),
+    ]
+    return GraphView(entities=entities, relations=relations)
+
+
+class TestFormatGraphSummary:
+    """Story 1.4 Task 4.2: _format_graph_summary static method."""
+
+    def test_both_schema_and_roots_enabled(self) -> None:
+        view = _build_summary_view()
+        result = KnowledgeGraphTool._format_graph_summary(view)
+        assert "Knowledge Graph Summary:" in result
+        assert "Entities: 5 | Relations: 3" in result
+        assert "Entity types:" in result
+        assert "Component" in result
+        assert "Service" in result
+        assert "Database" in result
+        assert "Relation types:" in result
+        assert "DEPENDS_ON" in result
+        assert "Root entities:" in result
+        assert "Product (Component): Main product platform" in result
+        assert "AuthService (Service): Central authentication service" in result
+        assert "UserDB (Database): Primary user data store" in result
+        assert "Use the get_graph tool" in result
+
+    def test_schema_disabled(self) -> None:
+        view = _build_summary_view()
+        result = KnowledgeGraphTool._format_graph_summary(
+            view, include_schema=False
+        )
+        assert "Entity types:" not in result
+        assert "Relation types:" not in result
+        # Counts and roots still present
+        assert "Entities: 5" in result
+        assert "Root entities:" in result
+
+    def test_roots_disabled(self) -> None:
+        view = _build_summary_view()
+        result = KnowledgeGraphTool._format_graph_summary(
+            view, include_roots=False
+        )
+        assert "Root entities:" not in result
+        assert "Product (Component)" not in result
+        # Counts and schema still present
+        assert "Entities: 5" in result
+        assert "Entity types:" in result
+
+    def test_both_disabled_counts_and_footer_only(self) -> None:
+        view = _build_summary_view()
+        result = KnowledgeGraphTool._format_graph_summary(
+            view, include_schema=False, include_roots=False
+        )
+        assert "Entities: 5 | Relations: 3" in result
+        assert "Entity types:" not in result
+        assert "Root entities:" not in result
+        assert "Use the get_graph tool" in result
+
+    def test_empty_graph(self) -> None:
+        result = KnowledgeGraphTool._format_graph_summary(GraphView())
+        assert result == "Knowledge graph is empty."
+
+    def test_scales_by_types_not_entities(self) -> None:
+        """AC-12: Summary length depends on distinct types + roots, not total count."""
+        from akgentic.tool.knowledge_graph.models import Entity, Relation
+
+        # Build graph with many entities but few types
+        entities = [
+            Entity(
+                name=f"E{i}", entity_type="TypeA" if i % 2 == 0 else "TypeB",
+                description=f"Entity {i}",
+            )
+            for i in range(50)
+        ]
+        entities[0].is_root = True
+        relations = [
+            Relation(
+                from_entity=f"E{i}", to_entity=f"E{i+1}", relation_type="REL",
+            )
+            for i in range(49)
+        ]
+        view = GraphView(entities=entities, relations=relations)
+        result = KnowledgeGraphTool._format_graph_summary(view)
+        # Summary should have lines for: header, counts, 2 entity types,
+        # 1 relation type, root header + 1 root, blank, footer = ~8 lines
+        lines = result.strip().split("\n")
+        assert len(lines) < 15  # NOT 50+ lines
+
+    def test_format_graph_view_still_returns_full_details(self) -> None:
+        """Task 4.4: _format_graph_view unchanged — still returns full entity/relation details."""
+        view = _build_summary_view()
+        result = KnowledgeGraphTool._format_graph_view(view)
+        assert "Knowledge Graph:" in result
+        assert "Entities:" in result
+        assert "Relations:" in result
+        # Full details — every entity listed
+        assert "Product" in result
+        assert "Cache" in result
+        assert "Logger" in result
+
+
+class TestSystemPromptConfig:
+    """Story 1.4 Task 4.3/4.5: prompt config passed through to summary."""
+
+    def test_prompt_schema_disabled(self) -> None:
+        tool = KnowledgeGraphTool(
+            get_graph=GetGraph(prompt_include_schema=False)
+        )
+        observer = MockActorToolObserver()
+        actor = observer.setup_kg_actor()
+        actor.update_graph(
+            ManageGraph(
+                create_entities=[
+                    EntityCreate(
+                        name="X", entity_type="T", description="d", is_root=True
+                    ),
+                ]
+            )
+        )
+        tool.observer(observer)
+
+        result = tool.get_system_prompts()[0]()
+        assert "Entity types:" not in result
+        assert "Entities: 1" in result
+
+    def test_prompt_roots_disabled(self) -> None:
+        tool = KnowledgeGraphTool(
+            get_graph=GetGraph(prompt_include_roots=False)
+        )
+        observer = MockActorToolObserver()
+        actor = observer.setup_kg_actor()
+        actor.update_graph(
+            ManageGraph(
+                create_entities=[
+                    EntityCreate(
+                        name="X", entity_type="T", description="d", is_root=True
+                    ),
+                ]
+            )
+        )
+        tool.observer(observer)
+
+        result = tool.get_system_prompts()[0]()
+        assert "Root entities:" not in result
+        assert "Entity types:" in result

--- a/tests/test_team_tool.py
+++ b/tests/test_team_tool.py
@@ -345,8 +345,8 @@ def test_role_profiles_prompt():
     result = profiles_prompt()
 
     assert "Available team roles:" in result
-    assert "**Developer**: Writes code (Skills: python, testing)" in result
-    assert "**Tester**: Tests code (Skills: selenium, pytest)" in result
+    assert "Developer: Writes code (Skills: python, testing)" in result
+    assert "Tester: Tests code (Skills: selenium, pytest)" in result
 
 
 def test_role_profiles_prompt_empty():


### PR DESCRIPTION
## Summary

- Add `akgentic/tool/knowledge_graph/` module with:
  - `KGActor` — Pykka actor managing the in-memory knowledge graph
  - `KGTool` — pydantic-ai tool wrapper for agent-accessible KG operations
  - `models.py` — Entity, Relation, and graph model definitions
  - `vector_index.py` — Vector similarity index stub
- Add `roots_only` query and compact system prompt (Story 1.4)
- Refactor: DRY graph formatting, improve KG dependency guard
- Full test suite: unit + integration tests for actor, tool, models, and queries

## Related PRs

| Package | PR | Description |
|---------|----|-------------|
| akgentic-agent | https://github.com/b12consulting/akgentic-agent/pull/1 | docs: package README + collaboration docs |
| akgentic-quick-start | https://github.com/b12consulting/akgentic-quick-start/pull/25 | chore: submodule sync |

## Merge order

1. Merge `akgentic-agent` #1 first
2. Merge this PR second
3. Merge `akgentic-quick-start` #25 last