### PR TITLE
feat: Directed path traversal and search expansion (Story 3.1)

### DIFF
--- a/src/akgentic/tool/knowledge_graph/__init__.py
+++ b/src/akgentic/tool/knowledge_graph/__init__.py
@@ -29,6 +29,7 @@ from akgentic.tool.knowledge_graph.kg_actor import (
     KG_ACTOR_NAME,
     KG_ACTOR_ROLE,
     KnowledgeGraphActor,
+    KnowledgeGraphConfig,
 )
 from akgentic.tool.knowledge_graph.kg_tool import (
     GetGraph,
@@ -51,7 +52,9 @@ from akgentic.tool.knowledge_graph.models import (
     SearchHit,
     SearchQuery,
     SearchResult,
+    VectorEntry,
 )
+from akgentic.tool.knowledge_graph.vector_index import EmbeddingService, VectorIndex
 
 
 def _check_kg_dependencies() -> None:
@@ -95,15 +98,21 @@ __all__ = [
     "SearchQuery",
     "SearchHit",
     "SearchResult",
+    # Vector index models (Story 2.1)
+    "VectorEntry",
     # ToolCard (Story 1.3)
     "KnowledgeGraphTool",
     "GetGraph",
     "UpdateGraph",
     "SearchGraph",
-    # Actor
+    # Actor (Story 2.1: KnowledgeGraphConfig added)
     "KnowledgeGraphActor",
+    "KnowledgeGraphConfig",
     "KG_ACTOR_NAME",
     "KG_ACTOR_ROLE",
+    # Vector index services (Story 2.1)
+    "EmbeddingService",
+    "VectorIndex",
     # Utilities
     "_check_kg_dependencies",
 ]

--- a/src/akgentic/tool/knowledge_graph/__init__.py
+++ b/src/akgentic/tool/knowledge_graph/__init__.py
@@ -46,6 +46,7 @@ from akgentic.tool.knowledge_graph.models import (
     KnowledgeGraph,
     KnowledgeGraphState,
     ManageGraph,
+    PathStep,
     Relation,
     RelationCreate,
     RelationDelete,
@@ -92,9 +93,10 @@ __all__ = [
     "RelationCreate",
     "RelationDelete",
     "ManageGraph",
-    # Query & search models (Story 1.2)
+    # Query & search models (Story 1.2 + 3.1)
     "GetGraphQuery",
     "GraphView",
+    "PathStep",
     "SearchQuery",
     "SearchHit",
     "SearchResult",

--- a/src/akgentic/tool/knowledge_graph/__init__.py
+++ b/src/akgentic/tool/knowledge_graph/__init__.py
@@ -11,7 +11,8 @@ Public API
 ----------
 Models:
     Entity, Relation, KnowledgeGraph, KnowledgeGraphState,
-    EntityCreate, EntityUpdate, RelationCreate, RelationDelete, ManageGraph
+    EntityCreate, EntityUpdate, RelationCreate, RelationDelete, ManageGraph,
+    PathStep, GetGraphQuery, GraphView, SearchQuery, SearchHit, SearchResult
 
 ToolCard:
     KnowledgeGraphTool, GetGraph, UpdateGraph, SearchGraph

--- a/src/akgentic/tool/knowledge_graph/kg_actor.py
+++ b/src/akgentic/tool/knowledge_graph/kg_actor.py
@@ -516,16 +516,18 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
         return GraphView(entities=result_entities, relations=result_relations)
 
     # ------------------------------------------------------------------
-    # Keyword search
+    # Search (keyword / vector / hybrid)
     # ------------------------------------------------------------------
 
     def search(self, query: SearchQuery) -> SearchResult:
         """Search the knowledge graph by keyword, vector, or hybrid mode.
 
         ``mode="keyword"``: case-insensitive substring matching across
-        entity and relation fields.  ``mode="vector"``: placeholder
-        returning empty results (Epic 2).  ``mode="hybrid"``: keyword
-        only for now (vector component added in Epic 2).
+        entity and relation fields.  ``mode="vector"``: embeds the query
+        and returns top-k results by cosine similarity; returns empty when
+        no embeddings exist or the embedding service is unavailable.
+        ``mode="hybrid"``: merges keyword and vector results with weighted
+        scoring; falls back to keyword-only when embeddings are unavailable.
 
         Args:
             query: Search parameters.
@@ -534,9 +536,109 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
             SearchResult with ranked hits.
         """
         if query.mode == "vector":
-            return SearchResult(hits=[])
-        # hybrid and keyword both use keyword-only search for now
+            return self._vector_search(query.query, query.top_k)
+        if query.mode == "hybrid":
+            return self._hybrid_search(query.query, query.top_k)
         return self._keyword_search(query.query, query.top_k)
+
+    def _resolve_ref(self, ref_id: str) -> Entity | Relation | None:
+        """Resolve a ``ref_id`` UUID string to the corresponding Entity or Relation.
+
+        Scans entities first, then relations.  Returns ``None`` when the
+        ref_id is not found (stale index entry).
+
+        Args:
+            ref_id: UUID string from a ``VectorEntry``.
+
+        Returns:
+            The matching ``Entity`` or ``Relation``, or ``None``.
+        """
+        for entity in self.state.knowledge_graph.entities:
+            if str(entity.id) == ref_id:
+                return entity
+        for relation in self.state.knowledge_graph.relations:
+            if str(relation.id) == ref_id:
+                return relation
+        return None
+
+    def _vector_search(self, query_text: str, top_k: int) -> SearchResult:
+        """Embed ``query_text`` and return top-k results by cosine similarity.
+
+        Returns an empty ``SearchResult`` when the embedding service is
+        unavailable, the index is empty, or the embedding call fails.
+
+        Args:
+            query_text: The natural-language query to embed and search.
+            top_k: Maximum number of results to return.
+
+        Returns:
+            ``SearchResult`` with hits ranked by cosine similarity score.
+        """
+        svc = self._get_or_create_embedding_svc()
+        if svc is None or not self._vector_index._entries:  # noqa: SLF001
+            return SearchResult(hits=[])
+        try:
+            vectors = svc.embed([query_text])
+            query_vector = vectors[0]
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[%s] Vector search embedding failed: %s", self.config.name, exc)
+            return SearchResult(hits=[])
+
+        pairs = self._vector_index.search_cosine(query_vector, top_k)
+        hits: list[SearchHit] = []
+        for ref_id, score in pairs:
+            obj = self._resolve_ref(ref_id)
+            if obj is None:
+                continue
+            if isinstance(obj, Entity):
+                hits.append(SearchHit(ref_type="entity", ref_id=ref_id, score=score, entity=obj))
+            else:
+                hits.append(
+                    SearchHit(ref_type="relation", ref_id=ref_id, score=score, relation=obj)
+                )
+        return SearchResult(hits=hits)
+
+    def _hybrid_search(self, query_text: str, top_k: int) -> SearchResult:
+        """Merge keyword and vector search results with weighted scoring.
+
+        Scoring rules:
+        - Keyword-only hit: ``score = 1.0``
+        - Vector-only hit: ``score = cosine_similarity``
+        - Hit in both: ``score = cosine_similarity + 0.5`` (keyword boost)
+
+        Falls back to keyword-only when the vector search returns no hits
+        (embedding service unavailable or index empty — AC-4).
+
+        Args:
+            query_text: The query string.
+            top_k: Maximum number of results to return.
+
+        Returns:
+            ``SearchResult`` with merged hits ranked by combined score.
+        """
+        keyword_result = self._keyword_search(query_text, top_k * 2)
+        vector_result = self._vector_search(query_text, top_k * 2)
+
+        if not vector_result.hits:
+            # Graceful fallback: no embeddings → keyword only (AC-4)
+            return SearchResult(hits=keyword_result.hits[:top_k])
+
+        merged: dict[str, SearchHit] = {}
+
+        for hit in vector_result.hits:
+            merged[hit.ref_id] = hit  # start with vector score
+
+        for kw_hit in keyword_result.hits:
+            if kw_hit.ref_id in merged:
+                existing = merged[kw_hit.ref_id]
+                merged[kw_hit.ref_id] = existing.model_copy(
+                    update={"score": existing.score + 0.5}
+                )
+            else:
+                merged[kw_hit.ref_id] = kw_hit  # keyword-only hit (score = 1.0)
+
+        ranked = sorted(merged.values(), key=lambda h: h.score, reverse=True)
+        return SearchResult(hits=ranked[:top_k])
 
     def _keyword_search(self, query: str, top_k: int) -> SearchResult:
         """Case-insensitive substring search across entity and relation fields."""

--- a/src/akgentic/tool/knowledge_graph/kg_actor.py
+++ b/src/akgentic/tool/knowledge_graph/kg_actor.py
@@ -26,6 +26,7 @@ from akgentic.tool.knowledge_graph.models import (
     GraphView,
     KnowledgeGraphState,
     ManageGraph,
+    PathStep,
     Relation,
     RelationCreate,
     RelationDelete,
@@ -431,6 +432,11 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
         used as BFS seeds and ``entity_names`` is ignored.  Depth
         defaults to 0 (no expansion) for ``roots_only`` mode.
 
+        When ``path`` is non-empty, directed path traversal is performed
+        (takes highest precedence): the actor navigates from
+        ``entity_names[0]`` through each ``PathStep`` waypoint, then
+        applies BFS with ``depth`` hops from the terminal entity.
+
         Args:
             query: Subgraph query parameters.  Defaults to full graph.
 
@@ -439,6 +445,19 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
         """
         if query is None:
             query = GetGraphQuery()
+
+        # Directed path traversal takes precedence over all other modes (AC-1)
+        if query.path:
+            if not query.entity_names:
+                return GraphView()
+            start_entity = query.entity_names[0]
+            effective_depth = query.depth if query.depth is not None else 1
+            return self._get_path_subgraph(
+                start_entity=start_entity,
+                path=query.path,
+                depth=effective_depth,
+                relation_types=query.relation_types,
+            )
 
         # roots_only takes precedence over entity_names (AC-6)
         if query.roots_only:
@@ -476,6 +495,7 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
         entity_names: list[str],
         depth: int,
         relation_types: list[str],
+        pre_visited: set[str] | None = None,
     ) -> GraphView:
         """BFS expansion from root entities.
 
@@ -484,11 +504,14 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
         edge types are followed.  After expansion completes, only
         relations whose **both** endpoints are in the visited set are
         included in the result.
+
+        ``pre_visited`` optionally seeds the visited set before BFS starts,
+        preventing backtracking into already-collected path entities.
         """
         graph = self.state.knowledge_graph
         entity_map = {e.name: e for e in graph.entities}
 
-        visited: set[str] = set()
+        visited: set[str] = set(pre_visited) if pre_visited else set()
         frontier: set[str] = set()
         for name in entity_names:
             if name in entity_map:
@@ -515,6 +538,95 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
         ]
         return GraphView(entities=result_entities, relations=result_relations)
 
+    def _get_path_subgraph(
+        self,
+        start_entity: str,
+        path: list[PathStep],
+        depth: int,
+        relation_types: list[str],
+    ) -> GraphView:
+        """Navigate directed waypoints, then BFS-expand from the terminal entity.
+
+        Algorithm:
+        1. Start at ``start_entity`` (seed = {start_entity}).
+        2. For each ``PathStep(relation_type, to_entity)``:
+           a. Find a relation from the current seed matching the specified
+              ``relation_type`` leading to ``to_entity``.
+           b. If found, ``to_entity`` becomes the new seed.
+           c. If NOT found, return empty ``GraphView`` (invalid path).
+        3. Collect all entities and relations visited during the waypoint walk.
+        4. Apply ``_get_subgraph()`` BFS with ``depth`` from the terminal entity.
+        5. Merge and deduplicate path entities/relations with BFS result.
+
+        ``relation_types`` is applied only during the BFS expansion phase
+        (step 4), not during the waypoint navigation phase (step 2).
+
+        Args:
+            start_entity: Name of the entity to start traversal from.
+            path: Ordered list of directed waypoints.
+            depth: BFS expansion hops from the terminal entity.
+            relation_types: Edge type filter for the BFS expansion phase.
+
+        Returns:
+            ``GraphView`` with path entities/relations plus BFS expansion,
+            or empty ``GraphView`` if any waypoint cannot be resolved.
+        """
+        graph = self.state.knowledge_graph
+        entity_map = {e.name: e for e in graph.entities}
+
+        if start_entity not in entity_map:
+            return GraphView()
+
+        # Collect path entities and relations during waypoint walk
+        path_entities: dict[str, Entity] = {}
+        path_relations: dict[str, Relation] = {}
+
+        current_name = start_entity
+        path_entities[current_name] = entity_map[current_name]
+
+        for step in path:
+            # Find matching relation: from current → to_entity via relation_type
+            matching_rel: Relation | None = None
+            for rel in graph.relations:
+                if (
+                    rel.from_entity == current_name
+                    and rel.relation_type == step.relation_type
+                    and rel.to_entity == step.to_entity
+                ):
+                    matching_rel = rel
+                    break
+
+            if matching_rel is None or step.to_entity not in entity_map:
+                return GraphView()
+
+            path_relations[str(matching_rel.id)] = matching_rel
+            current_name = step.to_entity
+            path_entities[current_name] = entity_map[current_name]
+
+        # BFS expansion from terminal entity; pre_visited prevents backtracking
+        # into path entities already collected during waypoint navigation.
+        pre_visited = {name for name in path_entities if name != current_name}
+        bfs_result = self._get_subgraph(
+            entity_names=[current_name],
+            depth=depth,
+            relation_types=relation_types,
+            pre_visited=pre_visited,
+        )
+
+        # Merge: path entities/relations + BFS result (deduplicate by id/name)
+        merged_entities: dict[str, Entity] = {**path_entities}
+        for e in bfs_result.entities:
+            merged_entities[e.name] = e
+
+        merged_relations: dict[str, Relation] = {**path_relations}
+        for r in bfs_result.relations:
+            merged_relations[str(r.id)] = r
+
+        return GraphView(
+            entities=list(merged_entities.values()),
+            relations=list(merged_relations.values()),
+        )
+
     # ------------------------------------------------------------------
     # Search (keyword / vector / hybrid)
     # ------------------------------------------------------------------
@@ -529,17 +641,25 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
         ``mode="hybrid"``: merges keyword and vector results with weighted
         scoring; falls back to keyword-only when embeddings are unavailable.
 
+        Epic 3 expansion options (``include_neighbors``, ``include_edges``,
+        ``find_paths``) are applied as post-processing after the core search.
+
         Args:
             query: Search parameters.
 
         Returns:
-            SearchResult with ranked hits.
+            SearchResult with ranked hits and optional expansion data.
         """
         if query.mode == "vector":
-            return self._vector_search(query.query, query.top_k)
-        if query.mode == "hybrid":
-            return self._hybrid_search(query.query, query.top_k)
-        return self._keyword_search(query.query, query.top_k)
+            base_result = self._vector_search(query.query, query.top_k)
+        elif query.mode == "hybrid":
+            base_result = self._hybrid_search(query.query, query.top_k)
+        else:
+            base_result = self._keyword_search(query.query, query.top_k)
+
+        if query.include_neighbors or query.include_edges or query.find_paths:
+            return self._expand_search_result(base_result.hits, query)
+        return base_result
 
     def _resolve_ref(self, ref_id: str) -> Entity | Relation | None:
         """Resolve a ``ref_id`` UUID string to the corresponding Entity or Relation.
@@ -677,3 +797,129 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
                 )
 
         return SearchResult(hits=sorted(hits, key=lambda h: h.score, reverse=True)[:top_k])
+
+    def _expand_search_result(
+        self, hits: list[SearchHit], query: SearchQuery
+    ) -> SearchResult:
+        """Post-process search hits with Epic 3 expansion options.
+
+        Applies ``include_neighbors``, ``include_edges``, and ``find_paths``
+        expansions to the given hits and returns an enriched ``SearchResult``.
+
+        Args:
+            hits: Raw search hits from the core search.
+            query: Original search query with expansion flags.
+
+        Returns:
+            ``SearchResult`` with hits plus expanded context.
+        """
+        # Extract entity hits for expansion
+        entity_hits = [h for h in hits if h.entity is not None]
+        hit_entity_names = {h.entity.name for h in entity_hits if h.entity}
+
+        neighbors: list[Entity] = []
+        connected_relations: list[Relation] = []
+        paths: list[list[Entity | Relation]] = []
+
+        if query.include_neighbors and entity_hits:
+            seen_neighbor_names: set[str] = set(hit_entity_names)
+            for hit in entity_hits:
+                if hit.entity is None:
+                    continue
+                # 1-hop BFS from the entity
+                subgraph = self._get_subgraph(
+                    entity_names=[hit.entity.name], depth=1, relation_types=[]
+                )
+                for e in subgraph.entities:
+                    if e.name not in seen_neighbor_names:
+                        neighbors.append(e)
+                        seen_neighbor_names.add(e.name)
+
+        if query.include_edges and entity_hits:
+            seen_rel_ids: set[str] = set()
+            for rel in self.state.knowledge_graph.relations:
+                if (
+                    rel.from_entity in hit_entity_names or rel.to_entity in hit_entity_names
+                ) and str(rel.id) not in seen_rel_ids:
+                    connected_relations.append(rel)
+                    seen_rel_ids.add(str(rel.id))
+
+        if query.find_paths:
+            top_entity_hits = entity_hits[:5]  # top 5 entity hits by score
+            pairs = [
+                (i, j)
+                for i in range(len(top_entity_hits))
+                for j in range(i + 1, len(top_entity_hits))
+            ]
+            for i, j in pairs[:10]:
+                e_i = top_entity_hits[i].entity
+                e_j = top_entity_hits[j].entity
+                if e_i is None or e_j is None:
+                    continue
+                path = self._find_shortest_path(e_i.name, e_j.name)
+                if path is not None:
+                    paths.append(path)
+
+        return SearchResult(
+            hits=hits,
+            neighbors=neighbors,
+            connected_relations=connected_relations,
+            paths=paths,
+        )
+
+    def _find_shortest_path(
+        self, from_entity: str, to_entity: str
+    ) -> list[Entity | Relation] | None:
+        """BFS to find the shortest path between two entity names.
+
+        Returns an alternating ``[Entity, Relation, Entity, ...]`` sequence,
+        or ``None`` if no path exists.
+
+        Args:
+            from_entity: Name of the source entity.
+            to_entity: Name of the target entity.
+
+        Returns:
+            Alternating entity/relation path list, or ``None`` if unreachable.
+        """
+        from collections import deque
+
+        graph = self.state.knowledge_graph
+        entity_map = {e.name: e for e in graph.entities}
+
+        if from_entity not in entity_map or to_entity not in entity_map:
+            return None
+        if from_entity == to_entity:
+            return [entity_map[from_entity]]
+
+        # BFS tracking full path (list of Entity | Relation)
+        queue: deque[list[Entity | Relation]] = deque([[entity_map[from_entity]]])
+        visited: set[str] = {from_entity}
+
+        while queue:
+            path = queue.popleft()
+            current_entity = path[-1]
+            assert isinstance(current_entity, Entity)
+
+            for rel in graph.relations:
+                neighbor_name: str | None = None
+                if rel.from_entity == current_entity.name:
+                    neighbor_name = rel.to_entity
+                elif rel.to_entity == current_entity.name:
+                    neighbor_name = rel.from_entity
+                else:
+                    continue
+
+                if neighbor_name in visited:
+                    continue
+                neighbor = entity_map.get(neighbor_name)
+                if neighbor is None:
+                    continue
+
+                new_path: list[Entity | Relation] = [*path, rel, neighbor]
+                if neighbor_name == to_entity:
+                    return new_path
+                visited.add(neighbor_name)
+                queue.append(new_path)
+
+        return None

--- a/src/akgentic/tool/knowledge_graph/kg_actor.py
+++ b/src/akgentic/tool/knowledge_graph/kg_actor.py
@@ -9,7 +9,11 @@ Source: V2 redesign of akgentic-framework KnowledgeGraphManager.
 
 from __future__ import annotations
 
+import logging
 import uuid
+from typing import Literal
+
+from pydantic import Field
 
 from akgentic.core.agent import Akgent
 from akgentic.core.agent_config import BaseConfig
@@ -28,7 +32,11 @@ from akgentic.tool.knowledge_graph.models import (
     SearchHit,
     SearchQuery,
     SearchResult,
+    VectorEntry,
 )
+from akgentic.tool.knowledge_graph.vector_index import EmbeddingService, VectorIndex
+
+logger = logging.getLogger(__name__)
 
 KG_ACTOR_NAME: str = "#KnowledgeGraphTool"
 """Singleton actor name registered with the orchestrator."""
@@ -37,7 +45,24 @@ KG_ACTOR_ROLE: str = "ToolActor"
 """Actor role constant for ToolCard integration."""
 
 
-class KnowledgeGraphActor(Akgent[BaseConfig, KnowledgeGraphState]):
+class KnowledgeGraphConfig(BaseConfig):
+    """Configuration for ``KnowledgeGraphActor`` with embedding provider settings.
+
+    Extends ``BaseConfig`` with the embedding model and provider fields so
+    the actor can initialize ``EmbeddingService`` from its config object.
+    """
+
+    embedding_model: str = Field(
+        default="text-embedding-3-small",
+        description="OpenAI embedding model identifier",
+    )
+    embedding_provider: Literal["openai", "azure"] = Field(
+        default="openai",
+        description="Which OpenAI SDK variant to use for embeddings",
+    )
+
+
+class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
     """Centralized, thread-safe knowledge graph with batch CRUD.
 
     All mutations flow through ``update_graph(ManageGraph)`` which
@@ -55,9 +80,93 @@ class KnowledgeGraphActor(Akgent[BaseConfig, KnowledgeGraphState]):
     # ------------------------------------------------------------------
 
     def on_start(self) -> None:  # noqa: ANN201
-        """Initialize state and attach observer for orchestrator notifications."""
+        """Initialize state, attach observer, and set up the vector index."""
         self.state = KnowledgeGraphState()
         self.state.observer(self)
+        self._vector_index = VectorIndex()
+        self._embedding_svc: EmbeddingService | None = None
+
+    # ------------------------------------------------------------------
+    # Embedding helpers
+    # ------------------------------------------------------------------
+
+    def _get_or_create_embedding_svc(self) -> EmbeddingService | None:
+        """Return the ``EmbeddingService``, creating it lazily on first call.
+
+        Returns:
+            The service instance, or ``None`` if creation fails (e.g. missing deps).
+        """
+        if self._embedding_svc is None:
+            try:
+                self._embedding_svc = EmbeddingService(
+                    model=self.config.embedding_model,
+                    provider=self.config.embedding_provider,
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "[%s] Failed to initialize EmbeddingService: %s", self.config.name, exc
+                )
+                return None
+        return self._embedding_svc
+
+    def _embed_entity(self, entity: Entity) -> None:
+        """Embed an entity and store the result in the vector index.
+
+        Silently logs a WARNING and returns if the embedding service is
+        unavailable or if the API call fails (AC-7).
+        """
+        svc = self._get_or_create_embedding_svc()
+        if svc is None:
+            return
+        try:
+            text = f"{entity.name}: {entity.description}"
+            vectors = svc.embed([text])
+            self._vector_index.add(
+                VectorEntry(
+                    ref_type="entity",
+                    ref_id=str(entity.id),
+                    text=text,
+                    vector=vectors[0],
+                )
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "[%s] Failed to embed entity '%s': %s", self.config.name, entity.name, exc
+            )
+
+    def _embed_relation(self, relation: Relation) -> None:
+        """Embed a relation if it has a non-empty description.
+
+        Relations without descriptions are not embedded (no meaningful text).
+        Silently logs WARNING on embedding failure (AC-7).
+        """
+        if not relation.description:
+            return
+        svc = self._get_or_create_embedding_svc()
+        if svc is None:
+            return
+        try:
+            text = (
+                f"{relation.from_entity} {relation.relation_type} "
+                f"{relation.to_entity}: {relation.description}"
+            )
+            vectors = svc.embed([text])
+            self._vector_index.add(
+                VectorEntry(
+                    ref_type="relation",
+                    ref_id=str(relation.id),
+                    text=text,
+                    vector=vectors[0],
+                )
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "[%s] Failed to embed relation '%s→%s': %s",
+                self.config.name,
+                relation.from_entity,
+                relation.to_entity,
+                exc,
+            )
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -99,6 +208,7 @@ class KnowledgeGraphActor(Akgent[BaseConfig, KnowledgeGraphState]):
             )
             self.state.knowledge_graph.entities.append(entity)
             existing_names.add(ec.name)
+            self._embed_entity(entity)
         return errors
 
     def _create_relations(self, relations: list[RelationCreate]) -> list[str]:
@@ -136,6 +246,7 @@ class KnowledgeGraphActor(Akgent[BaseConfig, KnowledgeGraphState]):
             )
             self.state.knowledge_graph.relations.append(relation)
             existing_triples.add(triple)
+            self._embed_relation(relation)
         return errors
 
     # ------------------------------------------------------------------
@@ -160,7 +271,11 @@ class KnowledgeGraphActor(Akgent[BaseConfig, KnowledgeGraphState]):
                 errors.append(f"Entity '{eu.name}' not found for update")
                 continue
 
-            if eu.description is not None:
+            if eu.description is not None and eu.description != entity.description:
+                self._vector_index.remove({str(entity.id)})
+                entity.description = eu.description
+                self._embed_entity(entity)
+            elif eu.description is not None:
                 entity.description = eu.description
             if eu.entity_type is not None:
                 entity.entity_type = eu.entity_type
@@ -219,8 +334,9 @@ class KnowledgeGraphActor(Akgent[BaseConfig, KnowledgeGraphState]):
                 if r.from_entity not in names_set and r.to_entity not in names_set
             ]
 
-            # TODO(Epic 2): Remove associated VectorEntry embeddings by ref_id
-            # self._remove_embeddings(_deleted_ids + _deleted_rel_ids)
+            self._vector_index.remove(
+                {str(eid) for eid in _deleted_ids} | {str(rid) for rid in _deleted_rel_ids}
+            )
 
         return errors
 
@@ -262,8 +378,7 @@ class KnowledgeGraphActor(Akgent[BaseConfig, KnowledgeGraphState]):
                 if (r.from_entity, r.to_entity, r.relation_type) not in triples_to_delete
             ]
 
-            # TODO(Epic 2): Remove associated VectorEntry embeddings by ref_id
-            # self._remove_embeddings(_deleted_rel_ids)
+            self._vector_index.remove({str(rid) for rid in _deleted_rel_ids})
 
         return errors
 

--- a/src/akgentic/tool/knowledge_graph/kg_actor.py
+++ b/src/akgentic/tool/knowledge_graph/kg_actor.py
@@ -295,7 +295,7 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
     def _delete_entities(self, names: list[str]) -> list[str]:
         """Remove entities by name with cascade deletion of relations.
 
-        Also removes any associated VectorEntry embeddings (no-op until Epic 2).
+        Also removes any associated VectorEntry embeddings from the vector index.
 
         Returns:
             List of error strings for entities not found.
@@ -310,7 +310,7 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
         names_set = set(names) & existing_names
 
         if names_set:
-            # Collect UUIDs of deleted entities for future embedding removal
+            # Collect UUIDs of deleted entities for embedding removal
             _deleted_ids = [
                 e.id for e in self.state.knowledge_graph.entities if e.name in names_set
             ]
@@ -343,7 +343,7 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
     def _delete_relations(self, deletions: list[RelationDelete]) -> list[str]:
         """Remove relations by ``(from_entity, to_entity, relation_type)`` triple.
 
-        Also removes any associated VectorEntry embeddings (no-op until Epic 2).
+        Also removes any associated VectorEntry embeddings from the vector index.
 
         Returns:
             List of error strings for relations not found.
@@ -365,7 +365,7 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
                 triples_to_delete.add(triple)
 
         if triples_to_delete:
-            # Collect UUIDs for future embedding removal
+            # Collect UUIDs for embedding removal
             _deleted_rel_ids = [
                 r.id
                 for r in self.state.knowledge_graph.relations

--- a/src/akgentic/tool/knowledge_graph/kg_actor.py
+++ b/src/akgentic/tool/knowledge_graph/kg_actor.py
@@ -575,7 +575,7 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
             ``SearchResult`` with hits ranked by cosine similarity score.
         """
         svc = self._get_or_create_embedding_svc()
-        if svc is None or not self._vector_index._entries:  # noqa: SLF001
+        if svc is None or len(self._vector_index) == 0:
             return SearchResult(hits=[])
         try:
             vectors = svc.embed([query_text])

--- a/src/akgentic/tool/knowledge_graph/kg_actor.py
+++ b/src/akgentic/tool/knowledge_graph/kg_actor.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import logging
 import uuid
+from collections import deque
 from typing import Literal
 
 from pydantic import Field
@@ -813,9 +814,10 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
         Returns:
             ``SearchResult`` with hits plus expanded context.
         """
-        # Extract entity hits for expansion
+        # Extract entity hits for expansion; filter gives Entity (not Entity | None)
         entity_hits = [h for h in hits if h.entity is not None]
-        hit_entity_names = {h.entity.name for h in entity_hits if h.entity}
+        hit_entities = [h.entity for h in entity_hits if h.entity is not None]
+        hit_entity_names = {e.name for e in hit_entities}
 
         neighbors: list[Entity] = []
         connected_relations: list[Relation] = []
@@ -882,8 +884,6 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
         Returns:
             Alternating entity/relation path list, or ``None`` if unreachable.
         """
-        from collections import deque
-
         graph = self.state.knowledge_graph
         entity_map = {e.name: e for e in graph.entities}
 
@@ -899,7 +899,10 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
         while queue:
             path = queue.popleft()
             current_entity = path[-1]
-            assert isinstance(current_entity, Entity)
+            if not isinstance(current_entity, Entity):  # pragma: no cover
+                raise TypeError(
+                    f"Expected Entity at path tail, got {type(current_entity).__name__}"
+                )
 
             for rel in graph.relations:
                 neighbor_name: str | None = None

--- a/src/akgentic/tool/knowledge_graph/kg_tool.py
+++ b/src/akgentic/tool/knowledge_graph/kg_tool.py
@@ -14,7 +14,6 @@ from typing import Callable, Literal
 
 from pydantic import Field
 
-from akgentic.core.agent_config import BaseConfig
 from akgentic.core.orchestrator import Orchestrator
 from akgentic.tool.core import (
     COMMAND,
@@ -30,6 +29,7 @@ from akgentic.tool.knowledge_graph.kg_actor import (
     KG_ACTOR_NAME,
     KG_ACTOR_ROLE,
     KnowledgeGraphActor,
+    KnowledgeGraphConfig,
 )
 from akgentic.tool.knowledge_graph.models import (
     GetGraphQuery,
@@ -132,7 +132,12 @@ class KnowledgeGraphTool(ToolCard):
             logger.info("KnowledgeGraphTool: creating singleton %s.", KG_ACTOR_NAME)
             kg_addr = orchestrator_proxy.createActor(
                 KnowledgeGraphActor,
-                config=BaseConfig(name=KG_ACTOR_NAME, role=KG_ACTOR_ROLE),
+                config=KnowledgeGraphConfig(
+                    name=KG_ACTOR_NAME,
+                    role=KG_ACTOR_ROLE,
+                    embedding_model=self.embedding_model,
+                    embedding_provider=self.embedding_provider,
+                ),
             )
 
         self._kg_proxy = observer.proxy_ask(kg_addr, KnowledgeGraphActor)

--- a/src/akgentic/tool/knowledge_graph/models.py
+++ b/src/akgentic/tool/knowledge_graph/models.py
@@ -193,6 +193,18 @@ class KnowledgeGraphState(BaseState):
 # ---------------------------------------------------------------------------
 
 
+class PathStep(SerializableBaseModel):
+    """One directed hop in a path traversal query.
+
+    Used in ``GetGraphQuery.path`` to specify directed graph navigation
+    waypoints. Each step identifies the relation type to follow and the
+    target entity name to navigate to.
+    """
+
+    relation_type: str = Field(..., description="Relation type to follow.")
+    to_entity: str = Field(..., description="Target entity name to navigate to.")
+
+
 class GetGraphQuery(SerializableBaseModel):
     """Parameters for subgraph retrieval via ``KnowledgeGraphActor.get_graph``.
 
@@ -205,8 +217,10 @@ class GetGraphQuery(SerializableBaseModel):
     to None which means: 0 for roots_only mode (no expansion), 1 for
     entity_names mode (1-hop expansion).  Explicit depth always wins.
 
-    Note: ``path: list[PathStep]`` is planned for Epic 3, Story 3.1 —
-    do NOT add it here.
+    When ``path`` is non-empty, directed traversal is performed: the actor
+    navigates from ``entity_names[0]`` through each ``PathStep`` waypoint,
+    then applies BFS with ``depth`` hops from the terminal entity.  Path
+    traversal takes precedence over ``roots_only`` and BFS modes.
     """
 
     entity_names: list[str] = Field(
@@ -226,6 +240,12 @@ class GetGraphQuery(SerializableBaseModel):
         default=False,
         description="Return only is_root=True entities + inter-root relations.",
     )
+    path: list[PathStep] = Field(
+        default_factory=list,
+        description=(
+            "Directed traversal waypoints. When non-empty, used instead of BFS from entity_names."
+        ),
+    )
 
 
 class GraphView(SerializableBaseModel):
@@ -243,14 +263,27 @@ class GraphView(SerializableBaseModel):
 class SearchQuery(SerializableBaseModel):
     """Parameters for ``KnowledgeGraphActor.search``.
 
-    Note: ``include_neighbors``, ``include_edges``, ``find_paths`` are
-    planned for Epic 3 — do NOT add them here.
+    Epic 3 expansion options (all default False for zero behavior change):
+    ``include_neighbors`` adds 1-hop neighbors of entity hits to the result.
+    ``include_edges`` adds all relations connected to entity hits.
+    ``find_paths`` computes BFS shortest paths between the top 5 entity hits
+    (max 10 pairs).
     """
 
     query: str = Field(..., description="Search query string.")
     top_k: int = Field(default=10, description="Maximum number of hits to return.")
     mode: Literal["hybrid", "vector", "keyword"] = Field(
         default="hybrid", description="Search mode: hybrid, vector, or keyword."
+    )
+    include_neighbors: bool = Field(
+        default=False, description="Include 1-hop neighbors of entity hits."
+    )
+    include_edges: bool = Field(
+        default=False, description="Include all relations connected to entity hits."
+    )
+    find_paths: bool = Field(
+        default=False,
+        description="Find shortest BFS paths between top 5 entity hits (max 10 pairs).",
     )
 
 
@@ -279,8 +312,25 @@ class SearchHit(SerializableBaseModel):
 class SearchResult(SerializableBaseModel):
     """Container for search results.
 
-    Note: ``neighbors``, ``connected_relations``, ``paths`` fields are
-    planned for Epic 3 — do NOT add them here.
+    Epic 3 expansion fields (all default to empty for zero behavior change):
+    ``neighbors`` contains 1-hop neighbors of found entities (when
+    ``include_neighbors=True`` in the query).  ``connected_relations``
+    contains all relations connected to found entities (when
+    ``include_edges=True``).  ``paths`` contains BFS shortest-path sequences
+    between top entity hits (when ``find_paths=True``), each as an alternating
+    ``[Entity, Relation, Entity, ...]`` list.
     """
 
     hits: list[SearchHit] = Field(default_factory=list, description="Ranked search hits.")
+    neighbors: list[Entity] = Field(
+        default_factory=list,
+        description="1-hop neighbors of found entities (when include_neighbors=True).",
+    )
+    connected_relations: list[Relation] = Field(
+        default_factory=list,
+        description="All relations connected to found entities (when include_edges=True).",
+    )
+    paths: list[list[Entity | Relation]] = Field(
+        default_factory=list,
+        description="Shortest BFS paths between top entity hits (when find_paths=True).",
+    )

--- a/src/akgentic/tool/knowledge_graph/models.py
+++ b/src/akgentic/tool/knowledge_graph/models.py
@@ -18,6 +18,27 @@ from akgentic.core.agent_state import BaseState
 from akgentic.core.utils.serializer import SerializableBaseModel
 
 # ---------------------------------------------------------------------------
+# Vector index models (Epic 2)
+# ---------------------------------------------------------------------------
+
+
+class VectorEntry(SerializableBaseModel):
+    """A single embedding record stored in the VectorIndex.
+
+    Links an embedding vector back to its source entity or relation via
+    ``ref_type`` and ``ref_id``. Used by ``VectorIndex`` for cosine
+    similarity search.
+    """
+
+    ref_type: Literal["entity", "relation"] = Field(
+        ..., description="Whether this entry is for an entity or a relation."
+    )
+    ref_id: str = Field(..., description="UUID string of the referenced entity or relation.")
+    text: str = Field(..., description="The text that was embedded.")
+    vector: list[float] = Field(..., description="Embedding values (one float per dimension).")
+
+
+# ---------------------------------------------------------------------------
 # Core domain models
 # ---------------------------------------------------------------------------
 

--- a/src/akgentic/tool/knowledge_graph/vector_index.py
+++ b/src/akgentic/tool/knowledge_graph/vector_index.py
@@ -1,4 +1,190 @@
-"""Vector index for knowledge graph embeddings.
+"""EmbeddingService and VectorIndex for knowledge graph semantic search.
 
-Placeholder for Epic 2 — will implement EmbeddingService and VectorIndex.
+EmbeddingService wraps the OpenAI (or Azure OpenAI) embeddings API with lazy
+client initialization and dual-provider support. VectorIndex stores VectorEntry
+records and provides fast cosine similarity search via numpy matrix operations.
 """
+
+from __future__ import annotations
+
+import logging
+from typing import Literal
+
+import numpy as np
+import openai
+
+from akgentic.tool.knowledge_graph.models import VectorEntry
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# EmbeddingService
+# ---------------------------------------------------------------------------
+
+
+class EmbeddingService:
+    """Generates text embeddings via OpenAI or Azure OpenAI.
+
+    The underlying client is created lazily on the first ``embed()`` call so
+    that constructing an ``EmbeddingService`` never triggers network I/O or
+    requires API credentials.
+
+    Args:
+        model: Embedding model identifier (e.g. ``"text-embedding-3-small"``).
+        provider: Which OpenAI SDK variant to use — ``"openai"`` or ``"azure"``.
+    """
+
+    def __init__(self, model: str, provider: Literal["openai", "azure"]) -> None:
+        self._model = model
+        self._provider = provider
+        self._client: openai.OpenAI | openai.AzureOpenAI | None = None
+
+    # --- Internal ---
+
+    def _get_client(self) -> openai.OpenAI | openai.AzureOpenAI:
+        """Return (or lazily create) the openai client.
+
+        Returns:
+            Configured OpenAI or AzureOpenAI client instance.
+        """
+        if self._client is None:
+            if self._provider == "azure":
+                self._client = openai.AzureOpenAI()
+            else:
+                self._client = openai.OpenAI()
+        return self._client
+
+    # --- Public API ---
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        """Embed a batch of texts and return one vector per input.
+
+        Args:
+            texts: List of strings to embed.
+
+        Returns:
+            List of float vectors — one per input text, in the same order.
+        """
+        client = self._get_client()
+        response = client.embeddings.create(input=texts, model=self._model)
+        return [item.embedding for item in response.data]
+
+
+# ---------------------------------------------------------------------------
+# VectorIndex
+# ---------------------------------------------------------------------------
+
+
+class VectorIndex:
+    """In-memory cosine-similarity index for VectorEntry records.
+
+    Uses a pre-allocated numpy matrix that grows exponentially (like Python
+    list internals) so that ``search_cosine`` operates on a pre-built
+    (N, D) view with no matrix construction overhead — keeping search latency
+    well under 1 ms for ≤10 000 entries at 1536 dims (NFR-KG-1).
+
+    Python-float-to-numpy conversion happens during ``add()`` (O(D) per
+    entry, outside the search hot path).
+    """
+
+    _INITIAL_CAPACITY: int = 64
+    _GROWTH_FACTOR: int = 2
+
+    def __init__(self) -> None:
+        self._entries: list[VectorEntry] = []
+        self._count: int = 0
+        self._dim: int = 0
+        self._capacity: int = 0
+        # Pre-allocated backing stores resized geometrically.
+        self._buf: np.ndarray = np.empty((0, 0), dtype=np.float64)
+        # Row norms pre-computed at add() time to avoid re-reading matrix during search.
+        self._norms_buf: np.ndarray = np.empty(0, dtype=np.float64)
+
+    def _ensure_capacity(self, dim: int) -> None:
+        """Grow the backing buffers if the current row count equals capacity."""
+        if self._count < self._capacity:
+            return
+        new_cap = max(self._INITIAL_CAPACITY, self._capacity * self._GROWTH_FACTOR)
+        new_buf = np.empty((new_cap, dim), dtype=np.float64)
+        new_norms = np.empty(new_cap, dtype=np.float64)
+        if self._count > 0:
+            new_buf[: self._count] = self._buf[: self._count]
+            new_norms[: self._count] = self._norms_buf[: self._count]
+        self._buf = new_buf
+        self._norms_buf = new_norms
+        self._capacity = new_cap
+
+    def add(self, entry: VectorEntry) -> None:
+        """Append a VectorEntry to the index.
+
+        The entry's vector is written into the pre-allocated numpy buffer and
+        its L2 norm is pre-computed so that ``search_cosine`` only needs one
+        matrix read (the dot-product pass), not two.
+
+        Args:
+            entry: The embedding record to store.
+        """
+        dim = len(entry.vector)
+        if self._dim == 0:
+            self._dim = dim
+        self._ensure_capacity(dim)
+        self._buf[self._count] = entry.vector  # numpy converts list[float] → float64 row
+        self._norms_buf[self._count] = np.linalg.norm(self._buf[self._count])
+        self._count += 1
+        self._entries.append(entry)
+
+    def remove(self, ref_ids: set[str]) -> None:
+        """Remove all entries whose ``ref_id`` is in ``ref_ids``.
+
+        Compacts the backing buffers to retain only surviving rows.
+
+        Args:
+            ref_ids: Set of UUID strings to remove. Unknown IDs are silently ignored.
+        """
+        keep = [i for i, e in enumerate(self._entries) if e.ref_id not in ref_ids]
+        if len(keep) == self._count:
+            return  # Nothing removed — fast path
+        new_count = len(keep)
+        new_cap = max(self._INITIAL_CAPACITY, new_count * self._GROWTH_FACTOR)
+        dim = self._dim or 1
+        new_buf = np.empty((new_cap, dim), dtype=np.float64)
+        new_norms = np.empty(new_cap, dtype=np.float64)
+        for new_i, old_i in enumerate(keep):
+            new_buf[new_i] = self._buf[old_i]
+            new_norms[new_i] = self._norms_buf[old_i]
+        self._buf = new_buf
+        self._norms_buf = new_norms
+        self._capacity = new_cap
+        self._entries = [self._entries[i] for i in keep]
+        self._count = new_count
+
+    def search_cosine(self, query_vector: list[float], top_k: int) -> list[tuple[str, float]]:
+        """Return the top-k most similar entries by cosine similarity.
+
+        Operates on zero-copy views of pre-built buffers, with row norms
+        pre-computed at insertion time. Returns an empty list when the index
+        contains no entries.
+
+        Args:
+            query_vector: The query embedding (must match index dimensionality).
+            top_k: Maximum number of results to return.
+
+        Returns:
+            List of ``(ref_id, score)`` tuples sorted by score descending,
+            limited to ``top_k`` entries.
+        """
+        if not self._entries:
+            return []
+
+        matrix = self._buf[: self._count]  # zero-copy view, O(1)
+        row_norms = self._norms_buf[: self._count]  # zero-copy view, O(1)
+        q = np.array(query_vector, dtype=np.float64)  # (D,)
+
+        dot_products = matrix @ q  # (N,) — single BLAS dgemv pass
+        q_norm = float(np.linalg.norm(q))
+        norms = row_norms * q_norm  # (N,) — elementwise, no matrix read
+        scores = dot_products / np.maximum(norms, 1e-10)  # (N,) cosine similarity
+
+        indices = np.argsort(-scores)[:top_k]
+        return [(self._entries[int(i)].ref_id, float(scores[int(i)])) for i in indices]

--- a/src/akgentic/tool/knowledge_graph/vector_index.py
+++ b/src/akgentic/tool/knowledge_graph/vector_index.py
@@ -102,11 +102,18 @@ class VectorIndex:
         self._norms_buf: np.ndarray = np.empty(0, dtype=np.float64)
 
     def _ensure_capacity(self, dim: int) -> None:
-        """Grow the backing buffers if the current row count equals capacity."""
+        """Grow the backing buffers if the current row count equals capacity.
+
+        Uses ``self._dim`` (the index's established dimensionality) for the new
+        buffer shape.  The ``dim`` parameter is used only when initializing the
+        first buffer (``self._dim == 0``), ensuring consistent column counts
+        across resizes regardless of the caller's argument.
+        """
         if self._count < self._capacity:
             return
+        effective_dim = self._dim if self._dim > 0 else dim
         new_cap = max(self._INITIAL_CAPACITY, self._capacity * self._GROWTH_FACTOR)
-        new_buf = np.empty((new_cap, dim), dtype=np.float64)
+        new_buf = np.empty((new_cap, effective_dim), dtype=np.float64)
         new_norms = np.empty(new_cap, dtype=np.float64)
         if self._count > 0:
             new_buf[: self._count] = self._buf[: self._count]

--- a/src/akgentic/tool/knowledge_graph/vector_index.py
+++ b/src/akgentic/tool/knowledge_graph/vector_index.py
@@ -166,6 +166,10 @@ class VectorIndex:
         self._entries = [self._entries[i] for i in keep]
         self._count = new_count
 
+    def __len__(self) -> int:
+        """Return the number of entries currently stored in the index."""
+        return self._count
+
     def search_cosine(self, query_vector: list[float], top_k: int) -> list[tuple[str, float]]:
         """Return the top-k most similar entries by cosine similarity.
 

--- a/tests/test_kg_actor.py
+++ b/tests/test_kg_actor.py
@@ -14,7 +14,7 @@ test methods. Same pattern as test_planning_actor.py.
 from __future__ import annotations
 
 import uuid
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from akgentic.core.actor_address import ActorAddress
@@ -33,6 +33,7 @@ from akgentic.tool.knowledge_graph.models import (
     ManageGraph,
     RelationCreate,
     RelationDelete,
+    SearchQuery,
 )
 
 # ---------------------------------------------------------------------------
@@ -833,23 +834,6 @@ class TestEmbeddingGracefulDegradation:
 # ---------------------------------------------------------------------------
 
 
-def _actor_with_vector_entries() -> tuple[KnowledgeGraphActor, list[str]]:
-    """Return actor with 3 seeded entities whose vectors are pre-populated."""
-    actor, mock_svc = _actor_with_mock_embed()
-    actor.update_graph(
-        ManageGraph(
-            create_entities=[
-                EntityCreate(name="Alice", entity_type="Person", description="Engineer"),
-                EntityCreate(name="Bob", entity_type="Person", description="Designer"),
-                EntityCreate(name="Charlie", entity_type="Person", description="Manager"),
-            ]
-        )
-    )
-    # Return the ref_ids of the three entities
-    ref_ids = [str(e.id) for e in actor.get_graph().entities]
-    return actor, ref_ids
-
-
 class TestVectorSearch:
     """AC-1, AC-5: vector search returns ranked results or empty on no embeddings."""
 
@@ -863,23 +847,14 @@ class TestVectorSearch:
                 ]
             )
         )
-        # Assign distinct scores: first entity scores 0.9, second 0.5
         entity_ids = [str(e.id) for e in actor.get_graph().entities]
-        actor._vector_index._entries[0]  # noqa: SLF001 (exists: added by _actor_with_mock_embed)
-        # Override search_cosine to return predictable scores
-        from unittest.mock import patch
-
         with patch.object(
             actor._vector_index,  # noqa: SLF001
             "search_cosine",
             return_value=[(entity_ids[0], 0.9), (entity_ids[1], 0.5)],
         ):
             mock_svc.embed.return_value = [_FAKE_VECTOR]
-            result = actor.search(
-                __import__(
-                    "akgentic.tool.knowledge_graph.models", fromlist=["SearchQuery"]
-                ).SearchQuery(query="engineer", top_k=2, mode="vector")
-            )
+            result = actor.search(SearchQuery(query="engineer", top_k=2, mode="vector"))
         assert len(result.hits) == 2
         assert result.hits[0].score == 0.9
         assert result.hits[1].score == 0.5
@@ -887,14 +862,12 @@ class TestVectorSearch:
 
     def test_vector_search_returns_empty_when_no_entries_in_index(self) -> None:
         actor = _actor()
-        # Empty graph, no vectors
-        from akgentic.tool.knowledge_graph.models import SearchQuery
-
         result = actor.search(SearchQuery(query="anything", top_k=5, mode="vector"))
         assert result.hits == []
 
-    def test_vector_search_returns_empty_when_service_unavailable(self) -> None:
-        actor = _actor()
+    def test_vector_search_returns_empty_when_embed_call_fails(self) -> None:
+        """Verify graceful empty result when embed() raises during vector search (AC-5)."""
+        actor, mock_svc = _actor_with_mock_embed()
         actor.update_graph(
             ManageGraph(
                 create_entities=[
@@ -902,9 +875,8 @@ class TestVectorSearch:
                 ]
             )
         )
-        # _embedding_svc is None (never set) and openai would fail → graceful empty
-        from akgentic.tool.knowledge_graph.models import SearchQuery
-
+        # Index has 1 entry; make embed raise during the search query
+        mock_svc.embed.side_effect = RuntimeError("API quota exceeded")
         result = actor.search(SearchQuery(query="Alice", top_k=5, mode="vector"))
         assert result.hits == []
 
@@ -941,17 +913,12 @@ class TestHybridSearch:
         actor.update_graph(
             ManageGraph(
                 create_entities=[
-                    EntityCreate(
-                        name="Alice", entity_type="Person", description="Engineer"
-                    )
+                    EntityCreate(name="Alice", entity_type="Person", description="Engineer")
                 ]
             )
         )
         # No embedding service → vector search returns empty → hybrid falls back
-        from akgentic.tool.knowledge_graph.models import SearchQuery
-
         result = actor.search(SearchQuery(query="Alice", top_k=5, mode="hybrid"))
-        # Keyword should find Alice
         assert len(result.hits) == 1
         assert result.hits[0].entity is not None
         assert result.hits[0].entity.name == "Alice"
@@ -961,21 +928,13 @@ class TestHybridSearch:
         alice_id = str(
             next(e for e in actor.get_graph().entities if e.name == "Alice").id
         )
-
-        from unittest.mock import patch
-
-        from akgentic.tool.knowledge_graph.models import SearchQuery
-
-        # Vector search also returns Alice → should appear once in merged result
         with patch.object(
             actor._vector_index,  # noqa: SLF001
             "search_cosine",
             return_value=[(alice_id, 0.8)],
         ):
             mock_svc.embed.return_value = [_FAKE_VECTOR]
-            result = actor.search(
-                SearchQuery(query="Alice", top_k=10, mode="hybrid")
-            )
+            result = actor.search(SearchQuery(query="Alice", top_k=10, mode="hybrid"))
         alice_hits = [h for h in result.hits if h.ref_id == alice_id]
         assert len(alice_hits) == 1, "Alice should appear exactly once (deduplication)"
 
@@ -984,11 +943,6 @@ class TestHybridSearch:
         entities = actor.get_graph().entities
         alice_id = str(next(e for e in entities if e.name == "Alice").id)
         bob_id = str(next(e for e in entities if e.name == "Bob").id)
-
-        from unittest.mock import patch
-
-        from akgentic.tool.knowledge_graph.models import SearchQuery
-
         # Alice matches keyword "login" AND vector; Bob matches vector only
         with patch.object(
             actor._vector_index,  # noqa: SLF001
@@ -996,9 +950,7 @@ class TestHybridSearch:
             return_value=[(alice_id, 0.8), (bob_id, 0.9)],
         ):
             mock_svc.embed.return_value = [_FAKE_VECTOR]
-            result = actor.search(
-                SearchQuery(query="login", top_k=5, mode="hybrid")
-            )
+            result = actor.search(SearchQuery(query="login", top_k=5, mode="hybrid"))
         # Alice: vector(0.8) + keyword_boost(0.5) = 1.3; Bob: vector only = 0.9
         ref_ids = [h.ref_id for h in result.hits]
         assert ref_ids[0] == alice_id, "Alice (vector+keyword) should rank above Bob (vector-only)"
@@ -1014,18 +966,11 @@ class TestHybridSearch:
             )
         )
         entity_ids = [str(e.id) for e in actor.get_graph().entities]
-
-        from unittest.mock import patch
-
-        from akgentic.tool.knowledge_graph.models import SearchQuery
-
         with patch.object(
             actor._vector_index,  # noqa: SLF001
             "search_cosine",
             return_value=[(eid, 0.5) for eid in entity_ids],
         ):
             mock_svc.embed.return_value = [_FAKE_VECTOR]
-            result = actor.search(
-                SearchQuery(query="desc", top_k=3, mode="hybrid")
-            )
+            result = actor.search(SearchQuery(query="desc", top_k=3, mode="hybrid"))
         assert len(result.hits) <= 3

--- a/tests/test_kg_actor.py
+++ b/tests/test_kg_actor.py
@@ -2,6 +2,9 @@
 
 Covers: all CRUD ops, cascade deletion, error collection, partial updates,
 state change notification, deduplication logic, singleton constants (Task 2.9).
+Also covers embedding wiring: entity/relation embedding on create, re-embedding
+on description update, removal on delete, graceful degradation on API failure
+(Task 5.11, Story 2.1 ACs 3-7).
 
 Pattern: Instantiate KnowledgeGraphActor() directly, call on_start(),
 test methods. Same pattern as test_planning_actor.py.
@@ -10,6 +13,7 @@ test methods. Same pattern as test_planning_actor.py.
 from __future__ import annotations
 
 import uuid
+from unittest.mock import MagicMock, patch
 
 import pytest
 from akgentic.core.actor_address import ActorAddress
@@ -605,3 +609,181 @@ class TestIsRootWiring:
         )
         root = actor.get_graph().entities[0]
         assert root.is_root is True
+
+
+# ---------------------------------------------------------------------------
+# Embedding wiring (Task 5.11, Story 2.1 ACs 3-7)
+# ---------------------------------------------------------------------------
+
+_FAKE_VECTOR = [0.1, 0.2, 0.3]
+_EMBED_MODULE = "akgentic.tool.knowledge_graph.kg_actor.EmbeddingService"
+
+
+def _actor_with_mock_embed() -> tuple[KnowledgeGraphActor, MagicMock]:
+    """Return (actor, mock_embed_method) with a pre-wired mock EmbeddingService."""
+    actor = _actor()
+    mock_svc = MagicMock()
+    mock_svc.embed.return_value = [_FAKE_VECTOR]
+    actor._embedding_svc = mock_svc  # inject mock directly, bypassing lazy init
+    return actor, mock_svc
+
+
+class TestEmbeddingOnCreate:
+    """AC-3, AC-4: embedding called when entities/relations are created."""
+
+    def test_embedding_called_on_entity_create(self) -> None:
+        actor, mock_svc = _actor_with_mock_embed()
+        actor.update_graph(
+            ManageGraph(
+                create_entities=[EntityCreate(name="Alice", entity_type="Person", description="Eng")]
+            )
+        )
+        mock_svc.embed.assert_called_once()
+        call_args = mock_svc.embed.call_args[0][0]
+        assert "Alice" in call_args[0]
+        assert "Eng" in call_args[0]
+
+    def test_embedding_called_on_relation_create_with_description(self) -> None:
+        actor, mock_svc = _actor_with_mock_embed()
+        _seed_entities(actor)
+        mock_svc.reset_mock()
+        actor.update_graph(
+            ManageGraph(
+                create_relations=[
+                    RelationCreate(
+                        from_entity="Alice",
+                        to_entity="Bob",
+                        relation_type="knows",
+                        description="long colleagues",
+                    )
+                ]
+            )
+        )
+        mock_svc.embed.assert_called_once()
+        call_args = mock_svc.embed.call_args[0][0]
+        assert "long colleagues" in call_args[0]
+
+    def test_embedding_skipped_on_relation_create_empty_description(self) -> None:
+        actor, mock_svc = _actor_with_mock_embed()
+        _seed_entities(actor)
+        mock_svc.reset_mock()
+        actor.update_graph(
+            ManageGraph(
+                create_relations=[
+                    RelationCreate(from_entity="Alice", to_entity="Bob", relation_type="knows")
+                ]
+            )
+        )
+        mock_svc.embed.assert_not_called()
+
+
+class TestEmbeddingOnUpdate:
+    """AC-5: re-embedding on description change."""
+
+    def test_embedding_updated_on_description_change(self) -> None:
+        actor, mock_svc = _actor_with_mock_embed()
+        actor.update_graph(
+            ManageGraph(
+                create_entities=[EntityCreate(name="Alice", entity_type="Person", description="Eng")]
+            )
+        )
+        embed_count_before = mock_svc.embed.call_count
+        actor.update_graph(
+            ManageGraph(update_entities=[EntityUpdate(name="Alice", description="Senior Eng")])
+        )
+        assert mock_svc.embed.call_count == embed_count_before + 1
+        # Verify the new description is embedded, not the old one
+        last_call = mock_svc.embed.call_args[0][0]
+        assert "Senior Eng" in last_call[0]
+
+    def test_no_re_embedding_when_description_unchanged(self) -> None:
+        actor, mock_svc = _actor_with_mock_embed()
+        actor.update_graph(
+            ManageGraph(
+                create_entities=[EntityCreate(name="Alice", entity_type="Person", description="Eng")]
+            )
+        )
+        embed_count_before = mock_svc.embed.call_count
+        # Update entity_type only — no description change
+        actor.update_graph(
+            ManageGraph(update_entities=[EntityUpdate(name="Alice", entity_type="Engineer")])
+        )
+        assert mock_svc.embed.call_count == embed_count_before
+
+
+class TestEmbeddingOnDelete:
+    """AC-6: embedding removed when entities/relations are deleted."""
+
+    def test_entity_embedding_removed_on_delete(self) -> None:
+        actor, mock_svc = _actor_with_mock_embed()
+        actor.update_graph(
+            ManageGraph(
+                create_entities=[EntityCreate(name="Alice", entity_type="Person", description="Eng")]
+            )
+        )
+        # Check an embedding was stored
+        assert len(actor._vector_index._entries) == 1
+
+        actor.update_graph(ManageGraph(delete_entities=["Alice"]))
+        assert len(actor._vector_index._entries) == 0
+
+    def test_relation_embedding_removed_on_delete(self) -> None:
+        actor, mock_svc = _actor_with_mock_embed()
+        _seed_entities(actor)
+        actor.update_graph(
+            ManageGraph(
+                create_relations=[
+                    RelationCreate(
+                        from_entity="Alice",
+                        to_entity="Bob",
+                        relation_type="knows",
+                        description="old friends",
+                    )
+                ]
+            )
+        )
+        # 2 entity embeddings + 1 relation embedding
+        assert len(actor._vector_index._entries) == 3
+
+        actor.update_graph(
+            ManageGraph(
+                delete_relations=[
+                    RelationDelete(from_entity="Alice", to_entity="Bob", relation_type="knows")
+                ]
+            )
+        )
+        assert len(actor._vector_index._entries) == 2
+
+
+class TestEmbeddingGracefulDegradation:
+    """AC-7: embedding failures do not block CRUD operations."""
+
+    def test_embedding_failure_does_not_block_entity_create(self) -> None:
+        actor, mock_svc = _actor_with_mock_embed()
+        mock_svc.embed.side_effect = RuntimeError("API key invalid")
+        result = actor.update_graph(
+            ManageGraph(
+                create_entities=[EntityCreate(name="Alice", entity_type="Person", description="Eng")]
+            )
+        )
+        assert result == "Done"
+        assert len(actor.get_graph().entities) == 1
+
+    def test_embedding_failure_does_not_block_relation_create(self) -> None:
+        actor, mock_svc = _actor_with_mock_embed()
+        _seed_entities(actor)
+        mock_svc.embed.side_effect = RuntimeError("API timeout")
+        result = actor.update_graph(
+            ManageGraph(
+                create_relations=[
+                    RelationCreate(
+                        from_entity="Alice",
+                        to_entity="Bob",
+                        relation_type="knows",
+                        description="desc",
+                    )
+                ]
+            )
+        )
+        assert result == "Done"
+        assert len(actor.get_graph().relations) == 1

--- a/tests/test_kg_actor.py
+++ b/tests/test_kg_actor.py
@@ -974,3 +974,217 @@ class TestHybridSearch:
             mock_svc.embed.return_value = [_FAKE_VECTOR]
             result = actor.search(SearchQuery(query="desc", top_k=3, mode="hybrid"))
         assert len(result.hits) <= 3
+
+
+# ---------------------------------------------------------------------------
+# Search expansion: include_neighbors, include_edges, find_paths (Story 3.1, ACs 2-5)
+# ---------------------------------------------------------------------------
+
+
+def _seed_expansion_graph(actor: KnowledgeGraphActor) -> None:
+    """Populate a test graph for search expansion tests.
+
+    Graph topology:
+        Alice --KNOWS--> Bob
+        Alice --WORKS_AT--> Corp
+        Bob --WORKS_AT--> Corp
+        Corp --LOCATED_IN--> City
+        Dave --KNOWS--> Eve   (disconnected island)
+    """
+    actor.update_graph(
+        ManageGraph(
+            create_entities=[
+                EntityCreate(name="Alice", entity_type="Person", description="alice engineer"),
+                EntityCreate(name="Bob", entity_type="Person", description="bob designer"),
+                EntityCreate(name="Corp", entity_type="Organization", description="tech corporation"),
+                EntityCreate(name="City", entity_type="Location", description="metro city"),
+                EntityCreate(name="Dave", entity_type="Person", description="dave manager"),
+                EntityCreate(name="Eve", entity_type="Person", description="eve analyst"),
+            ],
+            create_relations=[
+                RelationCreate(from_entity="Alice", to_entity="Bob", relation_type="KNOWS"),
+                RelationCreate(from_entity="Alice", to_entity="Corp", relation_type="WORKS_AT"),
+                RelationCreate(from_entity="Bob", to_entity="Corp", relation_type="WORKS_AT"),
+                RelationCreate(from_entity="Corp", to_entity="City", relation_type="LOCATED_IN"),
+                RelationCreate(from_entity="Dave", to_entity="Eve", relation_type="KNOWS"),
+            ],
+        )
+    )
+
+
+class TestSearchIncludeNeighbors:
+    """AC-2: include_neighbors=True returns 1-hop neighbors of entity hits."""
+
+    def test_include_neighbors_returns_1hop_neighbors(self) -> None:
+        actor = _actor()
+        _seed_expansion_graph(actor)
+        result = actor.search(SearchQuery(query="alice engineer", mode="keyword", include_neighbors=True))
+        entity_hit_names = {h.entity.name for h in result.hits if h.entity}
+        assert "Alice" in entity_hit_names
+        # Alice's neighbors: Bob (KNOWS) and Corp (WORKS_AT)
+        neighbor_names = {e.name for e in result.neighbors}
+        assert "Bob" in neighbor_names
+        assert "Corp" in neighbor_names
+        # Neighbors should not include Alice herself
+        assert "Alice" not in neighbor_names
+
+    def test_include_neighbors_excludes_entities_in_hits(self) -> None:
+        """Neighbors should not duplicate entities already in hits."""
+        actor = _actor()
+        _seed_expansion_graph(actor)
+        # Search "alice" matches Alice (entity hit)
+        result = actor.search(SearchQuery(query="alice", mode="keyword", include_neighbors=True))
+        hit_names = {h.entity.name for h in result.hits if h.entity}
+        neighbor_names = {e.name for e in result.neighbors}
+        # No overlap between hits and neighbors
+        assert not (hit_names & neighbor_names)
+
+    def test_include_neighbors_no_entity_hits_returns_empty_neighbors(self) -> None:
+        actor = _actor()
+        _seed_expansion_graph(actor)
+        # Search for something that only matches relations (by relation_type)
+        result = actor.search(SearchQuery(query="zzz_no_match", mode="keyword", include_neighbors=True))
+        assert result.neighbors == []
+
+    def test_include_neighbors_false_returns_empty(self) -> None:
+        """Default behavior: no neighbors expansion."""
+        actor = _actor()
+        _seed_expansion_graph(actor)
+        result = actor.search(SearchQuery(query="alice", mode="keyword"))
+        assert result.neighbors == []
+
+
+class TestSearchIncludeEdges:
+    """AC-3: include_edges=True returns all relations connected to entity hits."""
+
+    def test_include_edges_returns_connected_relations(self) -> None:
+        actor = _actor()
+        _seed_expansion_graph(actor)
+        result = actor.search(SearchQuery(query="alice engineer", mode="keyword", include_edges=True))
+        entity_hit_names = {h.entity.name for h in result.hits if h.entity}
+        assert "Alice" in entity_hit_names
+        # Alice's relations: Alice→Bob (KNOWS), Alice→Corp (WORKS_AT)
+        rel_types = {r.relation_type for r in result.connected_relations}
+        assert "KNOWS" in rel_types
+        assert "WORKS_AT" in rel_types
+
+    def test_include_edges_deduplicates_relations(self) -> None:
+        """When multiple entity hits share a relation, it appears only once."""
+        actor = _actor()
+        _seed_expansion_graph(actor)
+        # Both Alice and Bob are connected via Corp's WORKS_AT relation
+        result = actor.search(
+            SearchQuery(query="designer", mode="keyword", include_edges=True)
+        )
+        # Find all relation IDs — should be unique
+        rel_ids = [str(r.id) for r in result.connected_relations]
+        assert len(rel_ids) == len(set(rel_ids))
+
+    def test_include_edges_false_returns_empty(self) -> None:
+        actor = _actor()
+        _seed_expansion_graph(actor)
+        result = actor.search(SearchQuery(query="alice", mode="keyword"))
+        assert result.connected_relations == []
+
+
+class TestSearchFindPaths:
+    """AC-4, AC-5: find_paths computes BFS paths between top 5 entity hits."""
+
+    def test_find_paths_with_5_entity_hits(self) -> None:
+        """find_paths=True with 5+ entity hits finds paths between top 5."""
+        actor = _actor()
+        # Create 5 connected entities
+        actor.update_graph(
+            ManageGraph(
+                create_entities=[
+                    EntityCreate(name=f"Node{i}", entity_type="T", description="node target")
+                    for i in range(5)
+                ],
+                create_relations=[
+                    RelationCreate(from_entity=f"Node{i}", to_entity=f"Node{i+1}", relation_type="LINKS")
+                    for i in range(4)
+                ],
+            )
+        )
+        result = actor.search(SearchQuery(query="node target", mode="keyword", find_paths=True))
+        entity_hits = [h for h in result.hits if h.entity]
+        assert len(entity_hits) == 5
+        # Should find paths between connected nodes
+        assert len(result.paths) > 0
+
+    def test_find_paths_fewer_than_2_hits_returns_empty(self) -> None:
+        """AC-5: fewer than 2 entity hits → empty paths."""
+        actor = _actor()
+        actor.update_graph(
+            ManageGraph(
+                create_entities=[
+                    EntityCreate(name="OnlyOne", entity_type="T", description="unique item xyz123")
+                ]
+            )
+        )
+        result = actor.search(SearchQuery(query="unique item xyz123", mode="keyword", find_paths=True))
+        entity_hits = [h for h in result.hits if h.entity]
+        assert len(entity_hits) == 1
+        assert result.paths == []
+
+    def test_find_paths_max_10_pairs(self) -> None:
+        """find_paths uses top 5 entities → max C(5,2) = 10 pairs."""
+        actor = _actor()
+        # Create 6 entities all matching but only top 5 used
+        actor.update_graph(
+            ManageGraph(
+                create_entities=[
+                    EntityCreate(name=f"N{i}", entity_type="T", description="path target")
+                    for i in range(6)
+                ],
+                create_relations=[
+                    RelationCreate(from_entity=f"N{i}", to_entity=f"N{i+1}", relation_type="LINKS")
+                    for i in range(5)
+                ],
+            )
+        )
+        result = actor.search(SearchQuery(query="path target", mode="keyword", find_paths=True))
+        # Max 10 paths (C(5,2) = 10 pairs)
+        assert len(result.paths) <= 10
+
+    def test_find_paths_no_path_between_disconnected_entities(self) -> None:
+        """Disconnected entities: path not found → silently skipped."""
+        actor = _actor()
+        _seed_expansion_graph(actor)
+        # Alice-Corp-Bob are connected; Dave-Eve are disconnected from them
+        # Search for "person" matches Alice, Bob, Dave, Eve → paths between disconnected pairs skipped
+        result = actor.search(SearchQuery(query="person", mode="keyword", find_paths=True))
+        entity_hit_names = {h.entity.name for h in result.hits if h.entity}
+        # We should have multiple entity hits but paths only between reachable pairs
+        assert isinstance(result.paths, list)
+        # Paths are returned (may be empty if none reachable) but no exception
+
+    def test_find_paths_false_returns_empty(self) -> None:
+        actor = _actor()
+        _seed_expansion_graph(actor)
+        result = actor.search(SearchQuery(query="alice", mode="keyword"))
+        assert result.paths == []
+
+    def test_find_paths_path_is_alternating_entity_relation_sequence(self) -> None:
+        """Paths contain alternating [Entity, Relation, Entity, ...] sequences."""
+        from akgentic.tool.knowledge_graph.models import Entity, Relation
+        actor = _actor()
+        actor.update_graph(
+            ManageGraph(
+                create_entities=[
+                    EntityCreate(name="Start", entity_type="T", description="route node"),
+                    EntityCreate(name="End", entity_type="T", description="route node"),
+                ],
+                create_relations=[
+                    RelationCreate(from_entity="Start", to_entity="End", relation_type="CONNECTS"),
+                ],
+            )
+        )
+        result = actor.search(SearchQuery(query="route node", mode="keyword", find_paths=True))
+        assert len(result.paths) == 1
+        path = result.paths[0]
+        # [Entity, Relation, Entity] for direct connection
+        assert len(path) == 3
+        assert isinstance(path[0], Entity)
+        assert isinstance(path[1], Relation)
+        assert isinstance(path[2], Entity)

--- a/tests/test_kg_actor.py
+++ b/tests/test_kg_actor.py
@@ -5,6 +5,7 @@ state change notification, deduplication logic, singleton constants (Task 2.9).
 Also covers embedding wiring: entity/relation embedding on create, re-embedding
 on description update, removal on delete, graceful degradation on API failure
 (Task 5.11, Story 2.1 ACs 3-7).
+Also covers vector search and hybrid search (Story 2.2 ACs 1-5).
 
 Pattern: Instantiate KnowledgeGraphActor() directly, call on_start(),
 test methods. Same pattern as test_planning_actor.py.
@@ -825,3 +826,206 @@ class TestEmbeddingGracefulDegradation:
         )
         assert result == "Done"
         assert len(actor.get_graph().relations) == 1
+
+
+# ---------------------------------------------------------------------------
+# Vector search (Story 2.2 Task 1, ACs 1, 3, 5)
+# ---------------------------------------------------------------------------
+
+
+def _actor_with_vector_entries() -> tuple[KnowledgeGraphActor, list[str]]:
+    """Return actor with 3 seeded entities whose vectors are pre-populated."""
+    actor, mock_svc = _actor_with_mock_embed()
+    actor.update_graph(
+        ManageGraph(
+            create_entities=[
+                EntityCreate(name="Alice", entity_type="Person", description="Engineer"),
+                EntityCreate(name="Bob", entity_type="Person", description="Designer"),
+                EntityCreate(name="Charlie", entity_type="Person", description="Manager"),
+            ]
+        )
+    )
+    # Return the ref_ids of the three entities
+    ref_ids = [str(e.id) for e in actor.get_graph().entities]
+    return actor, ref_ids
+
+
+class TestVectorSearch:
+    """AC-1, AC-5: vector search returns ranked results or empty on no embeddings."""
+
+    def test_vector_search_returns_top_k_ranked_by_score(self) -> None:
+        actor, mock_svc = _actor_with_mock_embed()
+        actor.update_graph(
+            ManageGraph(
+                create_entities=[
+                    EntityCreate(name="Alice", entity_type="Person", description="Engineer"),
+                    EntityCreate(name="Bob", entity_type="Person", description="Designer"),
+                ]
+            )
+        )
+        # Assign distinct scores: first entity scores 0.9, second 0.5
+        entity_ids = [str(e.id) for e in actor.get_graph().entities]
+        actor._vector_index._entries[0]  # noqa: SLF001 (exists: added by _actor_with_mock_embed)
+        # Override search_cosine to return predictable scores
+        from unittest.mock import patch
+
+        with patch.object(
+            actor._vector_index,  # noqa: SLF001
+            "search_cosine",
+            return_value=[(entity_ids[0], 0.9), (entity_ids[1], 0.5)],
+        ):
+            mock_svc.embed.return_value = [_FAKE_VECTOR]
+            result = actor.search(
+                __import__(
+                    "akgentic.tool.knowledge_graph.models", fromlist=["SearchQuery"]
+                ).SearchQuery(query="engineer", top_k=2, mode="vector")
+            )
+        assert len(result.hits) == 2
+        assert result.hits[0].score == 0.9
+        assert result.hits[1].score == 0.5
+        assert result.hits[0].entity is not None
+
+    def test_vector_search_returns_empty_when_no_entries_in_index(self) -> None:
+        actor = _actor()
+        # Empty graph, no vectors
+        from akgentic.tool.knowledge_graph.models import SearchQuery
+
+        result = actor.search(SearchQuery(query="anything", top_k=5, mode="vector"))
+        assert result.hits == []
+
+    def test_vector_search_returns_empty_when_service_unavailable(self) -> None:
+        actor = _actor()
+        actor.update_graph(
+            ManageGraph(
+                create_entities=[
+                    EntityCreate(name="Alice", entity_type="Person", description="Eng")
+                ]
+            )
+        )
+        # _embedding_svc is None (never set) and openai would fail → graceful empty
+        from akgentic.tool.knowledge_graph.models import SearchQuery
+
+        result = actor.search(SearchQuery(query="Alice", top_k=5, mode="vector"))
+        assert result.hits == []
+
+
+# ---------------------------------------------------------------------------
+# Hybrid search (Story 2.2 Task 2, ACs 2, 4)
+# ---------------------------------------------------------------------------
+
+
+class TestHybridSearch:
+    """AC-2, AC-4: hybrid merges keyword+vector, falls back to keyword when no embeddings."""
+
+    def _setup_actor_with_known_vectors(
+        self,
+    ) -> tuple[KnowledgeGraphActor, MagicMock]:
+        """Actor with Alice + Bob; mock embed returns fixed vectors."""
+        actor, mock_svc = _actor_with_mock_embed()
+        actor.update_graph(
+            ManageGraph(
+                create_entities=[
+                    EntityCreate(
+                        name="Alice", entity_type="Person", description="Engineer login"
+                    ),
+                    EntityCreate(
+                        name="Bob", entity_type="Person", description="Designer security"
+                    ),
+                ]
+            )
+        )
+        return actor, mock_svc
+
+    def test_hybrid_falls_back_to_keyword_when_no_embeddings(self) -> None:
+        actor = _actor()
+        actor.update_graph(
+            ManageGraph(
+                create_entities=[
+                    EntityCreate(
+                        name="Alice", entity_type="Person", description="Engineer"
+                    )
+                ]
+            )
+        )
+        # No embedding service → vector search returns empty → hybrid falls back
+        from akgentic.tool.knowledge_graph.models import SearchQuery
+
+        result = actor.search(SearchQuery(query="Alice", top_k=5, mode="hybrid"))
+        # Keyword should find Alice
+        assert len(result.hits) == 1
+        assert result.hits[0].entity is not None
+        assert result.hits[0].entity.name == "Alice"
+
+    def test_hybrid_deduplicates_by_ref_id(self) -> None:
+        actor, mock_svc = self._setup_actor_with_known_vectors()
+        alice_id = str(
+            next(e for e in actor.get_graph().entities if e.name == "Alice").id
+        )
+
+        from unittest.mock import patch
+
+        from akgentic.tool.knowledge_graph.models import SearchQuery
+
+        # Vector search also returns Alice → should appear once in merged result
+        with patch.object(
+            actor._vector_index,  # noqa: SLF001
+            "search_cosine",
+            return_value=[(alice_id, 0.8)],
+        ):
+            mock_svc.embed.return_value = [_FAKE_VECTOR]
+            result = actor.search(
+                SearchQuery(query="Alice", top_k=10, mode="hybrid")
+            )
+        alice_hits = [h for h in result.hits if h.ref_id == alice_id]
+        assert len(alice_hits) == 1, "Alice should appear exactly once (deduplication)"
+
+    def test_hybrid_combined_hits_rank_higher_than_vector_only(self) -> None:
+        actor, mock_svc = self._setup_actor_with_known_vectors()
+        entities = actor.get_graph().entities
+        alice_id = str(next(e for e in entities if e.name == "Alice").id)
+        bob_id = str(next(e for e in entities if e.name == "Bob").id)
+
+        from unittest.mock import patch
+
+        from akgentic.tool.knowledge_graph.models import SearchQuery
+
+        # Alice matches keyword "login" AND vector; Bob matches vector only
+        with patch.object(
+            actor._vector_index,  # noqa: SLF001
+            "search_cosine",
+            return_value=[(alice_id, 0.8), (bob_id, 0.9)],
+        ):
+            mock_svc.embed.return_value = [_FAKE_VECTOR]
+            result = actor.search(
+                SearchQuery(query="login", top_k=5, mode="hybrid")
+            )
+        # Alice: vector(0.8) + keyword_boost(0.5) = 1.3; Bob: vector only = 0.9
+        ref_ids = [h.ref_id for h in result.hits]
+        assert ref_ids[0] == alice_id, "Alice (vector+keyword) should rank above Bob (vector-only)"
+
+    def test_hybrid_top_k_limits_results(self) -> None:
+        actor, mock_svc = _actor_with_mock_embed()
+        actor.update_graph(
+            ManageGraph(
+                create_entities=[
+                    EntityCreate(name=f"Entity{i}", entity_type="T", description=f"desc {i}")
+                    for i in range(10)
+                ]
+            )
+        )
+        entity_ids = [str(e.id) for e in actor.get_graph().entities]
+
+        from unittest.mock import patch
+
+        from akgentic.tool.knowledge_graph.models import SearchQuery
+
+        with patch.object(
+            actor._vector_index,  # noqa: SLF001
+            "search_cosine",
+            return_value=[(eid, 0.5) for eid in entity_ids],
+        ):
+            mock_svc.embed.return_value = [_FAKE_VECTOR]
+            result = actor.search(
+                SearchQuery(query="desc", top_k=3, mode="hybrid")
+            )
+        assert len(result.hits) <= 3

--- a/tests/test_kg_actor.py
+++ b/tests/test_kg_actor.py
@@ -13,7 +13,7 @@ test methods. Same pattern as test_planning_actor.py.
 from __future__ import annotations
 
 import uuid
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 from akgentic.core.actor_address import ActorAddress
@@ -23,6 +23,7 @@ from akgentic.tool.knowledge_graph.kg_actor import (
     KG_ACTOR_NAME,
     KG_ACTOR_ROLE,
     KnowledgeGraphActor,
+    KnowledgeGraphConfig,
 )
 from akgentic.tool.knowledge_graph.models import (
     EntityCreate,
@@ -117,6 +118,33 @@ def _seed_with_relation(actor: KnowledgeGraphActor) -> None:
             ],
         )
     )
+
+
+# ---------------------------------------------------------------------------
+# KnowledgeGraphConfig (AC-1)
+# ---------------------------------------------------------------------------
+
+
+class TestKnowledgeGraphConfig:
+    """AC-1: KnowledgeGraphConfig extends BaseConfig with embedding settings."""
+
+    def test_default_embedding_model(self) -> None:
+        cfg = KnowledgeGraphConfig(name="test", role="ToolActor")
+        assert cfg.embedding_model == "text-embedding-3-small"
+
+    def test_default_embedding_provider(self) -> None:
+        cfg = KnowledgeGraphConfig(name="test", role="ToolActor")
+        assert cfg.embedding_provider == "openai"
+
+    def test_custom_embedding_model(self) -> None:
+        cfg = KnowledgeGraphConfig(
+            name="test", role="ToolActor", embedding_model="text-embedding-ada-002"
+        )
+        assert cfg.embedding_model == "text-embedding-ada-002"
+
+    def test_azure_provider(self) -> None:
+        cfg = KnowledgeGraphConfig(name="test", role="ToolActor", embedding_provider="azure")
+        assert cfg.embedding_provider == "azure"
 
 
 # ---------------------------------------------------------------------------
@@ -635,7 +663,9 @@ class TestEmbeddingOnCreate:
         actor, mock_svc = _actor_with_mock_embed()
         actor.update_graph(
             ManageGraph(
-                create_entities=[EntityCreate(name="Alice", entity_type="Person", description="Eng")]
+                create_entities=[
+                    EntityCreate(name="Alice", entity_type="Person", description="Eng")
+                ]
             )
         )
         mock_svc.embed.assert_called_once()
@@ -684,7 +714,9 @@ class TestEmbeddingOnUpdate:
         actor, mock_svc = _actor_with_mock_embed()
         actor.update_graph(
             ManageGraph(
-                create_entities=[EntityCreate(name="Alice", entity_type="Person", description="Eng")]
+                create_entities=[
+                    EntityCreate(name="Alice", entity_type="Person", description="Eng")
+                ]
             )
         )
         embed_count_before = mock_svc.embed.call_count
@@ -700,7 +732,9 @@ class TestEmbeddingOnUpdate:
         actor, mock_svc = _actor_with_mock_embed()
         actor.update_graph(
             ManageGraph(
-                create_entities=[EntityCreate(name="Alice", entity_type="Person", description="Eng")]
+                create_entities=[
+                    EntityCreate(name="Alice", entity_type="Person", description="Eng")
+                ]
             )
         )
         embed_count_before = mock_svc.embed.call_count
@@ -718,7 +752,9 @@ class TestEmbeddingOnDelete:
         actor, mock_svc = _actor_with_mock_embed()
         actor.update_graph(
             ManageGraph(
-                create_entities=[EntityCreate(name="Alice", entity_type="Person", description="Eng")]
+                create_entities=[
+                    EntityCreate(name="Alice", entity_type="Person", description="Eng")
+                ]
             )
         )
         # Check an embedding was stored
@@ -763,7 +799,9 @@ class TestEmbeddingGracefulDegradation:
         mock_svc.embed.side_effect = RuntimeError("API key invalid")
         result = actor.update_graph(
             ManageGraph(
-                create_entities=[EntityCreate(name="Alice", entity_type="Person", description="Eng")]
+                create_entities=[
+                    EntityCreate(name="Alice", entity_type="Person", description="Eng")
+                ]
             )
         )
         assert result == "Done"

--- a/tests/test_kg_models.py
+++ b/tests/test_kg_models.py
@@ -14,12 +14,16 @@ from akgentic.tool.knowledge_graph.models import (
     Entity,
     EntityCreate,
     EntityUpdate,
+    GetGraphQuery,
     KnowledgeGraph,
     KnowledgeGraphState,
     ManageGraph,
+    PathStep,
     Relation,
     RelationCreate,
     RelationDelete,
+    SearchQuery,
+    SearchResult,
 )
 
 # ---------------------------------------------------------------------------
@@ -246,6 +250,150 @@ class TestKnowledgeGraph:
 # ---------------------------------------------------------------------------
 # KnowledgeGraphState (Task 1.6)
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# PathStep model (Story 3.1, Task 1.1)
+# ---------------------------------------------------------------------------
+
+
+class TestPathStep:
+    """AC-1: PathStep model for directed traversal waypoints."""
+
+    def test_construction(self) -> None:
+        ps = PathStep(relation_type="HAS_COMPONENT", to_entity="ComponentA")
+        assert ps.relation_type == "HAS_COMPONENT"
+        assert ps.to_entity == "ComponentA"
+
+    def test_required_fields_enforced(self) -> None:
+        with pytest.raises(Exception):  # noqa: B017
+            PathStep()  # type: ignore[call-arg]
+
+    def test_serialization_round_trip(self) -> None:
+        ps = PathStep(relation_type="DEPENDS_ON", to_entity="ServiceB")
+        restored = PathStep.model_validate(ps.model_dump())
+        assert restored.relation_type == ps.relation_type
+        assert restored.to_entity == ps.to_entity
+
+    def test_list_of_path_steps(self) -> None:
+        steps = [
+            PathStep(relation_type="HAS_COMPONENT", to_entity="ComponentA"),
+            PathStep(relation_type="DEPENDS_ON", to_entity="ServiceB"),
+        ]
+        assert len(steps) == 2
+
+
+class TestGetGraphQueryWithPath:
+    """AC-1: GetGraphQuery path field (Story 3.1, Task 1.2)."""
+
+    def test_path_defaults_empty(self) -> None:
+        q = GetGraphQuery()
+        assert q.path == []
+
+    def test_path_with_steps(self) -> None:
+        q = GetGraphQuery(
+            entity_names=["Device"],
+            path=[PathStep(relation_type="HAS_COMPONENT", to_entity="ComponentA")],
+            depth=2,
+        )
+        assert len(q.path) == 1
+        assert q.path[0].relation_type == "HAS_COMPONENT"
+        assert q.path[0].to_entity == "ComponentA"
+        assert q.depth == 2
+
+    def test_path_serialization_round_trip(self) -> None:
+        q = GetGraphQuery(
+            entity_names=["A"],
+            path=[PathStep(relation_type="R", to_entity="B")],
+        )
+        restored = GetGraphQuery.model_validate(q.model_dump())
+        assert len(restored.path) == 1
+        assert restored.path[0].relation_type == "R"
+        assert restored.path[0].to_entity == "B"
+
+
+# ---------------------------------------------------------------------------
+# SearchQuery Epic 3 expansion fields (Story 3.1, Task 2.1)
+# ---------------------------------------------------------------------------
+
+
+class TestSearchQueryEpic3Fields:
+    """AC-2, AC-3, AC-4: SearchQuery expansion fields default to False."""
+
+    def test_include_neighbors_defaults_false(self) -> None:
+        sq = SearchQuery(query="test")
+        assert sq.include_neighbors is False
+
+    def test_include_edges_defaults_false(self) -> None:
+        sq = SearchQuery(query="test")
+        assert sq.include_edges is False
+
+    def test_find_paths_defaults_false(self) -> None:
+        sq = SearchQuery(query="test")
+        assert sq.find_paths is False
+
+    def test_expansion_fields_can_be_set(self) -> None:
+        sq = SearchQuery(query="test", include_neighbors=True, include_edges=True, find_paths=True)
+        assert sq.include_neighbors is True
+        assert sq.include_edges is True
+        assert sq.find_paths is True
+
+    def test_serialization_round_trip_with_expansion_fields(self) -> None:
+        sq = SearchQuery(query="x", include_neighbors=True, find_paths=True)
+        restored = SearchQuery.model_validate(sq.model_dump())
+        assert restored.include_neighbors is True
+        assert restored.find_paths is True
+        assert restored.include_edges is False
+
+
+# ---------------------------------------------------------------------------
+# SearchResult Epic 3 expansion fields (Story 3.1, Task 2.2)
+# ---------------------------------------------------------------------------
+
+
+class TestSearchResultEpic3Fields:
+    """AC-2, AC-3, AC-4: SearchResult expansion fields default to empty."""
+
+    def test_neighbors_defaults_empty(self) -> None:
+        sr = SearchResult()
+        assert sr.neighbors == []
+
+    def test_connected_relations_defaults_empty(self) -> None:
+        sr = SearchResult()
+        assert sr.connected_relations == []
+
+    def test_paths_defaults_empty(self) -> None:
+        sr = SearchResult()
+        assert sr.paths == []
+
+    def test_neighbors_with_entities(self) -> None:
+        e = Entity(name="N", entity_type="T", description="d")
+        sr = SearchResult(neighbors=[e])
+        assert len(sr.neighbors) == 1
+        assert sr.neighbors[0].name == "N"
+
+    def test_connected_relations_with_data(self) -> None:
+        r = Relation(from_entity="A", to_entity="B", relation_type="R")
+        sr = SearchResult(connected_relations=[r])
+        assert len(sr.connected_relations) == 1
+
+    def test_paths_with_entity_relation_sequence(self) -> None:
+        e1 = Entity(name="A", entity_type="T", description="d")
+        r = Relation(from_entity="A", to_entity="B", relation_type="R")
+        e2 = Entity(name="B", entity_type="T", description="d")
+        sr = SearchResult(paths=[[e1, r, e2]])
+        assert len(sr.paths) == 1
+        assert len(sr.paths[0]) == 3
+
+    def test_serialization_round_trip_with_expansion_fields(self) -> None:
+        from akgentic.tool.knowledge_graph.models import SearchHit
+        hit = SearchHit(ref_type="entity", ref_id="x", score=1.0)
+        e = Entity(name="N", entity_type="T", description="d")
+        sr = SearchResult(hits=[hit], neighbors=[e])
+        restored = SearchResult.model_validate(sr.model_dump())
+        assert len(restored.hits) == 1
+        assert len(restored.neighbors) == 1
+        assert restored.neighbors[0].name == "N"
 
 
 class TestKnowledgeGraphState:

--- a/tests/test_kg_models.py
+++ b/tests/test_kg_models.py
@@ -395,6 +395,24 @@ class TestSearchResultEpic3Fields:
         assert len(restored.neighbors) == 1
         assert restored.neighbors[0].name == "N"
 
+    def test_paths_serialization_round_trip(self) -> None:
+        """Serialization round-trip for paths: list[list[Entity | Relation]]."""
+        e1 = Entity(name="A", entity_type="T", description="d1")
+        r = Relation(from_entity="A", to_entity="B", relation_type="LINKS")
+        e2 = Entity(name="B", entity_type="T", description="d2")
+        sr = SearchResult(paths=[[e1, r, e2]])
+        dumped = sr.model_dump()
+        restored = SearchResult.model_validate(dumped)
+        assert len(restored.paths) == 1
+        path = restored.paths[0]
+        assert len(path) == 3
+        assert isinstance(path[0], Entity)
+        assert isinstance(path[1], Relation)
+        assert isinstance(path[2], Entity)
+        assert path[0].name == "A"
+        assert path[1].relation_type == "LINKS"
+        assert path[2].name == "B"
+
 
 class TestKnowledgeGraphState:
     def test_default_knowledge_graph(self) -> None:

--- a/tests/test_kg_query.py
+++ b/tests/test_kg_query.py
@@ -837,3 +837,28 @@ class TestDirectedPathTraversal:
         # ComponentA → ServiceB (DEPENDS_ON) → DatabaseC (DEPENDS_ON)
         assert "ServiceB" in entity_names
         assert "DatabaseC" in entity_names
+
+    def test_multi_step_path_traversal(self) -> None:
+        """AC-1: Multi-step path (2 waypoints) navigates correctly through the graph."""
+        actor = _actor()
+        _seed_path_graph(actor)
+        # Device → HAS_COMPONENT → ComponentA → DEPENDS_ON → ServiceB, then depth=1
+        result = actor.get_graph(
+            GetGraphQuery(
+                entity_names=["Device"],
+                path=[
+                    PathStep(relation_type="HAS_COMPONENT", to_entity="ComponentA"),
+                    PathStep(relation_type="DEPENDS_ON", to_entity="ServiceB"),
+                ],
+                depth=1,
+            )
+        )
+        entity_names = {e.name for e in result.entities}
+        # All waypoint entities present
+        assert "Device" in entity_names
+        assert "ComponentA" in entity_names
+        assert "ServiceB" in entity_names
+        # depth=1 from ServiceB includes DatabaseC
+        assert "DatabaseC" in entity_names
+        # ComponentX is off Device (sibling branch), not reachable from ServiceB
+        assert "ComponentX" not in entity_names

--- a/tests/test_kg_query.py
+++ b/tests/test_kg_query.py
@@ -18,6 +18,7 @@ from akgentic.tool.knowledge_graph.models import (
     GetGraphQuery,
     GraphView,
     ManageGraph,
+    PathStep,
     Relation,
     RelationCreate,
     SearchHit,
@@ -701,3 +702,138 @@ class TestRootsOnly:
         import pytest
         with pytest.raises(Exception):  # noqa: B017
             GetGraphQuery(depth=-1)
+
+
+# ===========================================================================
+# Task 5 — Path traversal tests (Story 3.1, AC-1)
+# ===========================================================================
+
+
+def _seed_path_graph(actor: KnowledgeGraphActor) -> None:
+    """Populate a linear + branching test graph for path traversal tests.
+
+    Graph topology:
+        Device --HAS_COMPONENT--> ComponentA
+        ComponentA --DEPENDS_ON--> ServiceB
+        ServiceB --DEPENDS_ON--> DatabaseC
+        Device --ALSO_HAS--> ComponentX  (side branch)
+
+    5 entities, 4 relations.
+    """
+    actor.update_graph(
+        ManageGraph(
+            create_entities=[
+                EntityCreate(name="Device", entity_type="Hardware", description="Main device"),
+                EntityCreate(name="ComponentA", entity_type="Component", description="Primary component"),
+                EntityCreate(name="ServiceB", entity_type="Service", description="Backend service"),
+                EntityCreate(name="DatabaseC", entity_type="Database", description="Persistent store"),
+                EntityCreate(name="ComponentX", entity_type="Component", description="Secondary component"),
+            ],
+            create_relations=[
+                RelationCreate(from_entity="Device", to_entity="ComponentA", relation_type="HAS_COMPONENT"),
+                RelationCreate(from_entity="ComponentA", to_entity="ServiceB", relation_type="DEPENDS_ON"),
+                RelationCreate(from_entity="ServiceB", to_entity="DatabaseC", relation_type="DEPENDS_ON"),
+                RelationCreate(from_entity="Device", to_entity="ComponentX", relation_type="ALSO_HAS"),
+            ],
+        )
+    )
+
+
+class TestDirectedPathTraversal:
+    """AC-1: Directed path traversal via PathStep waypoints."""
+
+    def test_single_waypoint_depth_2(self) -> None:
+        """Device → HAS_COMPONENT → ComponentA, then depth=2 expands from ComponentA."""
+        actor = _actor()
+        _seed_path_graph(actor)
+        result = actor.get_graph(
+            GetGraphQuery(
+                entity_names=["Device"],
+                path=[PathStep(relation_type="HAS_COMPONENT", to_entity="ComponentA")],
+                depth=2,
+            )
+        )
+        entity_names = {e.name for e in result.entities}
+        # Device and ComponentA collected during waypoint walk
+        assert "Device" in entity_names
+        assert "ComponentA" in entity_names
+        # Depth=2 from ComponentA: ServiceB (1 hop), DatabaseC (2 hops)
+        assert "ServiceB" in entity_names
+        assert "DatabaseC" in entity_names
+        # ComponentX is a sibling of ComponentA (off Device), NOT from ComponentA
+        assert "ComponentX" not in entity_names
+
+    def test_missing_waypoint_returns_empty(self) -> None:
+        """Path traversal with wrong relation type returns empty GraphView."""
+        actor = _actor()
+        _seed_path_graph(actor)
+        result = actor.get_graph(
+            GetGraphQuery(
+                entity_names=["Device"],
+                path=[PathStep(relation_type="NONEXISTENT_REL", to_entity="ComponentA")],
+                depth=1,
+            )
+        )
+        assert result.entities == []
+        assert result.relations == []
+
+    def test_missing_target_entity_returns_empty(self) -> None:
+        """Path traversal targeting a non-existent entity returns empty."""
+        actor = _actor()
+        _seed_path_graph(actor)
+        result = actor.get_graph(
+            GetGraphQuery(
+                entity_names=["Device"],
+                path=[PathStep(relation_type="HAS_COMPONENT", to_entity="NoSuchEntity")],
+                depth=1,
+            )
+        )
+        assert result.entities == []
+        assert result.relations == []
+
+    def test_empty_entity_names_returns_empty(self) -> None:
+        """Path traversal with empty entity_names returns empty GraphView."""
+        actor = _actor()
+        _seed_path_graph(actor)
+        result = actor.get_graph(
+            GetGraphQuery(
+                entity_names=[],
+                path=[PathStep(relation_type="HAS_COMPONENT", to_entity="ComponentA")],
+                depth=1,
+            )
+        )
+        assert result.entities == []
+        assert result.relations == []
+
+    def test_depth_0_returns_only_terminal_entity(self) -> None:
+        """Path traversal with depth=0 returns only the terminal entity (no BFS expansion)."""
+        actor = _actor()
+        _seed_path_graph(actor)
+        result = actor.get_graph(
+            GetGraphQuery(
+                entity_names=["Device"],
+                path=[PathStep(relation_type="HAS_COMPONENT", to_entity="ComponentA")],
+                depth=0,
+            )
+        )
+        entity_names = {e.name for e in result.entities}
+        # Terminal is ComponentA; with depth=0 no expansion, but path entities are collected
+        assert "ComponentA" in entity_names
+        assert "ServiceB" not in entity_names
+
+    def test_relation_types_filter_applies_during_expansion(self) -> None:
+        """relation_types filter applies during BFS expansion phase, not waypoint phase."""
+        actor = _actor()
+        _seed_path_graph(actor)
+        result = actor.get_graph(
+            GetGraphQuery(
+                entity_names=["Device"],
+                path=[PathStep(relation_type="HAS_COMPONENT", to_entity="ComponentA")],
+                depth=2,
+                relation_types=["DEPENDS_ON"],  # filter during expansion
+            )
+        )
+        entity_names = {e.name for e in result.entities}
+        # ComponentA → ServiceB (DEPENDS_ON) → DatabaseC (DEPENDS_ON)
+        assert "ServiceB" in entity_names
+        assert "DatabaseC" in entity_names

--- a/tests/test_kg_vector_index.py
+++ b/tests/test_kg_vector_index.py
@@ -10,7 +10,6 @@ Covers:
 from __future__ import annotations
 
 import time
-import unittest.mock as mock
 from typing import Literal
 from unittest.mock import MagicMock, patch
 
@@ -153,7 +152,9 @@ class TestEmbeddingService:
 # ---------------------------------------------------------------------------
 
 
-def _make_entry(ref_id: str, vector: list[float], ref_type: Literal["entity", "relation"] = "entity") -> VectorEntry:
+def _make_entry(
+    ref_id: str, vector: list[float], ref_type: Literal["entity", "relation"] = "entity"
+) -> VectorEntry:
     """Factory for VectorEntry instances in tests."""
     return VectorEntry(ref_type=ref_type, ref_id=ref_id, text=f"text-{ref_id}", vector=vector)
 
@@ -224,7 +225,6 @@ class TestVectorIndexCosineSearch:
     def test_results_sorted_descending_by_score(self) -> None:
         idx = VectorIndex()
         # e1 is aligned, e2 is 45°, e3 is orthogonal
-        import math
         idx.add(_make_entry("e1", [1.0, 0.0]))
         idx.add(_make_entry("e2", [1.0, 1.0]))  # normalized scores 1/sqrt(2)
         idx.add(_make_entry("e3", [0.0, 1.0]))

--- a/tests/test_kg_vector_index.py
+++ b/tests/test_kg_vector_index.py
@@ -1,0 +1,270 @@
+"""Tests for EmbeddingService, VectorIndex, and VectorEntry.
+
+Covers:
+  - VectorEntry construction and field validation (Task 1.3)
+  - EmbeddingService: correct client selection and return shape (Task 2.7)
+  - VectorIndex: add/remove, cosine search, empty-index guard (Task 3.5)
+  - Performance: 1000-vector x 1536-dim cosine search < 1ms (NFR-KG-1, Task 3.5)
+"""
+
+from __future__ import annotations
+
+import time
+import unittest.mock as mock
+from typing import Literal
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from akgentic.tool.knowledge_graph.models import VectorEntry
+from akgentic.tool.knowledge_graph.vector_index import EmbeddingService, VectorIndex
+
+# ---------------------------------------------------------------------------
+# VectorEntry (Task 1.3)
+# ---------------------------------------------------------------------------
+
+
+class TestVectorEntry:
+    """AC-3, AC-4: VectorEntry construction and field validation."""
+
+    def test_construct_entity_entry(self) -> None:
+        entry = VectorEntry(
+            ref_type="entity",
+            ref_id="abc-123",
+            text="Alice: Software engineer",
+            vector=[0.1, 0.2, 0.3],
+        )
+        assert entry.ref_type == "entity"
+        assert entry.ref_id == "abc-123"
+        assert entry.text == "Alice: Software engineer"
+        assert entry.vector == [0.1, 0.2, 0.3]
+
+    def test_construct_relation_entry(self) -> None:
+        entry = VectorEntry(
+            ref_type="relation",
+            ref_id="def-456",
+            text="Alice knows Bob: long colleagues",
+            vector=[0.5, 0.6],
+        )
+        assert entry.ref_type == "relation"
+
+    def test_invalid_ref_type_rejected(self) -> None:
+        with pytest.raises(Exception):
+            VectorEntry(
+                ref_type="unknown",  # type: ignore[arg-type]
+                ref_id="id",
+                text="text",
+                vector=[0.1],
+            )
+
+    def test_vector_field_accepts_empty_list(self) -> None:
+        entry = VectorEntry(ref_type="entity", ref_id="id", text="t", vector=[])
+        assert entry.vector == []
+
+
+# ---------------------------------------------------------------------------
+# EmbeddingService (Task 2.7)
+# ---------------------------------------------------------------------------
+
+
+class TestEmbeddingService:
+    """AC-1, AC-2: EmbeddingService correct client selection and return shape."""
+
+    def _make_mock_response(self, n: int = 2, dim: int = 3) -> MagicMock:
+        """Build a mock embeddings.create() response with n embeddings of dim dims."""
+        items = [MagicMock(embedding=[float(i)] * dim) for i in range(n)]
+        response = MagicMock()
+        response.data = items
+        return response
+
+    def test_openai_client_used_for_openai_provider(self) -> None:
+        with patch("akgentic.tool.knowledge_graph.vector_index.openai") as mock_openai:
+            mock_client = MagicMock()
+            mock_openai.OpenAI.return_value = mock_client
+            response = self._make_mock_response(1, 3)
+            mock_client.embeddings.create.return_value = response
+
+            svc = EmbeddingService(model="text-embedding-3-small", provider="openai")
+            result = svc.embed(["hello"])
+
+        mock_openai.OpenAI.assert_called_once()
+        assert len(result) == 1
+        assert len(result[0]) == 3
+
+    def test_azure_client_used_for_azure_provider(self) -> None:
+        with patch("akgentic.tool.knowledge_graph.vector_index.openai") as mock_openai:
+            mock_client = MagicMock()
+            mock_openai.AzureOpenAI.return_value = mock_client
+            response = self._make_mock_response(1, 4)
+            mock_client.embeddings.create.return_value = response
+
+            svc = EmbeddingService(model="text-embedding-3-small", provider="azure")
+            result = svc.embed(["hello"])
+
+        mock_openai.AzureOpenAI.assert_called_once()
+        mock_openai.OpenAI.assert_not_called()
+        assert len(result) == 1
+        assert len(result[0]) == 4
+
+    def test_embed_multiple_texts_returns_one_vector_per_text(self) -> None:
+        with patch("akgentic.tool.knowledge_graph.vector_index.openai") as mock_openai:
+            mock_client = MagicMock()
+            mock_openai.OpenAI.return_value = mock_client
+            mock_client.embeddings.create.return_value = self._make_mock_response(3, 5)
+
+            svc = EmbeddingService(model="text-embedding-3-small", provider="openai")
+            result = svc.embed(["a", "b", "c"])
+
+        assert len(result) == 3
+        for vec in result:
+            assert len(vec) == 5
+
+    def test_client_created_lazily_on_first_embed(self) -> None:
+        """Client must not be created at __init__ time, only on first embed()."""
+        with patch("akgentic.tool.knowledge_graph.vector_index.openai") as mock_openai:
+            mock_client = MagicMock()
+            mock_openai.OpenAI.return_value = mock_client
+            mock_client.embeddings.create.return_value = self._make_mock_response(1)
+
+            svc = EmbeddingService(model="m", provider="openai")
+            # Client NOT created yet
+            mock_openai.OpenAI.assert_not_called()
+
+            svc.embed(["x"])
+            # Now it is created
+            mock_openai.OpenAI.assert_called_once()
+
+    def test_client_cached_across_embed_calls(self) -> None:
+        """Second embed() must reuse the same client, not create a new one."""
+        with patch("akgentic.tool.knowledge_graph.vector_index.openai") as mock_openai:
+            mock_client = MagicMock()
+            mock_openai.OpenAI.return_value = mock_client
+            mock_client.embeddings.create.return_value = self._make_mock_response(1)
+
+            svc = EmbeddingService(model="m", provider="openai")
+            svc.embed(["x"])
+            svc.embed(["y"])
+
+            assert mock_openai.OpenAI.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# VectorIndex (Task 3.5)
+# ---------------------------------------------------------------------------
+
+
+def _make_entry(ref_id: str, vector: list[float], ref_type: Literal["entity", "relation"] = "entity") -> VectorEntry:
+    """Factory for VectorEntry instances in tests."""
+    return VectorEntry(ref_type=ref_type, ref_id=ref_id, text=f"text-{ref_id}", vector=vector)
+
+
+class TestVectorIndexAddRemove:
+    """AC-5, AC-6: add/remove entries from VectorIndex."""
+
+    def test_add_entry(self) -> None:
+        idx = VectorIndex()
+        idx.add(_make_entry("e1", [1.0, 0.0, 0.0]))
+        assert len(idx._entries) == 1
+
+    def test_add_multiple_entries(self) -> None:
+        idx = VectorIndex()
+        idx.add(_make_entry("e1", [1.0, 0.0]))
+        idx.add(_make_entry("e2", [0.0, 1.0]))
+        assert len(idx._entries) == 2
+
+    def test_remove_by_ref_id(self) -> None:
+        idx = VectorIndex()
+        idx.add(_make_entry("e1", [1.0, 0.0]))
+        idx.add(_make_entry("e2", [0.0, 1.0]))
+        idx.remove({"e1"})
+        assert len(idx._entries) == 1
+        assert idx._entries[0].ref_id == "e2"
+
+    def test_remove_multiple_ids(self) -> None:
+        idx = VectorIndex()
+        for i in range(5):
+            idx.add(_make_entry(f"e{i}", [float(i), 0.0]))
+        idx.remove({"e0", "e2", "e4"})
+        remaining = {e.ref_id for e in idx._entries}
+        assert remaining == {"e1", "e3"}
+
+    def test_remove_nonexistent_id_is_noop(self) -> None:
+        idx = VectorIndex()
+        idx.add(_make_entry("e1", [1.0]))
+        idx.remove({"doesnotexist"})
+        assert len(idx._entries) == 1
+
+
+class TestVectorIndexCosineSearch:
+    """AC-3, AC-4: cosine similarity search returns correct order."""
+
+    def test_empty_index_returns_empty_list(self) -> None:
+        idx = VectorIndex()
+        result = idx.search_cosine([1.0, 0.0, 0.0], top_k=5)
+        assert result == []
+
+    def test_exact_match_has_score_1(self) -> None:
+        idx = VectorIndex()
+        idx.add(_make_entry("e1", [1.0, 0.0, 0.0]))
+        results = idx.search_cosine([1.0, 0.0, 0.0], top_k=1)
+        assert len(results) == 1
+        ref_id, score = results[0]
+        assert ref_id == "e1"
+        assert abs(score - 1.0) < 1e-6
+
+    def test_orthogonal_vectors_have_zero_score(self) -> None:
+        idx = VectorIndex()
+        idx.add(_make_entry("e1", [1.0, 0.0]))
+        idx.add(_make_entry("e2", [0.0, 1.0]))
+        results = idx.search_cosine([1.0, 0.0], top_k=2)
+        scores = {r[0]: r[1] for r in results}
+        assert abs(scores["e1"] - 1.0) < 1e-6
+        assert abs(scores["e2"] - 0.0) < 1e-6
+
+    def test_results_sorted_descending_by_score(self) -> None:
+        idx = VectorIndex()
+        # e1 is aligned, e2 is 45°, e3 is orthogonal
+        import math
+        idx.add(_make_entry("e1", [1.0, 0.0]))
+        idx.add(_make_entry("e2", [1.0, 1.0]))  # normalized scores 1/sqrt(2)
+        idx.add(_make_entry("e3", [0.0, 1.0]))
+        results = idx.search_cosine([1.0, 0.0], top_k=3)
+        scores = [r[1] for r in results]
+        assert scores == sorted(scores, reverse=True)
+        assert results[0][0] == "e1"
+
+    def test_top_k_limits_results(self) -> None:
+        idx = VectorIndex()
+        for i in range(10):
+            idx.add(_make_entry(f"e{i}", [1.0, float(i)]))
+        results = idx.search_cosine([1.0, 0.0], top_k=3)
+        assert len(results) == 3
+
+    def test_top_k_larger_than_entries_returns_all(self) -> None:
+        idx = VectorIndex()
+        idx.add(_make_entry("e1", [1.0, 0.0]))
+        idx.add(_make_entry("e2", [0.0, 1.0]))
+        results = idx.search_cosine([1.0, 0.0], top_k=100)
+        assert len(results) == 2
+
+
+class TestVectorIndexPerformance:
+    """NFR-KG-1: 1000 vectors x 1536 dims cosine search must complete in < 1ms."""
+
+    def test_cosine_search_1000_vectors_1536_dims_under_1ms(self) -> None:
+        import numpy as np
+
+        idx = VectorIndex()
+        dim = 1536
+        rng = np.random.default_rng(42)
+        for i in range(1000):
+            vec = rng.random(dim).tolist()
+            idx.add(_make_entry(f"e{i}", vec))
+
+        query = rng.random(dim).tolist()
+        start = time.perf_counter()
+        results = idx.search_cosine(query, top_k=10)
+        elapsed_ms = (time.perf_counter() - start) * 1000
+
+        assert len(results) == 10
+        assert elapsed_ms < 1.0, f"Cosine search took {elapsed_ms:.3f}ms (> 1ms)"


### PR DESCRIPTION
## Summary

- Implements `PathStep` model and directed graph traversal via `GetGraphQuery.path` (AC-1)
- Adds search expansion options: `include_neighbors`, `include_edges`, `find_paths` (AC-2/3/4/5)
- BFS shortest-path finder returns alternating `[Entity, Relation, Entity, ...]` sequences

Closes #13