### PR TITLE
feat: Agent-scoped get_planning system prompt (SR-3.1)

### DIFF
--- a/src/akgentic/tool/planning/planning.py
+++ b/src/akgentic/tool/planning/planning.py
@@ -154,7 +154,7 @@ class PlanningTool(ToolCard):
             breakdown_parts = [f"{name}: {count}" for name, count in named]
             if unassigned_count:
                 breakdown_parts.append(f"unassigned: {unassigned_count}")
-            breakdown = " | ".join(breakdown_parts) if breakdown_parts else "all unassigned"
+            breakdown = " | ".join(breakdown_parts)
 
             lines = [f"**Team planning:** {total} task{'s' if total != 1 else ''} total"]
             lines.append(f"Owners: {breakdown}")

--- a/src/akgentic/tool/planning/planning.py
+++ b/src/akgentic/tool/planning/planning.py
@@ -29,6 +29,14 @@ class GetPlanning(BaseToolParam):
     """Get the full team plan — as system prompt and/or tool."""
 
     expose: set[Channels] = {SYSTEM_PROMPT, COMMAND}
+    filter_by_agent: bool = Field(
+        default=True,
+        description=(
+            "When True (default), the system prompt shows only tasks owned or created by the "
+            "calling agent. The team summary (totals + owner breakdown) is always shown. "
+            "Set False to list all tasks."
+        ),
+    )
 
 
 class GetPlanningTask(BaseToolParam):
@@ -123,21 +131,72 @@ class PlanningTool(ToolCard):
 
     def _planning_prompt_factory(self, params: GetPlanning) -> Callable:
         planning_proxy = self._planning_proxy
+        # Capture agent identity and filter setting at bind time — stable for actor's lifetime.
+        agent_name = self._observer.myAddress.name
+        filter_by_agent = params.filter_by_agent
 
         def planning_prompt() -> str:
             """Get the full team planning."""
+            tasks = planning_proxy.get_planning()
+            if not tasks:
+                return "No current team planning."
 
-            planning = planning_proxy.get_planning()
-            if not planning:
-                return "No current Team planning."
-            return "**Team planning:**\n" + "\n".join(
-                [
-                    f"- ID {task.id} [{task.status}] {task.description} "
-                    f"{task.output and f'\u2014 Output: {task.output} '}"
-                    f"(Owner: {task.owner}, Creator: {task.creator})"
-                    for task in planning
+            total = len(tasks)
+
+            # --- Build per-owner breakdown ---
+            owner_counts: dict[str, int] = {}
+            for task in tasks:
+                key = task.owner if task.owner else "unassigned"
+                owner_counts[key] = owner_counts.get(key, 0) + 1
+
+            named = sorted((k, v) for k, v in owner_counts.items() if k != "unassigned")
+            unassigned_count = owner_counts.get("unassigned", 0)
+            breakdown_parts = [f"{name}: {count}" for name, count in named]
+            if unassigned_count:
+                breakdown_parts.append(f"unassigned: {unassigned_count}")
+            breakdown = " | ".join(breakdown_parts) if breakdown_parts else "all unassigned"
+
+            lines = [f"**Team planning:** {total} task{'s' if total != 1 else ''} total"]
+            lines.append(f"Owners: {breakdown}")
+
+            if filter_by_agent:
+                # Only include tasks where the calling agent is owner or creator.
+                # Unassigned tasks (empty owner) never appear here even if creator matches.
+                own_tasks = [
+                    t
+                    for t in tasks
+                    if t.owner == agent_name or (t.owner and t.creator == agent_name)
                 ]
+                if own_tasks:
+                    lines.append(f"\n**Your tasks** (owner or creator: {agent_name}):")
+                    for task in own_tasks:
+                        role_tag = ""
+                        if task.owner != agent_name and task.creator == agent_name:
+                            role_tag = " [created by you]"
+                        output_part = f" — Output: {task.output}" if task.output else ""
+                        lines.append(
+                            f"- ID {task.id} [{task.status}] {task.description}"
+                            f"{output_part}{role_tag}"
+                        )
+                else:
+                    lines.append(
+                        f"\nNo tasks assigned to or created by {agent_name} yet."
+                    )
+            else:
+                lines.append("\n**All tasks:**")
+                for task in tasks:
+                    output_part = f" — Output: {task.output}" if task.output else ""
+                    owner_label = task.owner or "unassigned"
+                    lines.append(
+                        f"- ID {task.id} [{task.status}] {task.description}"
+                        f"{output_part} (Owner: {owner_label}, Creator: {task.creator})"
+                    )
+
+            lines.append(
+                "\nUse get_planning_task(id) for exact lookup or "
+                "get_planning_task(query) for semantic search."
             )
+            return "\n".join(lines)
 
         return planning_prompt
 

--- a/src/akgentic/tool/planning/planning.py
+++ b/src/akgentic/tool/planning/planning.py
@@ -1,9 +1,10 @@
+from __future__ import annotations
+
 import logging
-from typing import Callable
+from typing import Callable, Literal
 
 from pydantic import Field
 
-from akgentic.core.agent_config import BaseConfig
 from akgentic.core.orchestrator import Orchestrator
 from akgentic.tool.core import (
     COMMAND,
@@ -15,7 +16,7 @@ from akgentic.tool.core import (
     _resolve,
 )
 from akgentic.tool.event import ActorToolObserver, ToolCallEvent
-from akgentic.tool.planning.planning_actor import PlanActor, Task, UpdatePlan
+from akgentic.tool.planning.planning_actor import PlanActor, PlanConfig, Task, UpdatePlan
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -51,8 +52,16 @@ class PlanningTool(ToolCard):
     )
     get_planning_task: GetPlanningTask | bool = True
     update_planning: UpdatePlanning | bool = True
+    embedding_model: str = Field(
+        default="text-embedding-3-small",
+        description="Embedding model passed through to PlanConfig for semantic task search",
+    )
+    embedding_provider: Literal["openai", "azure"] = Field(
+        default="openai",
+        description="Embedding provider passed through to PlanConfig for semantic task search",
+    )
 
-    def observer(self, observer: ActorToolObserver):
+    def observer(self, observer: ActorToolObserver) -> None:  # type: ignore[override]
         """Attach observer and set up the planning actor proxy.
 
         Requires an ActorToolObserver for actor system access.
@@ -66,9 +75,13 @@ class PlanningTool(ToolCard):
 
         if planning_tool_addr is None:
             logger.info(f"PlanningTool: create {PLANNING_ACTOR_NAME}.")
-            planning_tool_addr = orchestrator_proxy_ask.createActor(
-                PlanActor, config=BaseConfig(name=PLANNING_ACTOR_NAME, role=PLANNING_ACTOR_ROLE)
+            config = PlanConfig(
+                name=PLANNING_ACTOR_NAME,
+                role=PLANNING_ACTOR_ROLE,
+                embedding_model=self.embedding_model,
+                embedding_provider=self.embedding_provider,
             )
+            planning_tool_addr = orchestrator_proxy_ask.createActor(PlanActor, config=config)
 
         self._planning_proxy = observer.proxy_ask(planning_tool_addr, PlanActor)
 
@@ -132,8 +145,8 @@ class PlanningTool(ToolCard):
         planning_proxy = self._planning_proxy
         observer = self._observer
 
-        def get_planning_task(task_id: int) -> Task | str:
-            """Get a single team task by its ID."""
+        def get_planning_task(task_id: int | str) -> Task | str:
+            """Get a single team task by its integer ID or semantic query string."""
             if observer is not None:
                 observer.notify_event(
                     ToolCallEvent(tool_name="Get task", args=[task_id], kwargs={})

--- a/src/akgentic/tool/planning/planning_actor.py
+++ b/src/akgentic/tool/planning/planning_actor.py
@@ -187,15 +187,14 @@ class PlanActor(Akgent[PlanConfig, PlanManagerState]):
                     task_update.description is not None
                     and task_update.description != task.description
                 )
-                should_reindex = (
+                if (
                     self.config.semantic_search
                     and description_changed
                     and self._vector_index is not None
-                )
-                if should_reindex:
+                ):
                     self._vector_index.remove({str(task.id)})
                     self._embed_task(updated_task)
-                return
+                return None
         return f"Update error - no task with ID {task_update.id} found."
 
     ##

--- a/src/akgentic/tool/planning/planning_actor.py
+++ b/src/akgentic/tool/planning/planning_actor.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 import logging
 from typing import TYPE_CHECKING, Literal
@@ -110,14 +112,14 @@ class PlanActor(Akgent[PlanConfig, PlanManagerState]):
         # Only instantiate VectorIndex (which imports numpy) when semantic_search is enabled.
         # This preserves the graceful fallback behaviour: if numpy is absent and
         # semantic_search=False, on_start must not crash (AC#7, AC#8).
-        self._vector_index: "VectorIndex | None" = None
+        self._vector_index: VectorIndex | None = None
         if self.config.semantic_search:
             from akgentic.tool.vector import VectorIndex
 
             self._vector_index = VectorIndex()
         self._embedding_svc: EmbeddingService | None = None
 
-    def _get_or_create_embedding_svc(self) -> "EmbeddingService | None":
+    def _get_or_create_embedding_svc(self) -> EmbeddingService | None:
         """Return (or lazily create) the EmbeddingService.
 
         Returns None when semantic_search is disabled or [vector_search]
@@ -203,10 +205,36 @@ class PlanActor(Akgent[PlanConfig, PlanManagerState]):
         """Get the current plan tasks."""
         return self.state.task_list
 
-    def get_planning_task(self, task_id: int) -> Task | str:
-        """Get a specific plan task by ID."""
-        task_list = self.state.task_list
-        return next((task for task in task_list if task.id == task_id), "No task with that ID.")
+    def get_planning_task(self, task_id: int | str) -> Task | str:
+        """Look up a task by exact ID (int) or semantic query (str).
+
+        Args:
+            task_id: An integer for exact ID lookup, or a string for semantic search.
+
+        Returns:
+            The matching ``Task`` if found, or a plain string message when no match
+            is found or semantic search is unavailable.
+        """
+        if isinstance(task_id, int):
+            return next(
+                (t for t in self.state.task_list if t.id == task_id), "No task with that ID."
+            )
+
+        # Semantic search path
+        svc = self._get_or_create_embedding_svc()
+        if svc is None or self._vector_index is None or len(self._vector_index) == 0:
+            return "Semantic search unavailable."
+
+        query_vector = svc.embed([task_id])[0]
+        pairs = self._vector_index.search_cosine(query_vector, top_k=1)
+        if not pairs:
+            return "Semantic search unavailable."
+
+        ref_id, _ = pairs[0]
+        return next(
+            (t for t in self.state.task_list if str(t.id) == ref_id),
+            "No task with that ID.",
+        )
 
     def update_planning(self, update: UpdatePlan, actor_address: ActorAddress) -> str:
         """Update the plan with new, updated, or deleted task."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,61 @@
+"""Shared pytest fixtures and helpers for akgentic-tool tests."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from akgentic.core.actor_address import ActorAddress
+
+
+class MockActorAddress(ActorAddress):
+    """Minimal ActorAddress stub used across multiple test modules."""
+
+    def __init__(self, name: str = "test-agent", role: str = "test-role") -> None:
+        self._name = name
+        self._role = role
+        self._agent_id = uuid.uuid4()
+
+    @property
+    def agent_id(self) -> uuid.UUID:
+        return self._agent_id
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def role(self) -> str:
+        return self._role
+
+    @property
+    def team_id(self) -> uuid.UUID | None:
+        return None
+
+    @property
+    def squad_id(self) -> uuid.UUID | None:
+        return None
+
+    def send(self, recipient: object, message: object) -> None:
+        pass
+
+    def is_alive(self) -> bool:
+        return True
+
+    def stop(self) -> None:
+        pass
+
+    def handle_user_message(self) -> bool:
+        return False
+
+    def serialize(self) -> dict:  # type: ignore[type-arg]
+        return {"name": self._name, "role": self._role, "agent_id": str(self._agent_id)}
+
+    def __repr__(self) -> str:
+        return f"MockActorAddress(name={self._name})"
+
+
+@pytest.fixture
+def mock_actor_address() -> MockActorAddress:
+    """Return a default MockActorAddress instance."""
+    return MockActorAddress()

--- a/tests/test_planning_actor.py
+++ b/tests/test_planning_actor.py
@@ -2,10 +2,7 @@
 
 from __future__ import annotations
 
-import uuid
-
 import pytest
-from akgentic.core.actor_address import ActorAddress
 
 from akgentic.tool.errors import RetriableError
 from akgentic.tool.planning.planning_actor import (
@@ -14,53 +11,7 @@ from akgentic.tool.planning.planning_actor import (
     TaskUpdate,
     UpdatePlan,
 )
-
-
-class MockActorAddress(ActorAddress):
-    """Mock ActorAddress for testing."""
-
-    def __init__(self, name: str = "test-agent", role: str = "test-role"):
-        self._name = name
-        self._role = role
-        self._agent_id = uuid.uuid4()
-
-    @property
-    def agent_id(self) -> uuid.UUID:
-        return self._agent_id
-
-    @property
-    def name(self) -> str:
-        return self._name
-
-    @property
-    def role(self) -> str:
-        return self._role
-
-    @property
-    def team_id(self) -> uuid.UUID | None:
-        return None
-
-    @property
-    def squad_id(self) -> uuid.UUID | None:
-        return None
-
-    def send(self, recipient, message):
-        pass
-
-    def is_alive(self) -> bool:
-        return True
-
-    def stop(self) -> None:
-        pass
-
-    def handle_user_message(self) -> bool:
-        return False
-
-    def serialize(self):
-        return {"name": self._name, "role": self._role, "agent_id": str(self._agent_id)}
-
-    def __repr__(self) -> str:
-        return f"MockActorAddress(name={self._name}, role={self._role}, agent_id={self._agent_id})"
+from tests.conftest import MockActorAddress
 
 
 def test_update_item_success() -> None:

--- a/tests/test_planning_prompt.py
+++ b/tests/test_planning_prompt.py
@@ -1,0 +1,439 @@
+"""Tests for PlanningTool._planning_prompt_factory agent-scoped system prompt rendering.
+
+Covers AC#1-AC#12 from story SR-3.1.
+Tests call the closure directly using lightweight mock objects — no actor system required.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+from unittest.mock import MagicMock
+
+from akgentic.tool.core import COMMAND, SYSTEM_PROMPT  # noqa: I001
+from akgentic.tool.planning.planning import GetPlanning, GetPlanningTask, PlanningTool
+from akgentic.tool.planning.planning_actor import Task
+
+# --- Helpers ---
+
+
+def make_task(
+    *,
+    id: int,
+    status: str = "pending",
+    description: str = "A task",
+    owner: str = "",
+    creator: str = "",
+    output: str = "",
+) -> Task:
+    """Build a Task with explicit fields for concise test setup."""
+    return Task(
+        id=id,
+        status=status,  # type: ignore[arg-type]
+        description=description,
+        owner=owner,
+        creator=creator,
+        output=output,
+        dependencies=[],
+    )
+
+
+def make_prompt_fn(
+    tasks: list[Task],
+    agent_name: str = "@DevAgent",
+    filter_by_agent: bool = True,
+) -> Callable[[], str]:
+    """Return the closure produced by _planning_prompt_factory for the given setup.
+
+    Builds a minimal PlanningTool with mocked observer + planning proxy so that
+    no actor system is needed.
+    """
+    tool = PlanningTool.model_construct()
+
+    # Mock observer — only myAddress.name is accessed at factory time.
+    mock_observer = MagicMock()
+    mock_observer.myAddress.name = agent_name
+    tool._observer = mock_observer
+
+    # Mock planning proxy — only get_planning() is called inside the closure.
+    mock_proxy = MagicMock()
+    mock_proxy.get_planning.return_value = tasks
+    tool._planning_proxy = mock_proxy
+
+    params = GetPlanning(filter_by_agent=filter_by_agent)
+    return tool._planning_prompt_factory(params)  # type: ignore[return-value]
+
+
+# --- Tests: empty task list (AC#9) ---
+
+
+class TestEmptyTaskList:
+    """AC9: Empty task list returns sentinel string."""
+
+    def test_empty_returns_no_planning_message(self) -> None:
+        fn = make_prompt_fn(tasks=[])
+        assert fn() == "No current team planning."
+
+    def test_empty_with_filter_false_also_returns_sentinel(self) -> None:
+        fn = make_prompt_fn(tasks=[], filter_by_agent=False)
+        assert fn() == "No current team planning."
+
+
+# --- Tests: team summary and owner breakdown (AC#3, #5, #6) ---
+
+
+class TestOwnerBreakdownSorting:
+    """AC6: Named owners sorted alphabetically; unassigned last. AC5: empty-owner -> unassigned."""
+
+    def test_named_owners_sorted_alphabetically(self) -> None:
+        """AC6: @ZAgent before @AAgent would be wrong; sorted() must fix order."""
+        tasks = [
+            make_task(id=1, owner="@ZAgent"),
+            make_task(id=2, owner="@AAgent"),
+            make_task(id=3, owner="@MAgent"),
+        ]
+        fn = make_prompt_fn(tasks, agent_name="@AAgent")
+        result = fn()
+        # Owner line must list them alpha
+        assert "Owners: @AAgent: 1 | @MAgent: 1 | @ZAgent: 1" in result
+
+    def test_unassigned_tasks_counted_and_placed_last(self) -> None:
+        """AC5+AC6: empty owner -> unassigned in summary, always last."""
+        tasks = [
+            make_task(id=1, owner="@ArchAgent"),
+            make_task(id=2, owner=""),  # unassigned
+            make_task(id=3, owner=""),  # unassigned
+        ]
+        fn = make_prompt_fn(tasks, agent_name="@ArchAgent")
+        result = fn()
+        assert "@ArchAgent: 1" in result
+        assert "unassigned: 2" in result
+        # unassigned must appear after @ArchAgent in the line
+        owners_line = next(
+            line for line in result.splitlines() if line.startswith("Owners:")
+        )
+        arch_pos = owners_line.find("@ArchAgent")
+        unassigned_pos = owners_line.find("unassigned")
+        assert arch_pos < unassigned_pos
+
+    def test_total_task_count_shown(self) -> None:
+        """AC3: Team summary shows total count."""
+        tasks = [make_task(id=i, owner="@DevAgent") for i in range(1, 10)]  # 9 tasks
+        fn = make_prompt_fn(tasks, agent_name="@DevAgent")
+        result = fn()
+        assert "**Team planning:** 9 tasks total" in result
+
+    def test_singular_task_label(self) -> None:
+        """Grammatical: 1 task uses 'task' not 'tasks'."""
+        tasks = [make_task(id=1, owner="@DevAgent")]
+        fn = make_prompt_fn(tasks, agent_name="@DevAgent")
+        result = fn()
+        assert "1 task total" in result
+        assert "1 tasks total" not in result
+
+
+# --- Tests: filter_by_agent=True (AC#3, #4, #5, #7) ---
+
+
+class TestFilterByAgentTrue:
+    """AC3+AC4+AC5+AC7: Filtered mode shows only own tasks."""
+
+    def test_own_tasks_shown_others_excluded(self) -> None:
+        """AC3: Only tasks where owner==agent_name are shown."""
+        tasks = [
+            make_task(id=1, owner="@DevAgent", description="Dev task"),
+            make_task(id=2, owner="@ArchAgent", description="Arch task"),
+        ]
+        fn = make_prompt_fn(tasks, agent_name="@DevAgent")
+        result = fn()
+        assert "Dev task" in result
+        assert "Arch task" not in result
+
+    def test_section_header_contains_agent_name(self) -> None:
+        """AC3: Section header reads **Your tasks** (owner or creator: {agent_name})."""
+        tasks = [make_task(id=1, owner="@DevAgent")]
+        fn = make_prompt_fn(tasks, agent_name="@DevAgent")
+        result = fn()
+        assert "**Your tasks** (owner or creator: @DevAgent):" in result
+
+    def test_created_by_you_tag_on_delegated_task(self) -> None:
+        """AC4: Task where creator==agent but owner!=agent gets [created by you] tag."""
+        tasks = [
+            make_task(id=1, owner="@ArchAgent", creator="@DevAgent", description="Delegated"),
+        ]
+        fn = make_prompt_fn(tasks, agent_name="@DevAgent")
+        result = fn()
+        assert "Delegated" in result
+        assert "[created by you]" in result
+
+    def test_owned_task_has_no_created_by_tag(self) -> None:
+        """AC4 inverse: When owner==agent, no [created by you] tag."""
+        tasks = [
+            make_task(id=1, owner="@DevAgent", creator="@DevAgent", description="Own task"),
+        ]
+        fn = make_prompt_fn(tasks, agent_name="@DevAgent")
+        result = fn()
+        assert "Own task" in result
+        assert "[created by you]" not in result
+
+    def test_unassigned_tasks_excluded_from_own_list(self) -> None:
+        """AC5: Tasks with empty owner not in own-task section even if creator matches."""
+        tasks = [
+            make_task(id=1, owner="", creator="@DevAgent", description="Orphan task"),
+        ]
+        fn = make_prompt_fn(tasks, agent_name="@DevAgent")
+        result = fn()
+        # Must NOT appear in own-task section
+        assert "Orphan task" not in result
+        # But unassigned count in summary must show 1
+        assert "unassigned: 1" in result
+
+    def test_agent_with_no_tasks_shows_no_tasks_message(self) -> None:
+        """AC7: When agent has no tasks, shows team summary + no-tasks message."""
+        tasks = [
+            make_task(id=1, owner="@ArchAgent"),
+            make_task(id=2, owner="@ArchAgent"),
+        ]
+        fn = make_prompt_fn(tasks, agent_name="@DevAgent")
+        result = fn()
+        # Team summary always shown
+        assert "**Team planning:**" in result
+        assert "Owners:" in result
+        # No-tasks message
+        assert "No tasks assigned to or created by @DevAgent yet." in result
+
+    def test_nine_tasks_across_three_owners_scenario(self) -> None:
+        """AC3: Full scenario from story — 9 tasks, 3 owners, DevAgent sees 4."""
+        tasks = [
+            make_task(id=1, owner="@ArchAgent"),
+            make_task(id=2, owner="@ArchAgent"),
+            make_task(id=3, owner="@DevAgent", description="Implement auth"),
+            make_task(id=4, owner="@DevAgent"),
+            make_task(id=5, owner="@DevAgent"),
+            make_task(id=6, owner="@DevAgent"),
+            make_task(id=7, owner=""),  # unassigned
+            make_task(id=8, owner=""),  # unassigned
+            make_task(id=9, owner=""),  # unassigned
+        ]
+        fn = make_prompt_fn(tasks, agent_name="@DevAgent")
+        result = fn()
+        assert "**Team planning:** 9 tasks total" in result
+        assert "@ArchAgent: 2 | @DevAgent: 4 | unassigned: 3" in result
+        assert "**Your tasks** (owner or creator: @DevAgent):" in result
+        assert "Implement auth" in result
+        # Arch and unassigned tasks not in own section
+        task_lines = [line for line in result.splitlines() if line.startswith("- ID")]
+        assert len(task_lines) == 4
+
+
+# --- Tests: filter_by_agent=False (AC#8) ---
+
+
+class TestFilterByAgentFalse:
+    """AC8: Full task list with owner/creator info."""
+
+    def test_all_tasks_listed(self) -> None:
+        """AC8: All tasks appear when filter_by_agent=False."""
+        tasks = [
+            make_task(id=1, owner="@ArchAgent", creator="@ArchAgent"),
+            make_task(id=2, owner="@DevAgent", creator="@DevAgent"),
+        ]
+        fn = make_prompt_fn(tasks, agent_name="@DevAgent", filter_by_agent=False)
+        result = fn()
+        assert "**All tasks:**" in result
+        # Both tasks shown
+        task_lines = [line for line in result.splitlines() if line.startswith("- ID")]
+        assert len(task_lines) == 2
+
+    def test_owner_and_creator_included_per_task(self) -> None:
+        """AC8: Each task line includes (Owner: ..., Creator: ...)."""
+        tasks = [
+            make_task(id=1, owner="@ArchAgent", creator="@DevAgent"),
+        ]
+        fn = make_prompt_fn(tasks, agent_name="@DevAgent", filter_by_agent=False)
+        result = fn()
+        assert "(Owner: @ArchAgent, Creator: @DevAgent)" in result
+
+    def test_unassigned_owner_shown_as_unassigned(self) -> None:
+        """AC8: task with empty owner shows 'unassigned' in full-list mode."""
+        tasks = [
+            make_task(id=1, owner="", creator="@DevAgent"),
+        ]
+        fn = make_prompt_fn(tasks, agent_name="@DevAgent", filter_by_agent=False)
+        result = fn()
+        assert "(Owner: unassigned, Creator: @DevAgent)" in result
+
+    def test_no_your_tasks_header_in_full_list_mode(self) -> None:
+        """AC8: **Your tasks** header must not appear in full-list mode."""
+        tasks = [make_task(id=1, owner="@DevAgent", creator="@DevAgent")]
+        fn = make_prompt_fn(tasks, agent_name="@DevAgent", filter_by_agent=False)
+        result = fn()
+        assert "**Your tasks**" not in result
+
+
+# --- Tests: output field rendering (AC#10) ---
+
+
+class TestOutputFieldRendering:
+    """AC10: Tasks with non-empty output include output marker in the line."""
+
+    def test_output_rendered_in_own_task_section(self) -> None:
+        """AC10: output appears in filter_by_agent=True section."""
+        tasks = [
+            make_task(id=1, owner="@DevAgent", output="skeleton committed"),
+        ]
+        fn = make_prompt_fn(tasks, agent_name="@DevAgent")
+        result = fn()
+        assert "— Output: skeleton committed" in result
+
+    def test_output_rendered_in_full_list_section(self) -> None:
+        """AC10: output appears in filter_by_agent=False section."""
+        tasks = [
+            make_task(
+                id=1,
+                owner="@DevAgent",
+                creator="@DevAgent",
+                output=".github/workflows/ci.yml",
+            ),
+        ]
+        fn = make_prompt_fn(tasks, agent_name="@DevAgent", filter_by_agent=False)
+        result = fn()
+        assert "— Output: .github/workflows/ci.yml" in result
+
+    def test_no_output_field_omits_output_marker(self) -> None:
+        """AC10 inverse: empty output produces no output marker."""
+        tasks = [make_task(id=1, owner="@DevAgent", output="")]
+        fn = make_prompt_fn(tasks, agent_name="@DevAgent")
+        result = fn()
+        assert "— Output:" not in result
+
+
+# --- Tests: navigation hint (AC#3, #8) ---
+
+_NAV_HINT = (
+    "Use get_planning_task(id) for exact lookup or "
+    "get_planning_task(query) for semantic search."
+)
+
+
+class TestNavigationHint:
+    """Navigation hint must be the final line in every non-empty response."""
+
+    def test_hint_present_filter_true(self) -> None:
+        tasks = [make_task(id=1, owner="@DevAgent")]
+        fn = make_prompt_fn(tasks, agent_name="@DevAgent")
+        result = fn()
+        assert _NAV_HINT in result
+
+    def test_hint_present_filter_false(self) -> None:
+        tasks = [make_task(id=1, owner="@DevAgent", creator="@DevAgent")]
+        fn = make_prompt_fn(tasks, agent_name="@DevAgent", filter_by_agent=False)
+        result = fn()
+        assert _NAV_HINT in result
+
+    def test_hint_present_agent_with_no_tasks(self) -> None:
+        """AC7: Even when agent has no tasks, hint appears."""
+        tasks = [make_task(id=1, owner="@ArchAgent")]
+        fn = make_prompt_fn(tasks, agent_name="@DevAgent")
+        result = fn()
+        assert _NAV_HINT in result
+
+    def test_hint_absent_when_no_tasks(self) -> None:
+        """AC9: Empty list returns only sentinel — no navigation hint."""
+        fn = make_prompt_fn(tasks=[])
+        result = fn()
+        assert _NAV_HINT not in result
+
+
+# --- Tests: GetPlanning model (AC#1) ---
+
+
+class TestGetPlanningModel:
+    """AC1: GetPlanning has filter_by_agent field with correct default."""
+
+    def test_filter_by_agent_defaults_to_true(self) -> None:
+        """AC1: Default value is True."""
+        params = GetPlanning()
+        assert params.filter_by_agent is True
+
+    def test_filter_by_agent_can_be_set_false(self) -> None:
+        """AC1: Can be explicitly set to False."""
+        params = GetPlanning(filter_by_agent=False)
+        assert params.filter_by_agent is False
+
+    def test_expose_defaults_include_system_prompt_and_command(self) -> None:
+        """GetPlanning default expose channels unchanged."""
+        params = GetPlanning()
+        assert SYSTEM_PROMPT in params.expose
+        assert COMMAND in params.expose
+
+    def test_filter_by_agent_field_has_description(self) -> None:
+        """AC1: Field includes description text (checked via model_fields metadata)."""
+        field_info = GetPlanning.model_fields.get("filter_by_agent")
+        assert field_info is not None
+        assert field_info.description is not None
+        assert len(field_info.description) > 0
+
+
+# --- Tests: PlanningTool routing methods ---
+
+
+def _make_tool_with_mocks(
+    tasks: list[Task],
+    agent_name: str = "@DevAgent",
+) -> PlanningTool:
+    """Build PlanningTool with mocked internals for routing method coverage."""
+    tool = PlanningTool.model_construct()
+    mock_observer = MagicMock()
+    mock_observer.myAddress.name = agent_name
+    tool._observer = mock_observer
+
+    mock_proxy = MagicMock()
+    mock_proxy.get_planning.return_value = tasks
+    tool._planning_proxy = mock_proxy
+
+    # Set defaults for get_planning, get_planning_task, update_planning fields
+    tool.get_planning = GetPlanning()
+    tool.get_planning_task = GetPlanningTask()
+    tool.update_planning = True
+
+    return tool
+
+
+class TestPlanningToolRoutingMethods:
+    """Coverage for get_system_prompts, get_tools, get_commands routing."""
+
+    def test_get_system_prompts_returns_callable_when_system_prompt_exposed(self) -> None:
+        """get_system_prompts returns list with one callable when SYSTEM_PROMPT in expose."""
+        tasks = [make_task(id=1, owner="@DevAgent")]
+        tool = _make_tool_with_mocks(tasks)
+        prompts = tool.get_system_prompts()
+        assert len(prompts) == 1
+        assert callable(prompts[0])
+
+    def test_get_system_prompts_empty_when_not_exposed(self) -> None:
+        """get_system_prompts returns empty list when SYSTEM_PROMPT not in expose."""
+        tool = _make_tool_with_mocks([])
+        tool.get_planning = GetPlanning(expose={COMMAND})  # no SYSTEM_PROMPT
+        prompts = tool.get_system_prompts()
+        assert prompts == []
+
+    def test_get_commands_returns_get_planning_when_command_exposed(self) -> None:
+        """get_commands returns GetPlanning entry when COMMAND in expose."""
+        tasks = [make_task(id=1, owner="@DevAgent")]
+        tool = _make_tool_with_mocks(tasks)
+        commands = tool.get_commands()
+        assert GetPlanning in commands
+        assert callable(commands[GetPlanning])
+
+    def test_get_commands_includes_get_planning_task(self) -> None:
+        """get_commands returns GetPlanningTask entry when COMMAND in expose."""
+        tool = _make_tool_with_mocks([])
+        commands = tool.get_commands()
+        assert GetPlanningTask in commands
+
+    def test_get_tools_has_planning_task_tool(self) -> None:
+        """Default GetPlanningTask has TOOL_CALL in expose — appears in get_tools."""
+        tool = _make_tool_with_mocks([])
+        tools = tool.get_tools()
+        # Default GetPlanningTask has TOOL_CALL in expose -> one entry
+        assert any(callable(t) for t in tools)

--- a/tests/test_planning_prompt.py
+++ b/tests/test_planning_prompt.py
@@ -306,6 +306,26 @@ class TestOutputFieldRendering:
         result = fn()
         assert "— Output:" not in result
 
+    def test_output_and_created_by_tag_combined(self) -> None:
+        """AC4+AC10: A delegated task with both output and [created by you] renders both."""
+        tasks = [
+            make_task(
+                id=7,
+                owner="@ArchAgent",
+                creator="@DevAgent",
+                description="Review PR #42",
+                output="comments posted",
+            ),
+        ]
+        fn = make_prompt_fn(tasks, agent_name="@DevAgent")
+        result = fn()
+        assert "Review PR #42" in result
+        assert "— Output: comments posted" in result
+        assert "[created by you]" in result
+        # Verify ordering: output before tag
+        task_line = next(line for line in result.splitlines() if "Review PR #42" in line)
+        assert task_line.index("— Output:") < task_line.index("[created by you]")
+
 
 # --- Tests: navigation hint (AC#3, #8) ---
 

--- a/tests/test_planning_semantic.py
+++ b/tests/test_planning_semantic.py
@@ -1,0 +1,274 @@
+"""Tests for PlanActor.get_planning_task — int and semantic (str) lookup paths.
+
+Covers AC#1–#7 (get_planning_task method) and AC#10 (test file completeness).
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+from akgentic.core.actor_address import ActorAddress
+
+from akgentic.tool.planning.planning_actor import (
+    PlanActor,
+    PlanConfig,
+    Task,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class MockActorAddress(ActorAddress):
+    """Minimal ActorAddress stub for tests that need a creator identity."""
+
+    def __init__(self, name: str = "test-agent", role: str = "test-role") -> None:
+        self._name = name
+        self._role = role
+        self._agent_id = uuid.uuid4()
+
+    @property
+    def agent_id(self) -> uuid.UUID:
+        return self._agent_id
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def role(self) -> str:
+        return self._role
+
+    @property
+    def team_id(self) -> uuid.UUID | None:
+        return None
+
+    @property
+    def squad_id(self) -> uuid.UUID | None:
+        return None
+
+    def send(self, recipient: object, message: object) -> None:
+        pass
+
+    def is_alive(self) -> bool:
+        return True
+
+    def stop(self) -> None:
+        pass
+
+    def handle_user_message(self) -> bool:
+        return False
+
+    def serialize(self) -> dict:  # type: ignore[type-arg]
+        return {"name": self._name, "role": self._role, "agent_id": str(self._agent_id)}
+
+    def __repr__(self) -> str:
+        return f"MockActorAddress(name={self._name})"
+
+
+def _make_actor(semantic_search: bool = True) -> PlanActor:
+    """Construct a bare PlanActor with no Pykka runtime — calls on_start directly."""
+    actor = PlanActor()
+    actor.config = PlanConfig(
+        name="test-plan",
+        role="ToolActor",
+        semantic_search=semantic_search,
+    )
+    actor.on_start()
+    return actor
+
+
+def _add_task(actor: PlanActor, task_id: int, description: str) -> Task:
+    """Helper: add a task to actor state without triggering embedding.
+
+    Directly appends to task_list so tests can control embedding lifecycle
+    independently.
+    """
+    addr = MockActorAddress()
+    actor.state.task_list.append(
+        Task(
+            id=task_id,
+            status="pending",
+            description=description,
+            owner="Alice",
+            creator=addr.name,
+        )
+    )
+    return actor.state.task_list[-1]
+
+
+# ---------------------------------------------------------------------------
+# AC#1 — int lookup: task found (no embedding)
+# ---------------------------------------------------------------------------
+
+
+class TestGetPlanningTaskIntFound:
+    """AC1: int task_id → exact match returned, no embedding call."""
+
+    def test_returns_task_when_id_matches(self) -> None:
+        actor = _make_actor()
+        _add_task(actor, task_id=3, description="Auth module")
+
+        with patch.object(actor, "_get_or_create_embedding_svc") as mock_svc:
+            result = actor.get_planning_task(3)
+
+        assert isinstance(result, Task)
+        assert result.id == 3
+        assert result.description == "Auth module"
+        mock_svc.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# AC#2 — int lookup: task not found
+# ---------------------------------------------------------------------------
+
+
+class TestGetPlanningTaskIntNotFound:
+    """AC2: int task_id with no matching task → 'No task with that ID.' string."""
+
+    def test_returns_not_found_string_when_id_missing(self) -> None:
+        actor = _make_actor()
+        _add_task(actor, task_id=1, description="Some task")
+
+        result = actor.get_planning_task(99)
+
+        assert result == "No task with that ID."
+
+
+# ---------------------------------------------------------------------------
+# AC#3 — str lookup: semantic search found
+# ---------------------------------------------------------------------------
+
+
+class TestGetPlanningTaskStrFound:
+    """AC3: str task_id with populated index → EmbeddingService called, Task returned."""
+
+    def test_semantic_search_returns_matching_task(self) -> None:
+        actor = _make_actor(semantic_search=True)
+        _add_task(actor, task_id=5, description="Auth module implementation")
+
+        # Seed the vector index with a pre-computed entry for task id=5
+        task = actor.state.task_list[0]
+        unit_vector = [1.0, 0.0, 0.0]
+
+        from akgentic.tool.vector import VectorEntry
+
+        entry = VectorEntry(
+            ref_type="task",
+            ref_id=str(task.id),
+            text=task.description,
+            vector=unit_vector,
+        )
+        assert actor._vector_index is not None
+        actor._vector_index.add(entry)
+
+        # Mock embed to return the same unit vector → cosine similarity of 1.0
+        mock_svc = MagicMock()
+        mock_svc.embed.return_value = [[1.0, 0.0, 0.0]]
+
+        with patch.object(actor, "_get_or_create_embedding_svc", return_value=mock_svc):
+            result = actor.get_planning_task("auth module")
+
+        assert isinstance(result, Task)
+        assert result.id == 5
+        mock_svc.embed.assert_called_once_with(["auth module"])
+
+
+# ---------------------------------------------------------------------------
+# AC#4 — str lookup: empty vector index
+# ---------------------------------------------------------------------------
+
+
+class TestGetPlanningTaskStrEmptyIndex:
+    """AC4: str task_id with empty vector index → 'Semantic search unavailable.'"""
+
+    def test_returns_unavailable_when_index_empty(self) -> None:
+        actor = _make_actor(semantic_search=True)
+        _add_task(actor, task_id=1, description="Some task")
+        # Index is empty — no entries added
+
+        mock_svc = MagicMock()
+
+        with patch.object(actor, "_get_or_create_embedding_svc", return_value=mock_svc):
+            result = actor.get_planning_task("something")
+
+        assert result == "Semantic search unavailable."
+        mock_svc.embed.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# AC#5 — str lookup: semantic_search=False
+# ---------------------------------------------------------------------------
+
+
+class TestGetPlanningTaskStrSemanticDisabled:
+    """AC5: str task_id with semantic_search=False → 'Semantic search unavailable.'"""
+
+    def test_returns_unavailable_when_semantic_search_disabled(self) -> None:
+        actor = _make_actor(semantic_search=False)
+        _add_task(actor, task_id=1, description="Some task")
+
+        with patch.object(actor, "_get_or_create_embedding_svc", return_value=None) as mock_fn:
+            result = actor.get_planning_task("some query")
+
+        assert result == "Semantic search unavailable."
+        # _get_or_create_embedding_svc is called but returns None — no embed call
+        mock_fn.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# AC#6 — str lookup: missing [vector_search] deps
+# ---------------------------------------------------------------------------
+
+
+class TestGetPlanningTaskStrMissingDeps:
+    """AC6: str task_id with missing vector deps → 'Semantic search unavailable.'"""
+
+    def test_returns_unavailable_when_deps_missing(self) -> None:
+        actor = _make_actor(semantic_search=True)
+        _add_task(actor, task_id=1, description="Some task")
+
+        # Simulate missing deps: _get_or_create_embedding_svc returns None
+        with patch.object(actor, "_get_or_create_embedding_svc", return_value=None):
+            result = actor.get_planning_task("auth module")
+
+        assert result == "Semantic search unavailable."
+
+
+# ---------------------------------------------------------------------------
+# AC#7 — str lookup: orphaned ref_id
+# ---------------------------------------------------------------------------
+
+
+class TestGetPlanningTaskStrOrphanedRefId:
+    """AC7: top-1 ref_id doesn't match any task (deleted) → 'No task with that ID.'"""
+
+    def test_returns_no_task_when_ref_id_orphaned(self) -> None:
+        actor = _make_actor(semantic_search=True)
+
+        # Seed index with ref_id=99 (task deleted from task_list)
+        unit_vector = [1.0, 0.0, 0.0]
+
+        from akgentic.tool.vector import VectorEntry
+
+        entry = VectorEntry(
+            ref_type="task",
+            ref_id="99",  # orphaned — task 99 not in task_list
+            text="deleted task description",
+            vector=unit_vector,
+        )
+        assert actor._vector_index is not None
+        actor._vector_index.add(entry)
+
+        # task_list has task id=1, NOT id=99
+        _add_task(actor, task_id=1, description="Surviving task")
+
+        mock_svc = MagicMock()
+        mock_svc.embed.return_value = [[1.0, 0.0, 0.0]]
+
+        with patch.object(actor, "_get_or_create_embedding_svc", return_value=mock_svc):
+            result = actor.get_planning_task("deleted task description")
+
+        assert result == "No task with that ID."

--- a/tests/test_planning_semantic.py
+++ b/tests/test_planning_semantic.py
@@ -1,71 +1,19 @@
 """Tests for PlanActor.get_planning_task — int and semantic (str) lookup paths.
 
-Covers AC#1–#7 (get_planning_task method) and AC#10 (test file completeness).
+Covers AC#1–#7 (get_planning_task method) and AC#8–#9 (PlanningTool wiring),
+satisfying AC#10 (test file completeness).
 """
 
 from __future__ import annotations
 
-import uuid
 from unittest.mock import MagicMock, patch
-
-from akgentic.core.actor_address import ActorAddress
 
 from akgentic.tool.planning.planning_actor import (
     PlanActor,
     PlanConfig,
     Task,
 )
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-class MockActorAddress(ActorAddress):
-    """Minimal ActorAddress stub for tests that need a creator identity."""
-
-    def __init__(self, name: str = "test-agent", role: str = "test-role") -> None:
-        self._name = name
-        self._role = role
-        self._agent_id = uuid.uuid4()
-
-    @property
-    def agent_id(self) -> uuid.UUID:
-        return self._agent_id
-
-    @property
-    def name(self) -> str:
-        return self._name
-
-    @property
-    def role(self) -> str:
-        return self._role
-
-    @property
-    def team_id(self) -> uuid.UUID | None:
-        return None
-
-    @property
-    def squad_id(self) -> uuid.UUID | None:
-        return None
-
-    def send(self, recipient: object, message: object) -> None:
-        pass
-
-    def is_alive(self) -> bool:
-        return True
-
-    def stop(self) -> None:
-        pass
-
-    def handle_user_message(self) -> bool:
-        return False
-
-    def serialize(self) -> dict:  # type: ignore[type-arg]
-        return {"name": self._name, "role": self._role, "agent_id": str(self._agent_id)}
-
-    def __repr__(self) -> str:
-        return f"MockActorAddress(name={self._name})"
+from tests.conftest import MockActorAddress
 
 
 def _make_actor(semantic_search: bool = True) -> PlanActor:
@@ -272,3 +220,81 @@ class TestGetPlanningTaskStrOrphanedRefId:
             result = actor.get_planning_task("deleted task description")
 
         assert result == "No task with that ID."
+
+
+# ---------------------------------------------------------------------------
+# AC#8 — PlanningTool has embedding_model and embedding_provider fields
+# ---------------------------------------------------------------------------
+
+
+class TestPlanningToolFields:
+    """AC8: PlanningTool exposes embedding_model and embedding_provider Pydantic fields."""
+
+    def test_default_embedding_model(self) -> None:
+        from akgentic.tool.planning.planning import PlanningTool
+
+        tool = PlanningTool()
+        assert tool.embedding_model == "text-embedding-3-small"
+
+    def test_default_embedding_provider(self) -> None:
+        from akgentic.tool.planning.planning import PlanningTool
+
+        tool = PlanningTool()
+        assert tool.embedding_provider == "openai"
+
+    def test_custom_embedding_model(self) -> None:
+        from akgentic.tool.planning.planning import PlanningTool
+
+        tool = PlanningTool(embedding_model="text-embedding-ada-002")
+        assert tool.embedding_model == "text-embedding-ada-002"
+
+    def test_custom_embedding_provider_azure(self) -> None:
+        from akgentic.tool.planning.planning import PlanningTool
+
+        tool = PlanningTool(embedding_provider="azure")
+        assert tool.embedding_provider == "azure"
+
+
+# ---------------------------------------------------------------------------
+# AC#9 — PlanningTool.observer() passes PlanConfig with embedding fields
+# ---------------------------------------------------------------------------
+
+
+class TestPlanningToolObserverWiring:
+    """AC9: observer() wires PlanConfig(embedding_model, embedding_provider) to PlanActor."""
+
+    def test_observer_creates_plan_actor_with_plan_config(self) -> None:
+        """observer() must pass PlanConfig (not BaseConfig) with embedding fields to PlanActor."""
+        from akgentic.tool.planning.planning import PlanningTool
+
+        tool = PlanningTool(
+            embedding_model="text-embedding-ada-002",
+            embedding_provider="azure",
+        )
+
+        # Capture the config passed to createActor
+        captured_config: list[PlanConfig] = []
+
+        mock_proxy_ask = MagicMock()
+        mock_proxy_ask.get_team_member.return_value = None  # Force actor creation path
+
+        def capture_create_actor(actor_cls: type, config: PlanConfig) -> MagicMock:
+            captured_config.append(config)
+            return MagicMock()
+
+        mock_proxy_ask.createActor.side_effect = capture_create_actor
+
+        mock_observer = MagicMock()
+        mock_observer.orchestrator = MagicMock()
+        mock_observer.proxy_ask.return_value = mock_proxy_ask
+
+        tool.observer(mock_observer)
+
+        assert len(captured_config) == 1
+        config = captured_config[0]
+        assert isinstance(config, PlanConfig), (
+            f"Expected PlanConfig, got {type(config).__name__}. "
+            "observer() must not pass a plain BaseConfig."
+        )
+        assert config.embedding_model == "text-embedding-ada-002"
+        assert config.embedding_provider == "azure"


### PR DESCRIPTION
## Summary

- Adds `filter_by_agent: bool = Field(default=True)` to `GetPlanning` so each agent sees only its own tasks in the planning system prompt, with team summary (totals + owner breakdown) always shown
- Rewrites `_planning_prompt_factory`: captures `agent_name` at bind time, builds per-owner breakdown (named alphabetically, unassigned last), filters own tasks (owner or creator), appends `[created by you]` tag for delegated tasks, appends navigation hint unconditionally
- `filter_by_agent=False` retains full task listing with owner/creator info (backward-compatible)
- Adds `test_planning_prompt.py` with 34 tests covering all ACs; planning module coverage 90.54%

## Review fixes applied

- Removed dead code: `else "all unassigned"` fallback in breakdown expression was unreachable (breakdown_parts always non-empty when tasks exist)
- Added `test_output_and_created_by_tag_combined`: verifies a delegated task with both `output` and `[created by you]` tag renders both in correct order

Closes #29