### PR TITLE
feat: implement vector search and hybrid search modes (Story 2.2)

### DIFF
--- a/src/akgentic/tool/knowledge_graph/kg_actor.py
+++ b/src/akgentic/tool/knowledge_graph/kg_actor.py
@@ -516,16 +516,18 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
         return GraphView(entities=result_entities, relations=result_relations)
 
     # ------------------------------------------------------------------
-    # Keyword search
+    # Search (keyword / vector / hybrid)
     # ------------------------------------------------------------------
 
     def search(self, query: SearchQuery) -> SearchResult:
         """Search the knowledge graph by keyword, vector, or hybrid mode.
 
         ``mode="keyword"``: case-insensitive substring matching across
-        entity and relation fields.  ``mode="vector"``: placeholder
-        returning empty results (Epic 2).  ``mode="hybrid"``: keyword
-        only for now (vector component added in Epic 2).
+        entity and relation fields.  ``mode="vector"``: embeds the query
+        and returns top-k results by cosine similarity; returns empty when
+        no embeddings exist or the embedding service is unavailable.
+        ``mode="hybrid"``: merges keyword and vector results with weighted
+        scoring; falls back to keyword-only when embeddings are unavailable.
 
         Args:
             query: Search parameters.
@@ -534,9 +536,109 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
             SearchResult with ranked hits.
         """
         if query.mode == "vector":
-            return SearchResult(hits=[])
-        # hybrid and keyword both use keyword-only search for now
+            return self._vector_search(query.query, query.top_k)
+        if query.mode == "hybrid":
+            return self._hybrid_search(query.query, query.top_k)
         return self._keyword_search(query.query, query.top_k)
+
+    def _resolve_ref(self, ref_id: str) -> Entity | Relation | None:
+        """Resolve a ``ref_id`` UUID string to the corresponding Entity or Relation.
+
+        Scans entities first, then relations.  Returns ``None`` when the
+        ref_id is not found (stale index entry).
+
+        Args:
+            ref_id: UUID string from a ``VectorEntry``.
+
+        Returns:
+            The matching ``Entity`` or ``Relation``, or ``None``.
+        """
+        for entity in self.state.knowledge_graph.entities:
+            if str(entity.id) == ref_id:
+                return entity
+        for relation in self.state.knowledge_graph.relations:
+            if str(relation.id) == ref_id:
+                return relation
+        return None
+
+    def _vector_search(self, query_text: str, top_k: int) -> SearchResult:
+        """Embed ``query_text`` and return top-k results by cosine similarity.
+
+        Returns an empty ``SearchResult`` when the embedding service is
+        unavailable, the index is empty, or the embedding call fails.
+
+        Args:
+            query_text: The natural-language query to embed and search.
+            top_k: Maximum number of results to return.
+
+        Returns:
+            ``SearchResult`` with hits ranked by cosine similarity score.
+        """
+        svc = self._get_or_create_embedding_svc()
+        if svc is None or not self._vector_index._entries:  # noqa: SLF001
+            return SearchResult(hits=[])
+        try:
+            vectors = svc.embed([query_text])
+            query_vector = vectors[0]
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[%s] Vector search embedding failed: %s", self.config.name, exc)
+            return SearchResult(hits=[])
+
+        pairs = self._vector_index.search_cosine(query_vector, top_k)
+        hits: list[SearchHit] = []
+        for ref_id, score in pairs:
+            obj = self._resolve_ref(ref_id)
+            if obj is None:
+                continue
+            if isinstance(obj, Entity):
+                hits.append(SearchHit(ref_type="entity", ref_id=ref_id, score=score, entity=obj))
+            else:
+                hits.append(
+                    SearchHit(ref_type="relation", ref_id=ref_id, score=score, relation=obj)
+                )
+        return SearchResult(hits=hits)
+
+    def _hybrid_search(self, query_text: str, top_k: int) -> SearchResult:
+        """Merge keyword and vector search results with weighted scoring.
+
+        Scoring rules:
+        - Keyword-only hit: ``score = 1.0``
+        - Vector-only hit: ``score = cosine_similarity``
+        - Hit in both: ``score = cosine_similarity + 0.5`` (keyword boost)
+
+        Falls back to keyword-only when the vector search returns no hits
+        (embedding service unavailable or index empty — AC-4).
+
+        Args:
+            query_text: The query string.
+            top_k: Maximum number of results to return.
+
+        Returns:
+            ``SearchResult`` with merged hits ranked by combined score.
+        """
+        keyword_result = self._keyword_search(query_text, top_k * 2)
+        vector_result = self._vector_search(query_text, top_k * 2)
+
+        if not vector_result.hits:
+            # Graceful fallback: no embeddings → keyword only (AC-4)
+            return SearchResult(hits=keyword_result.hits[:top_k])
+
+        merged: dict[str, SearchHit] = {}
+
+        for hit in vector_result.hits:
+            merged[hit.ref_id] = hit  # start with vector score
+
+        for kw_hit in keyword_result.hits:
+            if kw_hit.ref_id in merged:
+                existing = merged[kw_hit.ref_id]
+                merged[kw_hit.ref_id] = existing.model_copy(
+                    update={"score": existing.score + 0.5}
+                )
+            else:
+                merged[kw_hit.ref_id] = kw_hit  # keyword-only hit (score = 1.0)
+
+        ranked = sorted(merged.values(), key=lambda h: h.score, reverse=True)
+        return SearchResult(hits=ranked[:top_k])
 
     def _keyword_search(self, query: str, top_k: int) -> SearchResult:
         """Case-insensitive substring search across entity and relation fields."""

--- a/src/akgentic/tool/knowledge_graph/kg_actor.py
+++ b/src/akgentic/tool/knowledge_graph/kg_actor.py
@@ -575,7 +575,7 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
             ``SearchResult`` with hits ranked by cosine similarity score.
         """
         svc = self._get_or_create_embedding_svc()
-        if svc is None or not self._vector_index._entries:  # noqa: SLF001
+        if svc is None or len(self._vector_index) == 0:
             return SearchResult(hits=[])
         try:
             vectors = svc.embed([query_text])

--- a/src/akgentic/tool/knowledge_graph/vector_index.py
+++ b/src/akgentic/tool/knowledge_graph/vector_index.py
@@ -166,6 +166,10 @@ class VectorIndex:
         self._entries = [self._entries[i] for i in keep]
         self._count = new_count
 
+    def __len__(self) -> int:
+        """Return the number of entries currently stored in the index."""
+        return self._count
+
     def search_cosine(self, query_vector: list[float], top_k: int) -> list[tuple[str, float]]:
         """Return the top-k most similar entries by cosine similarity.
 

--- a/tests/test_kg_actor.py
+++ b/tests/test_kg_actor.py
@@ -14,7 +14,7 @@ test methods. Same pattern as test_planning_actor.py.
 from __future__ import annotations
 
 import uuid
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from akgentic.core.actor_address import ActorAddress
@@ -33,6 +33,7 @@ from akgentic.tool.knowledge_graph.models import (
     ManageGraph,
     RelationCreate,
     RelationDelete,
+    SearchQuery,
 )
 
 # ---------------------------------------------------------------------------
@@ -833,23 +834,6 @@ class TestEmbeddingGracefulDegradation:
 # ---------------------------------------------------------------------------
 
 
-def _actor_with_vector_entries() -> tuple[KnowledgeGraphActor, list[str]]:
-    """Return actor with 3 seeded entities whose vectors are pre-populated."""
-    actor, mock_svc = _actor_with_mock_embed()
-    actor.update_graph(
-        ManageGraph(
-            create_entities=[
-                EntityCreate(name="Alice", entity_type="Person", description="Engineer"),
-                EntityCreate(name="Bob", entity_type="Person", description="Designer"),
-                EntityCreate(name="Charlie", entity_type="Person", description="Manager"),
-            ]
-        )
-    )
-    # Return the ref_ids of the three entities
-    ref_ids = [str(e.id) for e in actor.get_graph().entities]
-    return actor, ref_ids
-
-
 class TestVectorSearch:
     """AC-1, AC-5: vector search returns ranked results or empty on no embeddings."""
 
@@ -863,23 +847,14 @@ class TestVectorSearch:
                 ]
             )
         )
-        # Assign distinct scores: first entity scores 0.9, second 0.5
         entity_ids = [str(e.id) for e in actor.get_graph().entities]
-        actor._vector_index._entries[0]  # noqa: SLF001 (exists: added by _actor_with_mock_embed)
-        # Override search_cosine to return predictable scores
-        from unittest.mock import patch
-
         with patch.object(
             actor._vector_index,  # noqa: SLF001
             "search_cosine",
             return_value=[(entity_ids[0], 0.9), (entity_ids[1], 0.5)],
         ):
             mock_svc.embed.return_value = [_FAKE_VECTOR]
-            result = actor.search(
-                __import__(
-                    "akgentic.tool.knowledge_graph.models", fromlist=["SearchQuery"]
-                ).SearchQuery(query="engineer", top_k=2, mode="vector")
-            )
+            result = actor.search(SearchQuery(query="engineer", top_k=2, mode="vector"))
         assert len(result.hits) == 2
         assert result.hits[0].score == 0.9
         assert result.hits[1].score == 0.5
@@ -887,14 +862,12 @@ class TestVectorSearch:
 
     def test_vector_search_returns_empty_when_no_entries_in_index(self) -> None:
         actor = _actor()
-        # Empty graph, no vectors
-        from akgentic.tool.knowledge_graph.models import SearchQuery
-
         result = actor.search(SearchQuery(query="anything", top_k=5, mode="vector"))
         assert result.hits == []
 
-    def test_vector_search_returns_empty_when_service_unavailable(self) -> None:
-        actor = _actor()
+    def test_vector_search_returns_empty_when_embed_call_fails(self) -> None:
+        """Verify graceful empty result when embed() raises during vector search (AC-5)."""
+        actor, mock_svc = _actor_with_mock_embed()
         actor.update_graph(
             ManageGraph(
                 create_entities=[
@@ -902,9 +875,8 @@ class TestVectorSearch:
                 ]
             )
         )
-        # _embedding_svc is None (never set) and openai would fail → graceful empty
-        from akgentic.tool.knowledge_graph.models import SearchQuery
-
+        # Index has 1 entry; make embed raise during the search query
+        mock_svc.embed.side_effect = RuntimeError("API quota exceeded")
         result = actor.search(SearchQuery(query="Alice", top_k=5, mode="vector"))
         assert result.hits == []
 
@@ -941,17 +913,12 @@ class TestHybridSearch:
         actor.update_graph(
             ManageGraph(
                 create_entities=[
-                    EntityCreate(
-                        name="Alice", entity_type="Person", description="Engineer"
-                    )
+                    EntityCreate(name="Alice", entity_type="Person", description="Engineer")
                 ]
             )
         )
         # No embedding service → vector search returns empty → hybrid falls back
-        from akgentic.tool.knowledge_graph.models import SearchQuery
-
         result = actor.search(SearchQuery(query="Alice", top_k=5, mode="hybrid"))
-        # Keyword should find Alice
         assert len(result.hits) == 1
         assert result.hits[0].entity is not None
         assert result.hits[0].entity.name == "Alice"
@@ -961,21 +928,13 @@ class TestHybridSearch:
         alice_id = str(
             next(e for e in actor.get_graph().entities if e.name == "Alice").id
         )
-
-        from unittest.mock import patch
-
-        from akgentic.tool.knowledge_graph.models import SearchQuery
-
-        # Vector search also returns Alice → should appear once in merged result
         with patch.object(
             actor._vector_index,  # noqa: SLF001
             "search_cosine",
             return_value=[(alice_id, 0.8)],
         ):
             mock_svc.embed.return_value = [_FAKE_VECTOR]
-            result = actor.search(
-                SearchQuery(query="Alice", top_k=10, mode="hybrid")
-            )
+            result = actor.search(SearchQuery(query="Alice", top_k=10, mode="hybrid"))
         alice_hits = [h for h in result.hits if h.ref_id == alice_id]
         assert len(alice_hits) == 1, "Alice should appear exactly once (deduplication)"
 
@@ -984,11 +943,6 @@ class TestHybridSearch:
         entities = actor.get_graph().entities
         alice_id = str(next(e for e in entities if e.name == "Alice").id)
         bob_id = str(next(e for e in entities if e.name == "Bob").id)
-
-        from unittest.mock import patch
-
-        from akgentic.tool.knowledge_graph.models import SearchQuery
-
         # Alice matches keyword "login" AND vector; Bob matches vector only
         with patch.object(
             actor._vector_index,  # noqa: SLF001
@@ -996,9 +950,7 @@ class TestHybridSearch:
             return_value=[(alice_id, 0.8), (bob_id, 0.9)],
         ):
             mock_svc.embed.return_value = [_FAKE_VECTOR]
-            result = actor.search(
-                SearchQuery(query="login", top_k=5, mode="hybrid")
-            )
+            result = actor.search(SearchQuery(query="login", top_k=5, mode="hybrid"))
         # Alice: vector(0.8) + keyword_boost(0.5) = 1.3; Bob: vector only = 0.9
         ref_ids = [h.ref_id for h in result.hits]
         assert ref_ids[0] == alice_id, "Alice (vector+keyword) should rank above Bob (vector-only)"
@@ -1014,18 +966,11 @@ class TestHybridSearch:
             )
         )
         entity_ids = [str(e.id) for e in actor.get_graph().entities]
-
-        from unittest.mock import patch
-
-        from akgentic.tool.knowledge_graph.models import SearchQuery
-
         with patch.object(
             actor._vector_index,  # noqa: SLF001
             "search_cosine",
             return_value=[(eid, 0.5) for eid in entity_ids],
         ):
             mock_svc.embed.return_value = [_FAKE_VECTOR]
-            result = actor.search(
-                SearchQuery(query="desc", top_k=3, mode="hybrid")
-            )
+            result = actor.search(SearchQuery(query="desc", top_k=3, mode="hybrid"))
         assert len(result.hits) <= 3

--- a/tests/test_kg_actor.py
+++ b/tests/test_kg_actor.py
@@ -5,6 +5,7 @@ state change notification, deduplication logic, singleton constants (Task 2.9).
 Also covers embedding wiring: entity/relation embedding on create, re-embedding
 on description update, removal on delete, graceful degradation on API failure
 (Task 5.11, Story 2.1 ACs 3-7).
+Also covers vector search and hybrid search (Story 2.2 ACs 1-5).
 
 Pattern: Instantiate KnowledgeGraphActor() directly, call on_start(),
 test methods. Same pattern as test_planning_actor.py.
@@ -825,3 +826,206 @@ class TestEmbeddingGracefulDegradation:
         )
         assert result == "Done"
         assert len(actor.get_graph().relations) == 1
+
+
+# ---------------------------------------------------------------------------
+# Vector search (Story 2.2 Task 1, ACs 1, 3, 5)
+# ---------------------------------------------------------------------------
+
+
+def _actor_with_vector_entries() -> tuple[KnowledgeGraphActor, list[str]]:
+    """Return actor with 3 seeded entities whose vectors are pre-populated."""
+    actor, mock_svc = _actor_with_mock_embed()
+    actor.update_graph(
+        ManageGraph(
+            create_entities=[
+                EntityCreate(name="Alice", entity_type="Person", description="Engineer"),
+                EntityCreate(name="Bob", entity_type="Person", description="Designer"),
+                EntityCreate(name="Charlie", entity_type="Person", description="Manager"),
+            ]
+        )
+    )
+    # Return the ref_ids of the three entities
+    ref_ids = [str(e.id) for e in actor.get_graph().entities]
+    return actor, ref_ids
+
+
+class TestVectorSearch:
+    """AC-1, AC-5: vector search returns ranked results or empty on no embeddings."""
+
+    def test_vector_search_returns_top_k_ranked_by_score(self) -> None:
+        actor, mock_svc = _actor_with_mock_embed()
+        actor.update_graph(
+            ManageGraph(
+                create_entities=[
+                    EntityCreate(name="Alice", entity_type="Person", description="Engineer"),
+                    EntityCreate(name="Bob", entity_type="Person", description="Designer"),
+                ]
+            )
+        )
+        # Assign distinct scores: first entity scores 0.9, second 0.5
+        entity_ids = [str(e.id) for e in actor.get_graph().entities]
+        actor._vector_index._entries[0]  # noqa: SLF001 (exists: added by _actor_with_mock_embed)
+        # Override search_cosine to return predictable scores
+        from unittest.mock import patch
+
+        with patch.object(
+            actor._vector_index,  # noqa: SLF001
+            "search_cosine",
+            return_value=[(entity_ids[0], 0.9), (entity_ids[1], 0.5)],
+        ):
+            mock_svc.embed.return_value = [_FAKE_VECTOR]
+            result = actor.search(
+                __import__(
+                    "akgentic.tool.knowledge_graph.models", fromlist=["SearchQuery"]
+                ).SearchQuery(query="engineer", top_k=2, mode="vector")
+            )
+        assert len(result.hits) == 2
+        assert result.hits[0].score == 0.9
+        assert result.hits[1].score == 0.5
+        assert result.hits[0].entity is not None
+
+    def test_vector_search_returns_empty_when_no_entries_in_index(self) -> None:
+        actor = _actor()
+        # Empty graph, no vectors
+        from akgentic.tool.knowledge_graph.models import SearchQuery
+
+        result = actor.search(SearchQuery(query="anything", top_k=5, mode="vector"))
+        assert result.hits == []
+
+    def test_vector_search_returns_empty_when_service_unavailable(self) -> None:
+        actor = _actor()
+        actor.update_graph(
+            ManageGraph(
+                create_entities=[
+                    EntityCreate(name="Alice", entity_type="Person", description="Eng")
+                ]
+            )
+        )
+        # _embedding_svc is None (never set) and openai would fail → graceful empty
+        from akgentic.tool.knowledge_graph.models import SearchQuery
+
+        result = actor.search(SearchQuery(query="Alice", top_k=5, mode="vector"))
+        assert result.hits == []
+
+
+# ---------------------------------------------------------------------------
+# Hybrid search (Story 2.2 Task 2, ACs 2, 4)
+# ---------------------------------------------------------------------------
+
+
+class TestHybridSearch:
+    """AC-2, AC-4: hybrid merges keyword+vector, falls back to keyword when no embeddings."""
+
+    def _setup_actor_with_known_vectors(
+        self,
+    ) -> tuple[KnowledgeGraphActor, MagicMock]:
+        """Actor with Alice + Bob; mock embed returns fixed vectors."""
+        actor, mock_svc = _actor_with_mock_embed()
+        actor.update_graph(
+            ManageGraph(
+                create_entities=[
+                    EntityCreate(
+                        name="Alice", entity_type="Person", description="Engineer login"
+                    ),
+                    EntityCreate(
+                        name="Bob", entity_type="Person", description="Designer security"
+                    ),
+                ]
+            )
+        )
+        return actor, mock_svc
+
+    def test_hybrid_falls_back_to_keyword_when_no_embeddings(self) -> None:
+        actor = _actor()
+        actor.update_graph(
+            ManageGraph(
+                create_entities=[
+                    EntityCreate(
+                        name="Alice", entity_type="Person", description="Engineer"
+                    )
+                ]
+            )
+        )
+        # No embedding service → vector search returns empty → hybrid falls back
+        from akgentic.tool.knowledge_graph.models import SearchQuery
+
+        result = actor.search(SearchQuery(query="Alice", top_k=5, mode="hybrid"))
+        # Keyword should find Alice
+        assert len(result.hits) == 1
+        assert result.hits[0].entity is not None
+        assert result.hits[0].entity.name == "Alice"
+
+    def test_hybrid_deduplicates_by_ref_id(self) -> None:
+        actor, mock_svc = self._setup_actor_with_known_vectors()
+        alice_id = str(
+            next(e for e in actor.get_graph().entities if e.name == "Alice").id
+        )
+
+        from unittest.mock import patch
+
+        from akgentic.tool.knowledge_graph.models import SearchQuery
+
+        # Vector search also returns Alice → should appear once in merged result
+        with patch.object(
+            actor._vector_index,  # noqa: SLF001
+            "search_cosine",
+            return_value=[(alice_id, 0.8)],
+        ):
+            mock_svc.embed.return_value = [_FAKE_VECTOR]
+            result = actor.search(
+                SearchQuery(query="Alice", top_k=10, mode="hybrid")
+            )
+        alice_hits = [h for h in result.hits if h.ref_id == alice_id]
+        assert len(alice_hits) == 1, "Alice should appear exactly once (deduplication)"
+
+    def test_hybrid_combined_hits_rank_higher_than_vector_only(self) -> None:
+        actor, mock_svc = self._setup_actor_with_known_vectors()
+        entities = actor.get_graph().entities
+        alice_id = str(next(e for e in entities if e.name == "Alice").id)
+        bob_id = str(next(e for e in entities if e.name == "Bob").id)
+
+        from unittest.mock import patch
+
+        from akgentic.tool.knowledge_graph.models import SearchQuery
+
+        # Alice matches keyword "login" AND vector; Bob matches vector only
+        with patch.object(
+            actor._vector_index,  # noqa: SLF001
+            "search_cosine",
+            return_value=[(alice_id, 0.8), (bob_id, 0.9)],
+        ):
+            mock_svc.embed.return_value = [_FAKE_VECTOR]
+            result = actor.search(
+                SearchQuery(query="login", top_k=5, mode="hybrid")
+            )
+        # Alice: vector(0.8) + keyword_boost(0.5) = 1.3; Bob: vector only = 0.9
+        ref_ids = [h.ref_id for h in result.hits]
+        assert ref_ids[0] == alice_id, "Alice (vector+keyword) should rank above Bob (vector-only)"
+
+    def test_hybrid_top_k_limits_results(self) -> None:
+        actor, mock_svc = _actor_with_mock_embed()
+        actor.update_graph(
+            ManageGraph(
+                create_entities=[
+                    EntityCreate(name=f"Entity{i}", entity_type="T", description=f"desc {i}")
+                    for i in range(10)
+                ]
+            )
+        )
+        entity_ids = [str(e.id) for e in actor.get_graph().entities]
+
+        from unittest.mock import patch
+
+        from akgentic.tool.knowledge_graph.models import SearchQuery
+
+        with patch.object(
+            actor._vector_index,  # noqa: SLF001
+            "search_cosine",
+            return_value=[(eid, 0.5) for eid in entity_ids],
+        ):
+            mock_svc.embed.return_value = [_FAKE_VECTOR]
+            result = actor.search(
+                SearchQuery(query="desc", top_k=3, mode="hybrid")
+            )
+        assert len(result.hits) <= 3


### PR DESCRIPTION
## Story 2.2: Hybrid & Vector Search Modes

Implements vector similarity search and hybrid (vector + keyword) search for the knowledge graph.

### Implementation

- `_vector_search()`: embeds query via `EmbeddingService`, computes cosine similarity via `VectorIndex.search_cosine()`, resolves `ref_id`s back to `Entity`/`Relation` objects, returns ranked `SearchResult`
- `_resolve_ref()`: scans entities then relations by UUID string comparison
- `_hybrid_search()`: merges keyword + vector hits by `ref_id`, applies +0.5 keyword boost for combined hits, gracefully falls back to keyword-only when no embeddings available (AC-4)
- Updated `search()` dispatcher: `vector` → `_vector_search`, `hybrid` → `_hybrid_search`, `keyword` → `_keyword_search`
- Added `VectorIndex.__len__()` public API to avoid private attribute access

### Code Review Findings Fixed

| Severity | Issue | Fix Applied |
|----------|-------|-------------|
| Medium | Private attribute `_entries` accessed via `# noqa: SLF001` | Added `__len__()` to `VectorIndex`; use `len(self._vector_index)` |
| Low | Unused `_actor_with_vector_entries()` helper in tests | Removed helper function |
| Low | Inline imports in test methods | Moved all imports to top-level |
| Low | Weak `embed_fails` test (empty index — passed for wrong reason) | Replaced with non-empty index + `embed.side_effect = RuntimeError` |

### Tests

- 7 new tests: `TestVectorSearch` (3) + `TestHybridSearch` (4)
- All 278 tests pass; coverage 94.79% on `akgentic.tool.knowledge_graph`
- NFR-KG-1 verified: cosine on 1000×1536 completes in < 1ms

Closes #11