### PR TITLE
feat: get_planning_task semantic search and PlanningTool wiring (SR-2.2)

### DIFF
--- a/src/akgentic/tool/planning/planning.py
+++ b/src/akgentic/tool/planning/planning.py
@@ -1,9 +1,10 @@
+from __future__ import annotations
+
 import logging
-from typing import Callable
+from typing import Callable, Literal
 
 from pydantic import Field
 
-from akgentic.core.agent_config import BaseConfig
 from akgentic.core.orchestrator import Orchestrator
 from akgentic.tool.core import (
     COMMAND,
@@ -15,7 +16,7 @@ from akgentic.tool.core import (
     _resolve,
 )
 from akgentic.tool.event import ActorToolObserver, ToolCallEvent
-from akgentic.tool.planning.planning_actor import PlanActor, Task, UpdatePlan
+from akgentic.tool.planning.planning_actor import PlanActor, PlanConfig, Task, UpdatePlan
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -51,8 +52,16 @@ class PlanningTool(ToolCard):
     )
     get_planning_task: GetPlanningTask | bool = True
     update_planning: UpdatePlanning | bool = True
+    embedding_model: str = Field(
+        default="text-embedding-3-small",
+        description="Embedding model passed through to PlanConfig for semantic task search",
+    )
+    embedding_provider: Literal["openai", "azure"] = Field(
+        default="openai",
+        description="Embedding provider passed through to PlanConfig for semantic task search",
+    )
 
-    def observer(self, observer: ActorToolObserver):
+    def observer(self, observer: ActorToolObserver) -> None:  # type: ignore[override]
         """Attach observer and set up the planning actor proxy.
 
         Requires an ActorToolObserver for actor system access.
@@ -66,9 +75,13 @@ class PlanningTool(ToolCard):
 
         if planning_tool_addr is None:
             logger.info(f"PlanningTool: create {PLANNING_ACTOR_NAME}.")
-            planning_tool_addr = orchestrator_proxy_ask.createActor(
-                PlanActor, config=BaseConfig(name=PLANNING_ACTOR_NAME, role=PLANNING_ACTOR_ROLE)
+            config = PlanConfig(
+                name=PLANNING_ACTOR_NAME,
+                role=PLANNING_ACTOR_ROLE,
+                embedding_model=self.embedding_model,
+                embedding_provider=self.embedding_provider,
             )
+            planning_tool_addr = orchestrator_proxy_ask.createActor(PlanActor, config=config)
 
         self._planning_proxy = observer.proxy_ask(planning_tool_addr, PlanActor)
 
@@ -132,8 +145,8 @@ class PlanningTool(ToolCard):
         planning_proxy = self._planning_proxy
         observer = self._observer
 
-        def get_planning_task(task_id: int) -> Task | str:
-            """Get a single team task by its ID."""
+        def get_planning_task(task_id: int | str) -> Task | str:
+            """Get a single team task by its integer ID or semantic query string."""
             if observer is not None:
                 observer.notify_event(
                     ToolCallEvent(tool_name="Get task", args=[task_id], kwargs={})

--- a/src/akgentic/tool/planning/planning_actor.py
+++ b/src/akgentic/tool/planning/planning_actor.py
@@ -187,15 +187,14 @@ class PlanActor(Akgent[PlanConfig, PlanManagerState]):
                     task_update.description is not None
                     and task_update.description != task.description
                 )
-                should_reindex = (
+                if (
                     self.config.semantic_search
                     and description_changed
                     and self._vector_index is not None
-                )
-                if should_reindex:
+                ):
                     self._vector_index.remove({str(task.id)})
                     self._embed_task(updated_task)
-                return
+                return None
         return f"Update error - no task with ID {task_update.id} found."
 
     ##

--- a/src/akgentic/tool/planning/planning_actor.py
+++ b/src/akgentic/tool/planning/planning_actor.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 import logging
 from typing import TYPE_CHECKING, Literal
@@ -110,14 +112,14 @@ class PlanActor(Akgent[PlanConfig, PlanManagerState]):
         # Only instantiate VectorIndex (which imports numpy) when semantic_search is enabled.
         # This preserves the graceful fallback behaviour: if numpy is absent and
         # semantic_search=False, on_start must not crash (AC#7, AC#8).
-        self._vector_index: "VectorIndex | None" = None
+        self._vector_index: VectorIndex | None = None
         if self.config.semantic_search:
             from akgentic.tool.vector import VectorIndex
 
             self._vector_index = VectorIndex()
         self._embedding_svc: EmbeddingService | None = None
 
-    def _get_or_create_embedding_svc(self) -> "EmbeddingService | None":
+    def _get_or_create_embedding_svc(self) -> EmbeddingService | None:
         """Return (or lazily create) the EmbeddingService.
 
         Returns None when semantic_search is disabled or [vector_search]
@@ -203,10 +205,36 @@ class PlanActor(Akgent[PlanConfig, PlanManagerState]):
         """Get the current plan tasks."""
         return self.state.task_list
 
-    def get_planning_task(self, task_id: int) -> Task | str:
-        """Get a specific plan task by ID."""
-        task_list = self.state.task_list
-        return next((task for task in task_list if task.id == task_id), "No task with that ID.")
+    def get_planning_task(self, task_id: int | str) -> Task | str:
+        """Look up a task by exact ID (int) or semantic query (str).
+
+        Args:
+            task_id: An integer for exact ID lookup, or a string for semantic search.
+
+        Returns:
+            The matching ``Task`` if found, or a plain string message when no match
+            is found or semantic search is unavailable.
+        """
+        if isinstance(task_id, int):
+            return next(
+                (t for t in self.state.task_list if t.id == task_id), "No task with that ID."
+            )
+
+        # Semantic search path
+        svc = self._get_or_create_embedding_svc()
+        if svc is None or self._vector_index is None or len(self._vector_index) == 0:
+            return "Semantic search unavailable."
+
+        query_vector = svc.embed([task_id])[0]
+        pairs = self._vector_index.search_cosine(query_vector, top_k=1)
+        if not pairs:
+            return "Semantic search unavailable."
+
+        ref_id, _ = pairs[0]
+        return next(
+            (t for t in self.state.task_list if str(t.id) == ref_id),
+            "No task with that ID.",
+        )
 
     def update_planning(self, update: UpdatePlan, actor_address: ActorAddress) -> str:
         """Update the plan with new, updated, or deleted task."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,61 @@
+"""Shared pytest fixtures and helpers for akgentic-tool tests."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from akgentic.core.actor_address import ActorAddress
+
+
+class MockActorAddress(ActorAddress):
+    """Minimal ActorAddress stub used across multiple test modules."""
+
+    def __init__(self, name: str = "test-agent", role: str = "test-role") -> None:
+        self._name = name
+        self._role = role
+        self._agent_id = uuid.uuid4()
+
+    @property
+    def agent_id(self) -> uuid.UUID:
+        return self._agent_id
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def role(self) -> str:
+        return self._role
+
+    @property
+    def team_id(self) -> uuid.UUID | None:
+        return None
+
+    @property
+    def squad_id(self) -> uuid.UUID | None:
+        return None
+
+    def send(self, recipient: object, message: object) -> None:
+        pass
+
+    def is_alive(self) -> bool:
+        return True
+
+    def stop(self) -> None:
+        pass
+
+    def handle_user_message(self) -> bool:
+        return False
+
+    def serialize(self) -> dict:  # type: ignore[type-arg]
+        return {"name": self._name, "role": self._role, "agent_id": str(self._agent_id)}
+
+    def __repr__(self) -> str:
+        return f"MockActorAddress(name={self._name})"
+
+
+@pytest.fixture
+def mock_actor_address() -> MockActorAddress:
+    """Return a default MockActorAddress instance."""
+    return MockActorAddress()

--- a/tests/test_planning_actor.py
+++ b/tests/test_planning_actor.py
@@ -2,10 +2,7 @@
 
 from __future__ import annotations
 
-import uuid
-
 import pytest
-from akgentic.core.actor_address import ActorAddress
 
 from akgentic.tool.errors import RetriableError
 from akgentic.tool.planning.planning_actor import (
@@ -14,53 +11,7 @@ from akgentic.tool.planning.planning_actor import (
     TaskUpdate,
     UpdatePlan,
 )
-
-
-class MockActorAddress(ActorAddress):
-    """Mock ActorAddress for testing."""
-
-    def __init__(self, name: str = "test-agent", role: str = "test-role"):
-        self._name = name
-        self._role = role
-        self._agent_id = uuid.uuid4()
-
-    @property
-    def agent_id(self) -> uuid.UUID:
-        return self._agent_id
-
-    @property
-    def name(self) -> str:
-        return self._name
-
-    @property
-    def role(self) -> str:
-        return self._role
-
-    @property
-    def team_id(self) -> uuid.UUID | None:
-        return None
-
-    @property
-    def squad_id(self) -> uuid.UUID | None:
-        return None
-
-    def send(self, recipient, message):
-        pass
-
-    def is_alive(self) -> bool:
-        return True
-
-    def stop(self) -> None:
-        pass
-
-    def handle_user_message(self) -> bool:
-        return False
-
-    def serialize(self):
-        return {"name": self._name, "role": self._role, "agent_id": str(self._agent_id)}
-
-    def __repr__(self) -> str:
-        return f"MockActorAddress(name={self._name}, role={self._role}, agent_id={self._agent_id})"
+from tests.conftest import MockActorAddress
 
 
 def test_update_item_success() -> None:

--- a/tests/test_planning_semantic.py
+++ b/tests/test_planning_semantic.py
@@ -1,0 +1,274 @@
+"""Tests for PlanActor.get_planning_task — int and semantic (str) lookup paths.
+
+Covers AC#1–#7 (get_planning_task method) and AC#10 (test file completeness).
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+from akgentic.core.actor_address import ActorAddress
+
+from akgentic.tool.planning.planning_actor import (
+    PlanActor,
+    PlanConfig,
+    Task,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class MockActorAddress(ActorAddress):
+    """Minimal ActorAddress stub for tests that need a creator identity."""
+
+    def __init__(self, name: str = "test-agent", role: str = "test-role") -> None:
+        self._name = name
+        self._role = role
+        self._agent_id = uuid.uuid4()
+
+    @property
+    def agent_id(self) -> uuid.UUID:
+        return self._agent_id
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def role(self) -> str:
+        return self._role
+
+    @property
+    def team_id(self) -> uuid.UUID | None:
+        return None
+
+    @property
+    def squad_id(self) -> uuid.UUID | None:
+        return None
+
+    def send(self, recipient: object, message: object) -> None:
+        pass
+
+    def is_alive(self) -> bool:
+        return True
+
+    def stop(self) -> None:
+        pass
+
+    def handle_user_message(self) -> bool:
+        return False
+
+    def serialize(self) -> dict:  # type: ignore[type-arg]
+        return {"name": self._name, "role": self._role, "agent_id": str(self._agent_id)}
+
+    def __repr__(self) -> str:
+        return f"MockActorAddress(name={self._name})"
+
+
+def _make_actor(semantic_search: bool = True) -> PlanActor:
+    """Construct a bare PlanActor with no Pykka runtime — calls on_start directly."""
+    actor = PlanActor()
+    actor.config = PlanConfig(
+        name="test-plan",
+        role="ToolActor",
+        semantic_search=semantic_search,
+    )
+    actor.on_start()
+    return actor
+
+
+def _add_task(actor: PlanActor, task_id: int, description: str) -> Task:
+    """Helper: add a task to actor state without triggering embedding.
+
+    Directly appends to task_list so tests can control embedding lifecycle
+    independently.
+    """
+    addr = MockActorAddress()
+    actor.state.task_list.append(
+        Task(
+            id=task_id,
+            status="pending",
+            description=description,
+            owner="Alice",
+            creator=addr.name,
+        )
+    )
+    return actor.state.task_list[-1]
+
+
+# ---------------------------------------------------------------------------
+# AC#1 — int lookup: task found (no embedding)
+# ---------------------------------------------------------------------------
+
+
+class TestGetPlanningTaskIntFound:
+    """AC1: int task_id → exact match returned, no embedding call."""
+
+    def test_returns_task_when_id_matches(self) -> None:
+        actor = _make_actor()
+        _add_task(actor, task_id=3, description="Auth module")
+
+        with patch.object(actor, "_get_or_create_embedding_svc") as mock_svc:
+            result = actor.get_planning_task(3)
+
+        assert isinstance(result, Task)
+        assert result.id == 3
+        assert result.description == "Auth module"
+        mock_svc.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# AC#2 — int lookup: task not found
+# ---------------------------------------------------------------------------
+
+
+class TestGetPlanningTaskIntNotFound:
+    """AC2: int task_id with no matching task → 'No task with that ID.' string."""
+
+    def test_returns_not_found_string_when_id_missing(self) -> None:
+        actor = _make_actor()
+        _add_task(actor, task_id=1, description="Some task")
+
+        result = actor.get_planning_task(99)
+
+        assert result == "No task with that ID."
+
+
+# ---------------------------------------------------------------------------
+# AC#3 — str lookup: semantic search found
+# ---------------------------------------------------------------------------
+
+
+class TestGetPlanningTaskStrFound:
+    """AC3: str task_id with populated index → EmbeddingService called, Task returned."""
+
+    def test_semantic_search_returns_matching_task(self) -> None:
+        actor = _make_actor(semantic_search=True)
+        _add_task(actor, task_id=5, description="Auth module implementation")
+
+        # Seed the vector index with a pre-computed entry for task id=5
+        task = actor.state.task_list[0]
+        unit_vector = [1.0, 0.0, 0.0]
+
+        from akgentic.tool.vector import VectorEntry
+
+        entry = VectorEntry(
+            ref_type="task",
+            ref_id=str(task.id),
+            text=task.description,
+            vector=unit_vector,
+        )
+        assert actor._vector_index is not None
+        actor._vector_index.add(entry)
+
+        # Mock embed to return the same unit vector → cosine similarity of 1.0
+        mock_svc = MagicMock()
+        mock_svc.embed.return_value = [[1.0, 0.0, 0.0]]
+
+        with patch.object(actor, "_get_or_create_embedding_svc", return_value=mock_svc):
+            result = actor.get_planning_task("auth module")
+
+        assert isinstance(result, Task)
+        assert result.id == 5
+        mock_svc.embed.assert_called_once_with(["auth module"])
+
+
+# ---------------------------------------------------------------------------
+# AC#4 — str lookup: empty vector index
+# ---------------------------------------------------------------------------
+
+
+class TestGetPlanningTaskStrEmptyIndex:
+    """AC4: str task_id with empty vector index → 'Semantic search unavailable.'"""
+
+    def test_returns_unavailable_when_index_empty(self) -> None:
+        actor = _make_actor(semantic_search=True)
+        _add_task(actor, task_id=1, description="Some task")
+        # Index is empty — no entries added
+
+        mock_svc = MagicMock()
+
+        with patch.object(actor, "_get_or_create_embedding_svc", return_value=mock_svc):
+            result = actor.get_planning_task("something")
+
+        assert result == "Semantic search unavailable."
+        mock_svc.embed.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# AC#5 — str lookup: semantic_search=False
+# ---------------------------------------------------------------------------
+
+
+class TestGetPlanningTaskStrSemanticDisabled:
+    """AC5: str task_id with semantic_search=False → 'Semantic search unavailable.'"""
+
+    def test_returns_unavailable_when_semantic_search_disabled(self) -> None:
+        actor = _make_actor(semantic_search=False)
+        _add_task(actor, task_id=1, description="Some task")
+
+        with patch.object(actor, "_get_or_create_embedding_svc", return_value=None) as mock_fn:
+            result = actor.get_planning_task("some query")
+
+        assert result == "Semantic search unavailable."
+        # _get_or_create_embedding_svc is called but returns None — no embed call
+        mock_fn.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# AC#6 — str lookup: missing [vector_search] deps
+# ---------------------------------------------------------------------------
+
+
+class TestGetPlanningTaskStrMissingDeps:
+    """AC6: str task_id with missing vector deps → 'Semantic search unavailable.'"""
+
+    def test_returns_unavailable_when_deps_missing(self) -> None:
+        actor = _make_actor(semantic_search=True)
+        _add_task(actor, task_id=1, description="Some task")
+
+        # Simulate missing deps: _get_or_create_embedding_svc returns None
+        with patch.object(actor, "_get_or_create_embedding_svc", return_value=None):
+            result = actor.get_planning_task("auth module")
+
+        assert result == "Semantic search unavailable."
+
+
+# ---------------------------------------------------------------------------
+# AC#7 — str lookup: orphaned ref_id
+# ---------------------------------------------------------------------------
+
+
+class TestGetPlanningTaskStrOrphanedRefId:
+    """AC7: top-1 ref_id doesn't match any task (deleted) → 'No task with that ID.'"""
+
+    def test_returns_no_task_when_ref_id_orphaned(self) -> None:
+        actor = _make_actor(semantic_search=True)
+
+        # Seed index with ref_id=99 (task deleted from task_list)
+        unit_vector = [1.0, 0.0, 0.0]
+
+        from akgentic.tool.vector import VectorEntry
+
+        entry = VectorEntry(
+            ref_type="task",
+            ref_id="99",  # orphaned — task 99 not in task_list
+            text="deleted task description",
+            vector=unit_vector,
+        )
+        assert actor._vector_index is not None
+        actor._vector_index.add(entry)
+
+        # task_list has task id=1, NOT id=99
+        _add_task(actor, task_id=1, description="Surviving task")
+
+        mock_svc = MagicMock()
+        mock_svc.embed.return_value = [[1.0, 0.0, 0.0]]
+
+        with patch.object(actor, "_get_or_create_embedding_svc", return_value=mock_svc):
+            result = actor.get_planning_task("deleted task description")
+
+        assert result == "No task with that ID."

--- a/tests/test_planning_semantic.py
+++ b/tests/test_planning_semantic.py
@@ -1,71 +1,19 @@
 """Tests for PlanActor.get_planning_task — int and semantic (str) lookup paths.
 
-Covers AC#1–#7 (get_planning_task method) and AC#10 (test file completeness).
+Covers AC#1–#7 (get_planning_task method) and AC#8–#9 (PlanningTool wiring),
+satisfying AC#10 (test file completeness).
 """
 
 from __future__ import annotations
 
-import uuid
 from unittest.mock import MagicMock, patch
-
-from akgentic.core.actor_address import ActorAddress
 
 from akgentic.tool.planning.planning_actor import (
     PlanActor,
     PlanConfig,
     Task,
 )
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-class MockActorAddress(ActorAddress):
-    """Minimal ActorAddress stub for tests that need a creator identity."""
-
-    def __init__(self, name: str = "test-agent", role: str = "test-role") -> None:
-        self._name = name
-        self._role = role
-        self._agent_id = uuid.uuid4()
-
-    @property
-    def agent_id(self) -> uuid.UUID:
-        return self._agent_id
-
-    @property
-    def name(self) -> str:
-        return self._name
-
-    @property
-    def role(self) -> str:
-        return self._role
-
-    @property
-    def team_id(self) -> uuid.UUID | None:
-        return None
-
-    @property
-    def squad_id(self) -> uuid.UUID | None:
-        return None
-
-    def send(self, recipient: object, message: object) -> None:
-        pass
-
-    def is_alive(self) -> bool:
-        return True
-
-    def stop(self) -> None:
-        pass
-
-    def handle_user_message(self) -> bool:
-        return False
-
-    def serialize(self) -> dict:  # type: ignore[type-arg]
-        return {"name": self._name, "role": self._role, "agent_id": str(self._agent_id)}
-
-    def __repr__(self) -> str:
-        return f"MockActorAddress(name={self._name})"
+from tests.conftest import MockActorAddress
 
 
 def _make_actor(semantic_search: bool = True) -> PlanActor:
@@ -272,3 +220,81 @@ class TestGetPlanningTaskStrOrphanedRefId:
             result = actor.get_planning_task("deleted task description")
 
         assert result == "No task with that ID."
+
+
+# ---------------------------------------------------------------------------
+# AC#8 — PlanningTool has embedding_model and embedding_provider fields
+# ---------------------------------------------------------------------------
+
+
+class TestPlanningToolFields:
+    """AC8: PlanningTool exposes embedding_model and embedding_provider Pydantic fields."""
+
+    def test_default_embedding_model(self) -> None:
+        from akgentic.tool.planning.planning import PlanningTool
+
+        tool = PlanningTool()
+        assert tool.embedding_model == "text-embedding-3-small"
+
+    def test_default_embedding_provider(self) -> None:
+        from akgentic.tool.planning.planning import PlanningTool
+
+        tool = PlanningTool()
+        assert tool.embedding_provider == "openai"
+
+    def test_custom_embedding_model(self) -> None:
+        from akgentic.tool.planning.planning import PlanningTool
+
+        tool = PlanningTool(embedding_model="text-embedding-ada-002")
+        assert tool.embedding_model == "text-embedding-ada-002"
+
+    def test_custom_embedding_provider_azure(self) -> None:
+        from akgentic.tool.planning.planning import PlanningTool
+
+        tool = PlanningTool(embedding_provider="azure")
+        assert tool.embedding_provider == "azure"
+
+
+# ---------------------------------------------------------------------------
+# AC#9 — PlanningTool.observer() passes PlanConfig with embedding fields
+# ---------------------------------------------------------------------------
+
+
+class TestPlanningToolObserverWiring:
+    """AC9: observer() wires PlanConfig(embedding_model, embedding_provider) to PlanActor."""
+
+    def test_observer_creates_plan_actor_with_plan_config(self) -> None:
+        """observer() must pass PlanConfig (not BaseConfig) with embedding fields to PlanActor."""
+        from akgentic.tool.planning.planning import PlanningTool
+
+        tool = PlanningTool(
+            embedding_model="text-embedding-ada-002",
+            embedding_provider="azure",
+        )
+
+        # Capture the config passed to createActor
+        captured_config: list[PlanConfig] = []
+
+        mock_proxy_ask = MagicMock()
+        mock_proxy_ask.get_team_member.return_value = None  # Force actor creation path
+
+        def capture_create_actor(actor_cls: type, config: PlanConfig) -> MagicMock:
+            captured_config.append(config)
+            return MagicMock()
+
+        mock_proxy_ask.createActor.side_effect = capture_create_actor
+
+        mock_observer = MagicMock()
+        mock_observer.orchestrator = MagicMock()
+        mock_observer.proxy_ask.return_value = mock_proxy_ask
+
+        tool.observer(mock_observer)
+
+        assert len(captured_config) == 1
+        config = captured_config[0]
+        assert isinstance(config, PlanConfig), (
+            f"Expected PlanConfig, got {type(config).__name__}. "
+            "observer() must not pass a plain BaseConfig."
+        )
+        assert config.embedding_model == "text-embedding-ada-002"
+        assert config.embedding_provider == "azure"


### PR DESCRIPTION
## Summary

- Extends `PlanActor.get_planning_task` to accept `int | str`: integer triggers exact-ID lookup (no embedding), string triggers semantic cosine search via `_get_or_create_embedding_svc()` and `VectorIndex`
- Adds `embedding_model` and `embedding_provider` Pydantic fields to `PlanningTool`; `observer()` now constructs `PlanConfig` with those fields instead of a plain `BaseConfig`
- Adds `tests/test_planning_semantic.py` with 12 tests covering AC#1–#9 including all semantic search edge cases and `PlanningTool` field/wiring validation
- Extracts shared `MockActorAddress` fixture to `tests/conftest.py` eliminating duplication
- Fixes mypy `union-attr` in `_update_task` (direct narrowing replaces stored bool flag)

## Quality

- 376 tests pass, coverage 81.30% (>80% required)
- Ruff: clean
- mypy: 11 errors (all pre-existing; 2 fixed by this PR)

Closes #27