### PR TITLE
feat: PlanConfig and PlanActor embedding lifecycle (SR-2.1)

### DIFF
--- a/src/akgentic/tool/planning/planning_actor.py
+++ b/src/akgentic/tool/planning/planning_actor.py
@@ -10,7 +10,7 @@ from akgentic.core.utils.serializer import SerializableBaseModel
 from akgentic.tool.errors import RetriableError
 
 if TYPE_CHECKING:
-    from akgentic.tool.vector import EmbeddingService
+    from akgentic.tool.vector import EmbeddingService, VectorIndex
 
 logger = logging.getLogger(__name__)
 
@@ -97,8 +97,6 @@ class PlanActor(Akgent[PlanConfig, PlanManagerState]):
     """
 
     def on_start(self) -> None:
-        from akgentic.tool.vector import VectorIndex
-
         self.state = PlanManagerState()
         self.state.observer(self)
         # Coerce BaseConfig → PlanConfig if the actor was started with a plain BaseConfig
@@ -109,7 +107,14 @@ class PlanActor(Akgent[PlanConfig, PlanManagerState]):
                 name=self.config.name,
                 role=self.config.role,
             )
-        self._vector_index: VectorIndex = VectorIndex()
+        # Only instantiate VectorIndex (which imports numpy) when semantic_search is enabled.
+        # This preserves the graceful fallback behaviour: if numpy is absent and
+        # semantic_search=False, on_start must not crash (AC#7, AC#8).
+        self._vector_index: "VectorIndex | None" = None
+        if self.config.semantic_search:
+            from akgentic.tool.vector import VectorIndex
+
+            self._vector_index = VectorIndex()
         self._embedding_svc: EmbeddingService | None = None
 
     def _get_or_create_embedding_svc(self) -> "EmbeddingService | None":
@@ -137,11 +142,13 @@ class PlanActor(Akgent[PlanConfig, PlanManagerState]):
         """Embed a task's description and store the resulting VectorEntry.
 
         Called after task create or update. Does nothing when embedding service
-        is unavailable (semantic_search=False or missing deps).
+        is unavailable (semantic_search=False or missing deps). Any embedding
+        error (import, network, auth) is logged and swallowed so that task CRUD
+        is never interrupted by a transient embedding failure.
         """
         try:
             svc = self._get_or_create_embedding_svc()
-            if svc is None:
+            if svc is None or self._vector_index is None:
                 return
             from akgentic.tool.vector import VectorEntry
 
@@ -155,6 +162,10 @@ class PlanActor(Akgent[PlanConfig, PlanManagerState]):
             self._vector_index.add(entry)
         except ImportError:
             logger.warning("Vector search deps missing — skipping embedding for task %s", task.id)
+        except Exception:
+            logger.warning(
+                "Embedding failed for task %s — semantic index not updated", task.id, exc_info=True
+            )
 
     def _create_task(self, task: TaskCreate, actor_address: ActorAddress) -> None:
         new_task = Task(**task.__dict__, creator=actor_address.name)
@@ -169,7 +180,17 @@ class PlanActor(Akgent[PlanConfig, PlanManagerState]):
             if task.id == task_update.id:
                 updated_task = task.model_copy(update=updates)
                 self.state.task_list[idx] = updated_task
-                if self.config.semantic_search and task_update.description is not None:
+                # Re-index only when the description actually changed (AC#5).
+                description_changed = (
+                    task_update.description is not None
+                    and task_update.description != task.description
+                )
+                should_reindex = (
+                    self.config.semantic_search
+                    and description_changed
+                    and self._vector_index is not None
+                )
+                if should_reindex:
                     self._vector_index.remove({str(task.id)})
                     self._embed_task(updated_task)
                 return
@@ -207,7 +228,7 @@ class PlanActor(Akgent[PlanConfig, PlanManagerState]):
             if not any(task.id == task_id for task in self.state.task_list):
                 errors.append(f"Delete error - no task with ID {task_id} found.")
             else:
-                if self.config.semantic_search:
+                if self.config.semantic_search and self._vector_index is not None:
                     self._vector_index.remove({str(task_id)})
                 self.state.task_list = [task for task in self.state.task_list if task.id != task_id]
 

--- a/src/akgentic/tool/planning/planning_actor.py
+++ b/src/akgentic/tool/planning/planning_actor.py
@@ -1,5 +1,6 @@
 import datetime
-from typing import Literal
+import logging
+from typing import TYPE_CHECKING, Literal
 
 from pydantic import BaseModel, Field
 
@@ -7,6 +8,11 @@ from akgentic.core.actor_address import ActorAddress
 from akgentic.core.agent import Akgent, BaseConfig, BaseState
 from akgentic.core.utils.serializer import SerializableBaseModel
 from akgentic.tool.errors import RetriableError
+
+if TYPE_CHECKING:
+    from akgentic.tool.vector import EmbeddingService
+
+logger = logging.getLogger(__name__)
 
 TaskStatus = Literal["pending", "started", "completed", "abort"]
 
@@ -63,7 +69,21 @@ class PlanManagerState(BaseState):
     task_list: list[Task] = Field(default_factory=list)
 
 
-class PlanActor(Akgent[BaseConfig, PlanManagerState]):
+class PlanConfig(BaseConfig):
+    """Configuration for PlanActor with optional semantic search support."""
+
+    embedding_model: str = Field(default="text-embedding-3-small")
+    embedding_provider: Literal["openai", "azure"] = Field(default="openai")
+    semantic_search: bool = Field(
+        default=True,
+        description=(
+            "When True, task descriptions are embedded on create/update/delete "
+            "for semantic search. Falls back gracefully if [vector_search] deps are not installed."
+        ),
+    )
+
+
+class PlanActor(Akgent[PlanConfig, PlanManagerState]):
     """Actor responsible for managing the execution of a plan.
 
     The PlanManager oversees the execution of a plan, coordinating
@@ -76,20 +96,82 @@ class PlanActor(Akgent[BaseConfig, PlanManagerState]):
         state: Current state of the plan execution.
     """
 
-    def on_start(self):
+    def on_start(self) -> None:
+        from akgentic.tool.vector import VectorIndex
+
         self.state = PlanManagerState()
         self.state.observer(self)
+        # Coerce BaseConfig → PlanConfig if the actor was started with a plain BaseConfig
+        # (e.g., from existing PlanningTool wiring prior to Story 2.2 update).
+        # This preserves backward compatibility while giving PlanActor typed config access.
+        if not isinstance(self.config, PlanConfig):
+            self.config = PlanConfig(
+                name=self.config.name,
+                role=self.config.role,
+            )
+        self._vector_index: VectorIndex = VectorIndex()
+        self._embedding_svc: EmbeddingService | None = None
+
+    def _get_or_create_embedding_svc(self) -> "EmbeddingService | None":
+        """Return (or lazily create) the EmbeddingService.
+
+        Returns None when semantic_search is disabled or [vector_search]
+        optional dependencies are not installed.
+        """
+        if not self.config.semantic_search:
+            return None
+        if self._embedding_svc is None:
+            try:
+                from akgentic.tool.vector import EmbeddingService, _check_vector_search_dependencies
+
+                _check_vector_search_dependencies()
+            except ImportError:
+                return None
+            self._embedding_svc = EmbeddingService(
+                model=self.config.embedding_model,
+                provider=self.config.embedding_provider,
+            )
+        return self._embedding_svc
+
+    def _embed_task(self, task: Task) -> None:
+        """Embed a task's description and store the resulting VectorEntry.
+
+        Called after task create or update. Does nothing when embedding service
+        is unavailable (semantic_search=False or missing deps).
+        """
+        try:
+            svc = self._get_or_create_embedding_svc()
+            if svc is None:
+                return
+            from akgentic.tool.vector import VectorEntry
+
+            vector = svc.embed([task.description])[0]
+            entry = VectorEntry(
+                ref_type="task",
+                ref_id=str(task.id),
+                text=task.description,
+                vector=vector,
+            )
+            self._vector_index.add(entry)
+        except ImportError:
+            logger.warning("Vector search deps missing — skipping embedding for task %s", task.id)
 
     def _create_task(self, task: TaskCreate, actor_address: ActorAddress) -> None:
         new_task = Task(**task.__dict__, creator=actor_address.name)
         self.state.task_list.append(new_task)
+        if self.config.semantic_search:
+            self._embed_task(new_task)
 
     def _update_task(self, task_update: TaskUpdate) -> None | str:
         # Use __dict__ to get raw values, filter out None to only apply explicitly set fields
         updates = {k: v for k, v in task_update.__dict__.items() if v is not None}
         for idx, task in enumerate(self.state.task_list):
             if task.id == task_update.id:
-                self.state.task_list[idx] = task.model_copy(update=updates)
+                updated_task = task.model_copy(update=updates)
+                self.state.task_list[idx] = updated_task
+                if self.config.semantic_search and task_update.description is not None:
+                    self._vector_index.remove({str(task.id)})
+                    self._embed_task(updated_task)
                 return
         return f"Update error - no task with ID {task_update.id} found."
 
@@ -125,6 +207,8 @@ class PlanActor(Akgent[BaseConfig, PlanManagerState]):
             if not any(task.id == task_id for task in self.state.task_list):
                 errors.append(f"Delete error - no task with ID {task_id} found.")
             else:
+                if self.config.semantic_search:
+                    self._vector_index.remove({str(task_id)})
                 self.state.task_list = [task for task in self.state.task_list if task.id != task_id]
 
         self.state.notify_state_change()


### PR DESCRIPTION
## Summary

- Adds `PlanConfig(BaseConfig)` with `embedding_model`, `embedding_provider`, `semantic_search` fields
- Updates `PlanActor` generic type to `Akgent[PlanConfig, PlanManagerState]`
- Implements lazy `_vector_index` initialization (guarded by `semantic_search`), `_get_or_create_embedding_svc`, and `_embed_task`
- Wires embedding lifecycle into task CRUD (create/update/delete) with `semantic_search` guards
- Adds backward-compat coercion from `BaseConfig` → `PlanConfig` in `on_start`

### Review fixes applied

| Severity | Fix |
|----------|-----|
| CRITICAL | `VectorIndex()` now only instantiated when `semantic_search=True` — prevents numpy import crash when deps absent and `semantic_search=False` |
| MEDIUM | `_update_task` re-indexes only when description actually changed (not just when explicitly set) |
| MEDIUM | `_embed_task` catches all exceptions (not just `ImportError`) to prevent transient embedding errors from crashing task CRUD |

### Quality
- `ruff check`: all checks passed
- `pytest packages/akgentic-tool/tests/`: 364 passed, 0 failed
- `mypy planning_actor.py`: 3 pre-existing errors only, no new errors introduced

Closes #25