### PR TITLE
refactor: create vector.py module and rename [kg] to [vector_search] (SR-1.1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-semantic = [
+vector_search = [
     "openai>=1.0.0",
     "numpy>=1.26.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-kg = [
+semantic = [
     "openai>=1.0.0",
     "numpy>=1.26.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,8 @@ dev = [
     "pytest-cov>=4.1.0",
     "mypy>=1.8.0",
     "ruff>=0.1.0",
+    "openai>=1.0.0",
+    "numpy>=1.26.0",
 ]
 
 

--- a/src/akgentic/tool/__init__.py
+++ b/src/akgentic/tool/__init__.py
@@ -18,6 +18,7 @@ from .event import (
     ToolCallEvent,
     ToolObserver,
 )
+from .vector import EmbeddingService, VectorEntry, VectorIndex
 
 __all__ = [
     # Core abstractions
@@ -41,4 +42,8 @@ __all__ = [
     "planning",
     "search",
     "team",
+    # Vector infrastructure
+    "VectorEntry",
+    "EmbeddingService",
+    "VectorIndex",
 ]

--- a/src/akgentic/tool/__init__.py
+++ b/src/akgentic/tool/__init__.py
@@ -1,5 +1,7 @@
 """akgentic-tool public API."""
 
+from __future__ import annotations
+
 # Submodules with their own __init__ files
 from . import mcp, planning, search, team
 from .core import (
@@ -18,7 +20,13 @@ from .event import (
     ToolCallEvent,
     ToolObserver,
 )
-from .vector import EmbeddingService, VectorEntry, VectorIndex
+
+try:
+    from .vector import EmbeddingService, VectorEntry, VectorIndex
+
+    _VECTOR_SEARCH_AVAILABLE = True
+except ImportError:
+    _VECTOR_SEARCH_AVAILABLE = False
 
 __all__ = [
     # Core abstractions
@@ -42,7 +50,7 @@ __all__ = [
     "planning",
     "search",
     "team",
-    # Vector infrastructure
+    # Vector infrastructure (requires akgentic-tool[vector_search])
     "VectorEntry",
     "EmbeddingService",
     "VectorIndex",

--- a/src/akgentic/tool/__init__.py
+++ b/src/akgentic/tool/__init__.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 # Submodules with their own __init__ files
-from . import mcp, planning, search, team
-from .core import (
+from . import mcp, planning, search, team  # noqa: F401
+from .core import (  # noqa: F401
     COMMAND,
     SYSTEM_PROMPT,
     TOOL_CALL,
@@ -13,8 +13,8 @@ from .core import (
     ToolCard,
     ToolFactory,
 )
-from .errors import RetriableError
-from .event import (
+from .errors import RetriableError  # noqa: F401
+from .event import (  # noqa: F401
     ActorToolObserver,
     TeamManagementToolObserver,
     ToolCallEvent,
@@ -22,7 +22,7 @@ from .event import (
 )
 
 try:
-    from .vector import EmbeddingService, VectorEntry, VectorIndex
+    from .vector import EmbeddingService, VectorEntry, VectorIndex  # noqa: F401
 
     _VECTOR_SEARCH_AVAILABLE = True
 except ImportError:
@@ -50,8 +50,7 @@ __all__ = [
     "planning",
     "search",
     "team",
-    # Vector infrastructure (requires akgentic-tool[vector_search])
-    "VectorEntry",
-    "EmbeddingService",
-    "VectorIndex",
 ]
+
+if _VECTOR_SEARCH_AVAILABLE:
+    __all__ += ["VectorEntry", "EmbeddingService", "VectorIndex"]

--- a/src/akgentic/tool/knowledge_graph/__init__.py
+++ b/src/akgentic/tool/knowledge_graph/__init__.py
@@ -3,9 +3,9 @@
 Provides in-memory knowledge graph with entity/relation CRUD,
 backed by a Pykka actor (KnowledgeGraphActor) for thread safety.
 
-Requires the ``[semantic]`` optional dependency group::
+Requires the ``[vector_search]`` optional dependency group::
 
-    pip install akgentic-tool[semantic]
+    pip install akgentic-tool[vector_search]
 
 Public API
 ----------
@@ -60,7 +60,7 @@ from akgentic.tool.knowledge_graph.vector_index import EmbeddingService, VectorI
 
 
 def _check_kg_dependencies() -> None:
-    """Validate that ``[semantic]`` optional dependencies are installed.
+    """Validate that ``[vector_search]`` optional dependencies are installed.
 
     Raises:
         ImportError: With install instructions when ``numpy`` or ``openai`` is missing.
@@ -77,7 +77,7 @@ def _check_kg_dependencies() -> None:
     if missing:
         msg = (
             f"The knowledge_graph module requires extra dependencies ({', '.join(missing)}). "
-            "Install them with: pip install akgentic-tool[semantic]"
+            "Install them with: pip install akgentic-tool[vector_search]"
         )
         raise ImportError(msg)
 

--- a/src/akgentic/tool/knowledge_graph/__init__.py
+++ b/src/akgentic/tool/knowledge_graph/__init__.py
@@ -3,9 +3,9 @@
 Provides in-memory knowledge graph with entity/relation CRUD,
 backed by a Pykka actor (KnowledgeGraphActor) for thread safety.
 
-Requires the ``[kg]`` optional dependency group::
+Requires the ``[semantic]`` optional dependency group::
 
-    pip install akgentic-tool[kg]
+    pip install akgentic-tool[semantic]
 
 Public API
 ----------
@@ -60,7 +60,7 @@ from akgentic.tool.knowledge_graph.vector_index import EmbeddingService, VectorI
 
 
 def _check_kg_dependencies() -> None:
-    """Validate that ``[kg]`` optional dependencies are installed.
+    """Validate that ``[semantic]`` optional dependencies are installed.
 
     Raises:
         ImportError: With install instructions when ``numpy`` or ``openai`` is missing.
@@ -77,7 +77,7 @@ def _check_kg_dependencies() -> None:
     if missing:
         msg = (
             f"The knowledge_graph module requires extra dependencies ({', '.join(missing)}). "
-            "Install them with: pip install akgentic-tool[kg]"
+            "Install them with: pip install akgentic-tool[semantic]"
         )
         raise ImportError(msg)
 

--- a/src/akgentic/tool/knowledge_graph/__init__.py
+++ b/src/akgentic/tool/knowledge_graph/__init__.py
@@ -67,11 +67,11 @@ def _check_kg_dependencies() -> None:
     """
     missing: list[str] = []
     try:
-        import numpy as _  # noqa: F811, F401
+        import numpy as _np  # noqa: F401
     except ImportError:
         missing.append("numpy")
     try:
-        import openai as _  # noqa: F811, F401
+        import openai as _openai  # noqa: F401
     except ImportError:
         missing.append("openai")
     if missing:

--- a/src/akgentic/tool/knowledge_graph/models.py
+++ b/src/akgentic/tool/knowledge_graph/models.py
@@ -16,7 +16,7 @@ from pydantic import Field
 
 from akgentic.core.agent_state import BaseState
 from akgentic.core.utils.serializer import SerializableBaseModel
-from akgentic.tool.vector import VectorEntry  # noqa: F401 — re-exported for KG consumers
+from akgentic.tool.vector import VectorEntry as VectorEntry  # re-exported for KG consumers
 
 # ---------------------------------------------------------------------------
 # Core domain models

--- a/src/akgentic/tool/knowledge_graph/models.py
+++ b/src/akgentic/tool/knowledge_graph/models.py
@@ -16,27 +16,7 @@ from pydantic import Field
 
 from akgentic.core.agent_state import BaseState
 from akgentic.core.utils.serializer import SerializableBaseModel
-
-# ---------------------------------------------------------------------------
-# Vector index models (Epic 2)
-# ---------------------------------------------------------------------------
-
-
-class VectorEntry(SerializableBaseModel):
-    """A single embedding record stored in the VectorIndex.
-
-    Links an embedding vector back to its source entity or relation via
-    ``ref_type`` and ``ref_id``. Used by ``VectorIndex`` for cosine
-    similarity search.
-    """
-
-    ref_type: Literal["entity", "relation"] = Field(
-        ..., description="Whether this entry is for an entity or a relation."
-    )
-    ref_id: str = Field(..., description="UUID string of the referenced entity or relation.")
-    text: str = Field(..., description="The text that was embedded.")
-    vector: list[float] = Field(..., description="Embedding values (one float per dimension).")
-
+from akgentic.tool.vector import VectorEntry  # noqa: F401 — re-exported for KG consumers
 
 # ---------------------------------------------------------------------------
 # Core domain models

--- a/src/akgentic/tool/vector.py
+++ b/src/akgentic/tool/vector.py
@@ -1,0 +1,253 @@
+"""Shared vector embedding infrastructure for akgentic-tool.
+
+Zero domain coupling — no imports from knowledge_graph or planning.
+Install akgentic-tool[semantic] to use embedding functionality.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Literal
+
+import numpy as np
+import openai
+from pydantic import Field
+
+from akgentic.core.utils.serializer import SerializableBaseModel
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# VectorEntry
+# ---------------------------------------------------------------------------
+
+
+class VectorEntry(SerializableBaseModel):
+    """A single embedding record stored in a VectorIndex.
+
+    Links an embedding vector back to its source object via ``ref_type`` and
+    ``ref_id``. The ``ref_type`` field accepts any string so this model remains
+    domain-agnostic (knowledge graph uses "entity"/"relation"; planning uses
+    other values). Used by ``VectorIndex`` for cosine similarity search.
+    """
+
+    ref_type: str = Field(
+        ..., description="Domain-specific type label for the referenced object (e.g. 'entity')."
+    )
+    ref_id: str = Field(..., description="UUID string of the referenced object.")
+    text: str = Field(..., description="The text that was embedded.")
+    vector: list[float] = Field(..., description="Embedding values (one float per dimension).")
+
+
+# ---------------------------------------------------------------------------
+# EmbeddingService
+# ---------------------------------------------------------------------------
+
+
+class EmbeddingService:
+    """Generates text embeddings via OpenAI or Azure OpenAI.
+
+    The underlying client is created lazily on the first ``embed()`` call so
+    that constructing an ``EmbeddingService`` never triggers network I/O or
+    requires API credentials.
+
+    Args:
+        model: Embedding model identifier (e.g. ``"text-embedding-3-small"``).
+        provider: Which OpenAI SDK variant to use — ``"openai"`` or ``"azure"``.
+    """
+
+    def __init__(self, model: str, provider: Literal["openai", "azure"]) -> None:
+        self._model = model
+        self._provider = provider
+        self._client: openai.OpenAI | openai.AzureOpenAI | None = None
+
+    # --- Internal ---
+
+    def _get_client(self) -> openai.OpenAI | openai.AzureOpenAI:
+        """Return (or lazily create) the openai client.
+
+        Returns:
+            Configured OpenAI or AzureOpenAI client instance.
+        """
+        if self._client is None:
+            if self._provider == "azure":
+                self._client = openai.AzureOpenAI()
+            else:
+                self._client = openai.OpenAI()
+        return self._client
+
+    # --- Public API ---
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        """Embed a batch of texts and return one vector per input.
+
+        Args:
+            texts: List of strings to embed.
+
+        Returns:
+            List of float vectors — one per input text, in the same order.
+        """
+        client = self._get_client()
+        response = client.embeddings.create(input=texts, model=self._model)
+        return [item.embedding for item in response.data]
+
+
+# ---------------------------------------------------------------------------
+# VectorIndex
+# ---------------------------------------------------------------------------
+
+
+class VectorIndex:
+    """In-memory cosine-similarity index for VectorEntry records.
+
+    Uses a pre-allocated numpy matrix that grows exponentially (like Python
+    list internals) so that ``search_cosine`` operates on a pre-built
+    (N, D) view with no matrix construction overhead — keeping search latency
+    well under 1 ms for ≤10 000 entries at 1536 dims (NFR-KG-1).
+
+    Python-float-to-numpy conversion happens during ``add()`` (O(D) per
+    entry, outside the search hot path).
+    """
+
+    _INITIAL_CAPACITY: int = 64
+    _GROWTH_FACTOR: int = 2
+
+    def __init__(self) -> None:
+        self._entries: list[VectorEntry] = []
+        self._count: int = 0
+        self._dim: int = 0
+        self._capacity: int = 0
+        # Pre-allocated backing stores resized geometrically.
+        self._buf: np.ndarray = np.empty((0, 0), dtype=np.float64)
+        # Row norms pre-computed at add() time to avoid re-reading matrix during search.
+        self._norms_buf: np.ndarray = np.empty(0, dtype=np.float64)
+
+    def _ensure_capacity(self, dim: int) -> None:
+        """Grow the backing buffers if the current row count equals capacity.
+
+        Uses ``self._dim`` (the index's established dimensionality) for the new
+        buffer shape.  The ``dim`` parameter is used only when initializing the
+        first buffer (``self._dim == 0``), ensuring consistent column counts
+        across resizes regardless of the caller's argument.
+        """
+        if self._count < self._capacity:
+            return
+        effective_dim = self._dim if self._dim > 0 else dim
+        new_cap = max(self._INITIAL_CAPACITY, self._capacity * self._GROWTH_FACTOR)
+        new_buf = np.empty((new_cap, effective_dim), dtype=np.float64)
+        new_norms = np.empty(new_cap, dtype=np.float64)
+        if self._count > 0:
+            new_buf[: self._count] = self._buf[: self._count]
+            new_norms[: self._count] = self._norms_buf[: self._count]
+        self._buf = new_buf
+        self._norms_buf = new_norms
+        self._capacity = new_cap
+
+    def add(self, entry: VectorEntry) -> None:
+        """Append a VectorEntry to the index.
+
+        The entry's vector is written into the pre-allocated numpy buffer and
+        its L2 norm is pre-computed so that ``search_cosine`` only needs one
+        matrix read (the dot-product pass), not two.
+
+        Args:
+            entry: The embedding record to store.
+        """
+        dim = len(entry.vector)
+        if self._dim == 0:
+            self._dim = dim
+        self._ensure_capacity(dim)
+        self._buf[self._count] = entry.vector  # numpy converts list[float] → float64 row
+        self._norms_buf[self._count] = np.linalg.norm(self._buf[self._count])
+        self._count += 1
+        self._entries.append(entry)
+
+    def remove(self, ref_ids: set[str]) -> None:
+        """Remove all entries whose ``ref_id`` is in ``ref_ids``.
+
+        Compacts the backing buffers to retain only surviving rows.
+
+        Args:
+            ref_ids: Set of UUID strings to remove. Unknown IDs are silently ignored.
+        """
+        keep = [i for i, e in enumerate(self._entries) if e.ref_id not in ref_ids]
+        if len(keep) == self._count:
+            return  # Nothing removed — fast path
+        new_count = len(keep)
+        new_cap = max(self._INITIAL_CAPACITY, new_count * self._GROWTH_FACTOR)
+        dim = self._dim or 1
+        new_buf = np.empty((new_cap, dim), dtype=np.float64)
+        new_norms = np.empty(new_cap, dtype=np.float64)
+        for new_i, old_i in enumerate(keep):
+            new_buf[new_i] = self._buf[old_i]
+            new_norms[new_i] = self._norms_buf[old_i]
+        self._buf = new_buf
+        self._norms_buf = new_norms
+        self._capacity = new_cap
+        self._entries = [self._entries[i] for i in keep]
+        self._count = new_count
+
+    def __len__(self) -> int:
+        """Return the number of entries currently stored in the index."""
+        return self._count
+
+    def search_cosine(self, query_vector: list[float], top_k: int) -> list[tuple[str, float]]:
+        """Return the top-k most similar entries by cosine similarity.
+
+        Operates on zero-copy views of pre-built buffers, with row norms
+        pre-computed at insertion time. Returns an empty list when the index
+        contains no entries.
+
+        Args:
+            query_vector: The query embedding (must match index dimensionality).
+            top_k: Maximum number of results to return.
+
+        Returns:
+            List of ``(ref_id, score)`` tuples sorted by score descending,
+            limited to ``top_k`` entries.
+        """
+        if not self._entries:
+            return []
+
+        matrix = self._buf[: self._count]  # zero-copy view, O(1)
+        row_norms = self._norms_buf[: self._count]  # zero-copy view, O(1)
+        q = np.array(query_vector, dtype=np.float64)  # (D,)
+
+        dot_products = matrix @ q  # (N,) — single BLAS dgemv pass
+        q_norm = float(np.linalg.norm(q))
+        norms = row_norms * q_norm  # (N,) — elementwise, no matrix read
+        scores = dot_products / np.maximum(norms, 1e-10)  # (N,) cosine similarity
+
+        indices = np.argsort(-scores)[:top_k]
+        return [(self._entries[int(i)].ref_id, float(scores[int(i)])) for i in indices]
+
+
+# ---------------------------------------------------------------------------
+# Dependency check
+# ---------------------------------------------------------------------------
+
+
+def _check_semantic_dependencies() -> None:
+    """Validate that [semantic] optional dependencies are installed.
+
+    Raises:
+        ImportError: With install instructions when ``numpy`` or ``openai`` is missing.
+    """
+    missing: list[str] = []
+    try:
+        import numpy as _np  # noqa: F401
+    except ImportError:
+        missing.append("numpy")
+    try:
+        import openai as _openai  # noqa: F401
+    except ImportError:
+        missing.append("openai")
+    if missing:
+        raise ImportError(
+            f"Semantic search requires extra dependencies ({', '.join(missing)}). "
+            "Install with: pip install akgentic-tool[semantic]"
+        )
+
+
+__all__ = ["VectorEntry", "EmbeddingService", "VectorIndex", "_check_semantic_dependencies"]

--- a/src/akgentic/tool/vector.py
+++ b/src/akgentic/tool/vector.py
@@ -1,19 +1,21 @@
 """Shared vector embedding infrastructure for akgentic-tool.
 
 Zero domain coupling — no imports from knowledge_graph or planning.
-Install akgentic-tool[semantic] to use embedding functionality.
+Install akgentic-tool[vector_search] to use embedding functionality.
 """
 
 from __future__ import annotations
 
 import logging
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
-import numpy as np
-import openai
 from pydantic import Field
 
 from akgentic.core.utils.serializer import SerializableBaseModel
+
+if TYPE_CHECKING:
+    import numpy as np
+    import openai as _openai_typing
 
 logger = logging.getLogger(__name__)
 
@@ -60,21 +62,23 @@ class EmbeddingService:
     def __init__(self, model: str, provider: Literal["openai", "azure"]) -> None:
         self._model = model
         self._provider = provider
-        self._client: openai.OpenAI | openai.AzureOpenAI | None = None
+        self._client: _openai_typing.OpenAI | _openai_typing.AzureOpenAI | None = None
 
     # --- Internal ---
 
-    def _get_client(self) -> openai.OpenAI | openai.AzureOpenAI:
+    def _get_client(self) -> _openai_typing.OpenAI | _openai_typing.AzureOpenAI:
         """Return (or lazily create) the openai client.
 
         Returns:
             Configured OpenAI or AzureOpenAI client instance.
         """
+        import openai as _openai
+
         if self._client is None:
             if self._provider == "azure":
-                self._client = openai.AzureOpenAI()
+                self._client = _openai.AzureOpenAI()
             else:
-                self._client = openai.OpenAI()
+                self._client = _openai.OpenAI()
         return self._client
 
     # --- Public API ---
@@ -114,6 +118,8 @@ class VectorIndex:
     _GROWTH_FACTOR: int = 2
 
     def __init__(self) -> None:
+        import numpy as np
+
         self._entries: list[VectorEntry] = []
         self._count: int = 0
         self._dim: int = 0
@@ -131,6 +137,8 @@ class VectorIndex:
         first buffer (``self._dim == 0``), ensuring consistent column counts
         across resizes regardless of the caller's argument.
         """
+        import numpy as np
+
         if self._count < self._capacity:
             return
         effective_dim = self._dim if self._dim > 0 else dim
@@ -154,6 +162,8 @@ class VectorIndex:
         Args:
             entry: The embedding record to store.
         """
+        import numpy as np
+
         dim = len(entry.vector)
         if self._dim == 0:
             self._dim = dim
@@ -171,6 +181,8 @@ class VectorIndex:
         Args:
             ref_ids: Set of UUID strings to remove. Unknown IDs are silently ignored.
         """
+        import numpy as np
+
         keep = [i for i, e in enumerate(self._entries) if e.ref_id not in ref_ids]
         if len(keep) == self._count:
             return  # Nothing removed — fast path
@@ -207,6 +219,8 @@ class VectorIndex:
             List of ``(ref_id, score)`` tuples sorted by score descending,
             limited to ``top_k`` entries.
         """
+        import numpy as np
+
         if not self._entries:
             return []
 
@@ -228,8 +242,8 @@ class VectorIndex:
 # ---------------------------------------------------------------------------
 
 
-def _check_semantic_dependencies() -> None:
-    """Validate that [semantic] optional dependencies are installed.
+def _check_vector_search_dependencies() -> None:
+    """Validate that [vector_search] optional dependencies are installed.
 
     Raises:
         ImportError: With install instructions when ``numpy`` or ``openai`` is missing.
@@ -245,9 +259,9 @@ def _check_semantic_dependencies() -> None:
         missing.append("openai")
     if missing:
         raise ImportError(
-            f"Semantic search requires extra dependencies ({', '.join(missing)}). "
-            "Install with: pip install akgentic-tool[semantic]"
+            f"Vector search requires extra dependencies ({', '.join(missing)}). "
+            "Install with: pip install akgentic-tool[vector_search]"
         )
 
 
-__all__ = ["VectorEntry", "EmbeddingService", "VectorIndex", "_check_semantic_dependencies"]
+__all__ = ["VectorEntry", "EmbeddingService", "VectorIndex", "_check_vector_search_dependencies"]

--- a/src/akgentic/tool/vector.py
+++ b/src/akgentic/tool/vector.py
@@ -125,9 +125,9 @@ class VectorIndex:
         self._dim: int = 0
         self._capacity: int = 0
         # Pre-allocated backing stores resized geometrically.
-        self._buf: np.ndarray = np.empty((0, 0), dtype=np.float64)
+        self._buf: np.ndarray = np.empty((0, 0), dtype=np.float64)  # type: ignore[type-arg]
         # Row norms pre-computed at add() time to avoid re-reading matrix during search.
-        self._norms_buf: np.ndarray = np.empty(0, dtype=np.float64)
+        self._norms_buf: np.ndarray = np.empty(0, dtype=np.float64)  # type: ignore[type-arg]
 
     def _ensure_capacity(self, dim: int) -> None:
         """Grow the backing buffers if the current row count equals capacity.

--- a/tests/test_kg_vector_index.py
+++ b/tests/test_kg_vector_index.py
@@ -10,10 +10,7 @@ Covers:
 from __future__ import annotations
 
 import time
-from typing import Literal
 from unittest.mock import MagicMock, patch
-
-import pytest
 
 from akgentic.tool.knowledge_graph.models import VectorEntry
 from akgentic.tool.knowledge_graph.vector_index import EmbeddingService, VectorIndex
@@ -47,14 +44,10 @@ class TestVectorEntry:
         )
         assert entry.ref_type == "relation"
 
-    def test_invalid_ref_type_rejected(self) -> None:
-        with pytest.raises(Exception):
-            VectorEntry(
-                ref_type="unknown",  # type: ignore[arg-type]
-                ref_id="id",
-                text="text",
-                vector=[0.1],
-            )
+    def test_ref_type_accepts_any_string(self) -> None:
+        # VectorEntry is domain-agnostic; ref_type is a free-form string.
+        entry = VectorEntry(ref_type="custom_type", ref_id="id", text="text", vector=[0.1])
+        assert entry.ref_type == "custom_type"
 
     def test_vector_field_accepts_empty_list(self) -> None:
         entry = VectorEntry(ref_type="entity", ref_id="id", text="t", vector=[])
@@ -153,7 +146,7 @@ class TestEmbeddingService:
 
 
 def _make_entry(
-    ref_id: str, vector: list[float], ref_type: Literal["entity", "relation"] = "entity"
+    ref_id: str, vector: list[float], ref_type: str = "entity"
 ) -> VectorEntry:
     """Factory for VectorEntry instances in tests."""
     return VectorEntry(ref_type=ref_type, ref_id=ref_id, text=f"text-{ref_id}", vector=vector)


### PR DESCRIPTION
## Summary

- Extract shared vector infrastructure (`VectorEntry`, `EmbeddingService`, `VectorIndex`, `_check_vector_search_dependencies`) to new `akgentic/tool/vector.py` peer module
- Rename optional dependency group `[kg]` → `[vector_search]` in `pyproject.toml`
- Unify `VectorEntry` class identity: `knowledge_graph/models.py` re-imports from `akgentic.tool.vector` instead of defining its own
- Make all `numpy`/`openai` imports lazy (inside method bodies) so base `import akgentic.tool` never hard-requires `[vector_search]`
- Guard `tool/__init__.py` vector re-exports with `try/except ImportError`; `__all__` conditionally extended only when `[vector_search]` installed

## Code Review Fixes (this PR)

- Fixed double `import _ as _` → `_np`/`_openai` aliases in `_check_kg_dependencies` (mypy `no-redef`)
- Conditional `__all__` extension keyed on `_VECTOR_SEARCH_AVAILABLE`
- Explicit `VectorEntry as VectorEntry` re-export in `models.py` for mypy compliance
- `np.ndarray` type annotations suppressed with `type: ignore[type-arg]` (numpy generic typing)
- Added `openai`/`numpy` to `dev` extras so `pytest` works without separate install

Closes #19