### PR TITLE
Planning agent example with semantic search

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,92 +1,59 @@
-# Examples for akgentic-tool
+# akgentic-tool Examples
 
-This directory contains example scripts demonstrating the usage of this module.
+Progressive examples demonstrating the akgentic-tool module capabilities.
+Each example is a self-contained script paired with a companion `.md` file
+explaining concepts.
 
-## Running Examples
+## Running the Examples
+
+From the **project root**:
 
 ```bash
-# From workspace root with uv
-uv run python packages/akgentic-tool/examples/<example>.py
+uv run python packages/akgentic-tool/examples/knowledge_agent.py
+```
+
+From the **akgentic-tool directory**:
+
+```bash
+cd packages/akgentic-tool
+uv run python examples/knowledge_agent.py
 ```
 
 ## Available Examples
 
-### knowledge_agent.py
+### [knowledge_agent.py](knowledge_agent.py) — Knowledge Graph Tool End-to-End
 
-Demonstrates end-to-end usage of `KnowledgeGraphTool` in a realistic scenario.
+Demonstrates end-to-end usage of `KnowledgeGraphTool` in a realistic
+software tech stack scenario. Covers entity and relation creation,
+full graph and subgraph BFS queries, root-entity filtering, keyword
+and hybrid/vector search, and compact system prompt injection for LLM agents.
 
-**What it demonstrates:**
-- `KnowledgeGraphTool` configuration with `GetGraph`, `update_graph`, and `search` options
-- Entity and relation creation via `update_graph` using `ManageGraph`, `EntityCreate`, `RelationCreate`
-- Full graph retrieval and subgraph BFS queries via `get_graph`
-- Root entity filtering (`roots_only=True`)
-- Keyword search (no API key required) and hybrid/vector search (requires `OPENAI_API_KEY`)
-- Compact system prompt summary — how the tool injects graph context into LLM system prompts
-- Graceful degradation: hybrid search falls back to keyword mode without an OpenAI API key
-- Production-quality patterns: Pydantic models throughout, no `dict[str, Any]`
+Companion docs: [knowledge_agent.md](knowledge_agent.md)
 
-**How to run:**
+### [planning_agent.py](planning_agent.py) — Planning Tool with Semantic Search
+
+Demonstrates end-to-end usage of `PlanningTool` with a sprint backlog
+scenario. Covers task creation via `UpdatePlan`, exact-ID lookup via
+`get_planning_task(int)`, semantic query via `get_planning_task(str)`,
+and the agent-scoped planning system prompt with `filter_by_agent`.
+
+Companion docs: [planning_agent.md](planning_agent.md)
+
+## Prerequisites
+
+All examples require:
+
+- Python 3.12+
+- `akgentic-core`
+- `akgentic-tool`
+
+Install with:
 
 ```bash
-# Keyword-only mode — no API key required
-uv run python packages/akgentic-tool/examples/knowledge_agent.py
-
-# With hybrid/vector search (requires openai package and API key)
-OPENAI_API_KEY=sk-... uv run python packages/akgentic-tool/examples/knowledge_agent.py
+uv sync --all-packages --all-extras
 ```
 
-**Prerequisites:**
-
-```bash
-# Install all packages including knowledge graph extras
-uv sync --all-packages --extra kg
-```
-
-The `[kg]` extra installs `openai` and `numpy` required by the vector index.
-Keyword search and basic graph operations work without an OpenAI API key;
-only hybrid/vector search requires a valid `OPENAI_API_KEY`.
-
-**Expected output:**
-
-```
-============================================================
-Knowledge Graph Tool — End-to-End Example
-============================================================
-
---- Setup: configuring KnowledgeGraphTool ---
-Tool: KnowledgeGraph — Knowledge graph tool for structured knowledge with semantic search
-
---- Step 1: Building tech stack knowledge graph ---
-Graph built: Done
-  Entities: 6
-  Relations: 5
-
---- Step 2: Querying the knowledge graph ---
-
-Full graph: 6 entities, 5 relations
-  FastAPI (Framework) [ROOT]: Modern async Python web framework...
-  ...
-
---- Step 3: System prompt summary (compact graph context) ---
-**Knowledge Graph Summary:**
-Entities: 6 | Relations: 5
-Entity types: Cache, CI-CD, Container, Database, Framework, Language
-...
-
---- Step 4: Searching the knowledge graph ---
-
-Keyword search for 'database':
-Search Results:
-  - [entity] PostgreSQL (Database): ...
-  ...
-```
-
-## Example Structure
-
-Each example:
-
-1. Imports necessary dependencies with `from __future__ import annotations`
-2. Wires the tool using a minimal observer (same pattern as integration tests)
-3. Demonstrates realistic domain use cases with meaningful data
-4. Shows both simple and advanced usage patterns
-5. Cleans up resources on exit
+The `[vector_search]` extra installs `openai` and `numpy` required by
+embedding-based search. Keyword search, exact-ID lookup, and basic
+operations work without an OpenAI API key; only semantic/hybrid search
+requires a valid `OPENAI_API_KEY`.

--- a/examples/knowledge_agent.md
+++ b/examples/knowledge_agent.md
@@ -1,0 +1,57 @@
+# Knowledge Graph Tool — End-to-End Example
+
+Demonstrates end-to-end usage of `KnowledgeGraphTool` in a realistic
+software tech stack scenario, covering graph construction, queries,
+search, and system prompt injection.
+
+## What It Demonstrates
+
+- **KnowledgeGraphTool configuration** — wiring with `GetGraph`,
+  `update_graph`, and `search` options via a minimal observer pattern
+- **Graph construction** — creating entities and relations with
+  `ManageGraph`, `EntityCreate`, and `RelationCreate`
+- **Graph queries** — full graph retrieval, subgraph BFS from a starting
+  entity, and root-entity filtering (`roots_only=True`)
+- **Keyword search** — always available, no API key required
+- **Hybrid/vector search** — semantic search when `OPENAI_API_KEY` is set,
+  with graceful fallback to keyword mode when unavailable
+- **System prompt injection** — compact graph context summary for LLM agents
+
+## Key Concepts
+
+### Search Modes
+
+- **keyword** — substring matching against entity names and descriptions
+- **hybrid** — combines keyword results with embedding-based cosine
+  similarity; falls back to keyword-only without an OpenAI API key
+
+### Root Entities
+
+Entities marked `is_root=True` serve as primary entry points in the graph.
+The `roots_only=True` query filter and system prompt summary highlight these.
+
+### Graceful Degradation
+
+Without `OPENAI_API_KEY`, hybrid search automatically falls back to keyword
+mode. The example demonstrates both paths explicitly.
+
+## Running the Example
+
+**Keyword-only mode** (no API key required):
+
+```bash
+uv run python packages/akgentic-tool/examples/knowledge_agent.py
+```
+
+**With hybrid/vector search** (requires OpenAI API key):
+
+```bash
+OPENAI_API_KEY=sk-... uv run python packages/akgentic-tool/examples/knowledge_agent.py
+```
+
+From the **akgentic-tool directory**:
+
+```bash
+cd packages/akgentic-tool
+uv run python examples/knowledge_agent.py
+```

--- a/examples/knowledge_agent.py
+++ b/examples/knowledge_agent.py
@@ -66,8 +66,8 @@ class _MockAddress(ActorAddress):
         return self._role
 
     @property
-    def team_id(self) -> uuid.UUID | None:
-        return None
+    def team_id(self) -> uuid.UUID:
+        return self._agent_id
 
     @property
     def squad_id(self) -> uuid.UUID | None:

--- a/examples/planning_agent.md
+++ b/examples/planning_agent.md
@@ -1,0 +1,71 @@
+# Planning Tool — Semantic Search Example
+
+Demonstrates end-to-end usage of `PlanningTool` with a realistic sprint
+backlog scenario, covering task creation, exact-ID lookup, semantic search,
+and the agent-scoped planning system prompt.
+
+## What It Demonstrates
+
+- **Planning tool configuration** — wiring `PlanningTool` with `GetPlanning`,
+  `GetPlanningTask`, and `UpdatePlanning` via a minimal observer pattern
+- **Task lifecycle** — creating sprint tasks with `UpdatePlan` / `TaskCreate`,
+  including statuses, owners, and dependencies
+- **Exact-ID lookup** — `get_planning_task(int)` returns a typed `Task` object
+  by integer ID
+- **Semantic query** — `get_planning_task(str)` dispatches to embedding-based
+  search (e.g., `"login security"` finds the authentication middleware task)
+- **Agent-scoped system prompt** — `GetPlanning(filter_by_agent=True)` produces
+  a compact summary showing team totals plus only the calling agent's own tasks
+
+## Key Concepts
+
+### Exact-ID vs Semantic Dispatch
+
+`get_planning_task` accepts `int | str`:
+
+- **`int`** — direct ID match against the task list, always available
+- **`str`** — embeds the query and performs cosine similarity search against
+  task description embeddings, requires an embedding provider (OpenAI)
+
+### `filter_by_agent` in `GetPlanning`
+
+When `filter_by_agent=True` (the default), the system prompt includes:
+
+1. A **team summary** — total task count and per-owner breakdown (always shown)
+2. **Your tasks** — only tasks where the calling agent is owner or creator
+
+This keeps the prompt proportional to `O(own_tasks)` instead of `O(all_tasks)`,
+which matters in large multi-agent plans.
+
+When `filter_by_agent=False`, all tasks are listed with owner and creator labels.
+
+### Graceful Degradation
+
+Semantic search requires the `[vector_search]` optional dependency and a valid
+`OPENAI_API_KEY`. Without either:
+
+- Task CRUD works normally
+- Exact-ID lookup works normally
+- Semantic search returns `"Semantic search unavailable."` instead of crashing
+- Embedding failures during task creation are logged and swallowed
+
+## Running the Example
+
+**Keyword mode** (no API key required):
+
+```bash
+uv run python packages/akgentic-tool/examples/planning_agent.py
+```
+
+**Semantic mode** (requires OpenAI API key):
+
+```bash
+OPENAI_API_KEY=sk-... uv run python packages/akgentic-tool/examples/planning_agent.py
+```
+
+From the **akgentic-tool directory**:
+
+```bash
+cd packages/akgentic-tool
+uv run python examples/planning_agent.py
+```

--- a/examples/planning_agent.py
+++ b/examples/planning_agent.py
@@ -226,7 +226,9 @@ def demonstrate_exact_lookup(plan_actor: PlanActor) -> None:
     """
     print("\n--- Step 2: Exact-ID lookup ---")
     result = plan_actor.get_planning_task(2)
-    assert isinstance(result, Task)
+    if not isinstance(result, Task):
+        msg = f"Expected Task from exact-ID lookup, got {type(result).__name__}: {result}"
+        raise TypeError(msg)
     print(
         f"Task {result.id} (int lookup): {result.description}"
         f" [{result.status}] owner={result.owner}"
@@ -311,7 +313,8 @@ def main() -> None:
     for event in observer.events:
         print(f"  [{event.tool_name}]")
 
-    # --- Shutdown ---
+    # --- Shutdown: proper actor lifecycle (start was called in observer init) ---
+    plan_actor.on_stop()
     print("\n--- Shutdown complete ---")
     print("Planning agent example finished successfully.")
     print("=" * 60)

--- a/examples/planning_agent.py
+++ b/examples/planning_agent.py
@@ -1,0 +1,321 @@
+"""Planning Tool example — demonstrates end-to-end usage with semantic search.
+
+Shows how to integrate ``PlanningTool`` with an actor-based setup, create
+sprint tasks, perform exact-ID and semantic lookups, and observe the
+agent-scoped planning system prompt.
+
+Run without OpenAI API key for exact-ID lookup only (semantic falls back gracefully):
+    uv run python packages/akgentic-tool/examples/planning_agent.py
+
+Run with OpenAI API key for semantic search:
+    OPENAI_API_KEY=sk-... uv run python packages/akgentic-tool/examples/planning_agent.py
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from typing import Any
+
+from akgentic.core.actor_address import ActorAddress
+from akgentic.core.agent import AkgentType
+from akgentic.core.utils.deserializer import ActorAddressDict
+
+from akgentic.tool.event import ToolCallEvent
+from akgentic.tool.planning.planning import (
+    PLANNING_ACTOR_NAME,
+    PLANNING_ACTOR_ROLE,
+    GetPlanning,
+    GetPlanningTask,
+    PlanningTool,
+    UpdatePlanning,
+)
+from akgentic.tool.planning.planning_actor import (
+    PlanActor,
+    PlanConfig,
+    Task,
+    TaskCreate,
+    UpdatePlan,
+)
+
+# ---------------------------------------------------------------------------
+# Minimal actor wiring (same pattern as knowledge_agent.py)
+# ---------------------------------------------------------------------------
+
+
+class _MockAddress(ActorAddress):
+    """Minimal ActorAddress stand-in for example wiring."""
+
+    def __init__(self, name: str = "example-agent", role: str = "example-role") -> None:
+        self._name = name
+        self._role = role
+        self._agent_id = uuid.uuid4()
+
+    @property
+    def agent_id(self) -> uuid.UUID:
+        return self._agent_id
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def role(self) -> str:
+        return self._role
+
+    @property
+    def team_id(self) -> uuid.UUID:
+        return self._agent_id
+
+    @property
+    def squad_id(self) -> uuid.UUID | None:
+        return None
+
+    def send(self, recipient: Any, message: Any) -> None:  # noqa: ANN401 — ActorAddress protocol allows Any for generic message passing
+        pass
+
+    def is_alive(self) -> bool:
+        return True
+
+    def stop(self) -> None:
+        pass
+
+    def handle_user_message(self) -> bool:
+        return False
+
+    def serialize(self) -> ActorAddressDict:
+        return {
+            "__actor_address__": True,
+            "__actor_type__": type(self).__qualname__,
+            "agent_id": str(self._agent_id),
+            "name": self._name,
+            "role": self._role,
+            "team_id": "",
+            "squad_id": "",
+            "user_message": False,
+        }
+
+    def __repr__(self) -> str:
+        return f"_MockAddress(name={self._name})"
+
+
+class _OrchestratorStub:
+    """Minimal orchestrator stub returning the singleton PlanActor address."""
+
+    def __init__(self, plan_addr: _MockAddress) -> None:
+        self._plan_addr = plan_addr
+
+    def get_team_member(self, name: str) -> ActorAddress | None:
+        if name == PLANNING_ACTOR_NAME:
+            return self._plan_addr
+        return None
+
+    def createActor(self, *args: Any, **kwargs: Any) -> ActorAddress:  # noqa: N802, ANN401 — N802: Pykka actor convention; ANN401: generic stub accepting any actor args
+        return self._plan_addr
+
+
+class _ExampleObserver:
+    """Observer that wires a real PlanActor for the example.
+
+    Replicates the pattern from ``knowledge_agent.py`` so the example
+    runs without a full Pykka actor system.
+    """
+
+    def __init__(self) -> None:
+        self.events: list[ToolCallEvent] = []
+        self._address = _MockAddress("planning-agent")
+        self._orchestrator_addr = _MockAddress("orchestrator")
+        self._plan_actor = PlanActor(config=PlanConfig(
+            name=PLANNING_ACTOR_NAME,
+            role=PLANNING_ACTOR_ROLE,
+        ))
+        self._plan_actor.on_start()
+        self._plan_addr = _MockAddress(PLANNING_ACTOR_NAME, PLANNING_ACTOR_ROLE)
+
+    @property
+    def myAddress(self) -> ActorAddress:  # noqa: N802
+        """Return the example agent's actor address."""
+        return self._address
+
+    @property
+    def orchestrator(self) -> ActorAddress:
+        """Return the orchestrator's actor address."""
+        return self._orchestrator_addr
+
+    def notify_event(self, event: object) -> None:
+        """Record ToolCallEvents for introspection."""
+        if isinstance(event, ToolCallEvent):
+            self.events.append(event)
+
+    def proxy_ask(
+        self,
+        actor: ActorAddress,
+        actor_type: type[AkgentType] | None = None,
+        timeout: int | None = None,
+    ) -> Any:  # noqa: ANN401
+        """Return the appropriate stub based on which actor is being asked."""
+        if actor == self._orchestrator_addr:
+            return _OrchestratorStub(self._plan_addr)
+        return self._plan_actor
+
+
+# ---------------------------------------------------------------------------
+# Domain: sprint backlog for a web service
+# ---------------------------------------------------------------------------
+
+_SPRINT_TASKS: list[TaskCreate] = [
+    TaskCreate(
+        id=1,
+        description="Design REST API endpoint schema",
+        status="completed",
+        owner="@Alice",
+    ),
+    TaskCreate(
+        id=2,
+        description="Implement authentication middleware",
+        status="started",
+        owner="@Bob",
+    ),
+    TaskCreate(
+        id=3,
+        description="Write integration tests for auth",
+        status="pending",
+        owner="@Alice",
+        dependencies=[2],
+    ),
+    TaskCreate(
+        id=4,
+        description="Set up CI pipeline",
+        status="pending",
+        owner="@Bob",
+    ),
+    TaskCreate(
+        id=5,
+        description="Database migration for user table",
+        status="pending",
+        owner="",
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Example functions
+# ---------------------------------------------------------------------------
+
+
+def create_sprint_tasks(plan_actor: PlanActor, address: ActorAddress) -> None:
+    """Populate the plan with sprint backlog tasks.
+
+    Args:
+        plan_actor: The PlanActor instance to mutate.
+        address: The actor address of the creator.
+    """
+    print("\n--- Step 1: Creating sprint tasks ---")
+    plan_actor.update_planning(
+        UpdatePlan(create_tasks=_SPRINT_TASKS),
+        address,
+    )
+    print(f"Created {len(_SPRINT_TASKS)} tasks.")
+
+
+def demonstrate_exact_lookup(plan_actor: PlanActor) -> None:
+    """Show exact-ID lookup returning a typed Task object.
+
+    Args:
+        plan_actor: The PlanActor instance to query.
+    """
+    print("\n--- Step 2: Exact-ID lookup ---")
+    result = plan_actor.get_planning_task(2)
+    assert isinstance(result, Task)
+    print(
+        f"Task {result.id} (int lookup): {result.description}"
+        f" [{result.status}] owner={result.owner}"
+    )
+
+
+def demonstrate_semantic_search(plan_actor: PlanActor) -> None:
+    """Show semantic search — guarded by OPENAI_API_KEY availability.
+
+    Args:
+        plan_actor: The PlanActor instance to query.
+    """
+    print("\n--- Step 3: Semantic search ---")
+    if os.environ.get("OPENAI_API_KEY"):
+        # Queries with no substring overlap — proves real semantic value
+        result = plan_actor.get_planning_task("login security")
+        print(f'  get_planning_task("login security") → {result}')
+        result = plan_actor.get_planning_task("automated testing")
+        print(f'  get_planning_task("automated testing") → {result}')
+    else:
+        print("OPENAI_API_KEY not set — semantic search unavailable (graceful fallback):")
+        result = plan_actor.get_planning_task("login security")
+        print(f'  get_planning_task("login security") → "{result}"')
+
+
+def demonstrate_planning_prompt(tool: PlanningTool) -> None:
+    """Show the agent-scoped planning system prompt.
+
+    Args:
+        tool: The configured PlanningTool for system-prompt demonstration.
+    """
+    print("\n--- Step 4: Agent-scoped planning system prompt ---")
+    prompts = tool.get_system_prompts()
+    if prompts:
+        system_prompt = prompts[0]()
+        print(system_prompt)
+
+
+def main() -> None:
+    """Run the planning agent example end-to-end.
+
+    Sets up an actor-based planning tool, creates sprint tasks,
+    demonstrates exact-ID and semantic lookups, prints the agent-scoped
+    system prompt, then shuts down cleanly.
+    """
+    print("=" * 60)
+    print("Planning Tool — Semantic Search Example")
+    print("=" * 60)
+
+    # --- Setup: wire PlanningTool with observer ---
+    print("\n--- Setup: configuring PlanningTool ---")
+    observer = _ExampleObserver()
+    tool = PlanningTool(
+        get_planning=GetPlanning(filter_by_agent=True),
+        get_planning_task=GetPlanningTask(),
+        update_planning=UpdatePlanning(),
+        embedding_model="text-embedding-3-small",
+        embedding_provider="openai",
+    )
+    tool.observer(observer)
+    print(f"Tool: {tool.name} — {tool.description}")
+
+    # Access the underlying actor via observer for direct calls
+    plan_actor = observer._plan_actor
+    address = observer.myAddress
+
+    # --- Create sprint tasks ---
+    create_sprint_tasks(plan_actor, address)
+
+    # --- Exact-ID lookup ---
+    demonstrate_exact_lookup(plan_actor)
+
+    # --- Semantic search ---
+    demonstrate_semantic_search(plan_actor)
+
+    # --- Agent-scoped planning system prompt ---
+    demonstrate_planning_prompt(tool)
+
+    # --- Summary of tool call events ---
+    print("\n--- Tool call event log ---")
+    print(f"Total tool events recorded: {len(observer.events)}")
+    for event in observer.events:
+        print(f"  [{event.tool_name}]")
+
+    # --- Shutdown ---
+    print("\n--- Shutdown complete ---")
+    print("Planning agent example finished successfully.")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_planning_agent_example.py
+++ b/tests/test_planning_agent_example.py
@@ -33,7 +33,11 @@ def _load_example_module() -> types.ModuleType:
     assert spec is not None and spec.loader is not None, "Could not load example module spec"
     module = importlib.util.module_from_spec(spec)
     sys.modules[module_key] = module
-    spec.loader.exec_module(module)  # type: ignore[union-attr]  # loader type narrowed by assert above
+    try:
+        spec.loader.exec_module(module)  # type: ignore[union-attr]  # loader type narrowed by assert above
+    except Exception:
+        sys.modules.pop(module_key, None)
+        raise
     return module
 
 

--- a/tests/test_planning_agent_example.py
+++ b/tests/test_planning_agent_example.py
@@ -1,0 +1,92 @@
+"""Smoke tests for the planning_agent.py example.
+
+Validates that the example runs end-to-end without errors and
+that exact-ID lookup returns a typed Task object.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+from akgentic.tool.planning.planning_actor import Task
+
+
+def _load_example_module() -> types.ModuleType:
+    """Load planning_agent.py as a module via importlib.
+
+    Uses a unique module name per call to avoid sys.modules caching
+    between tests, ensuring each call gets a fresh module with clean state.
+
+    Returns:
+        The loaded planning_agent module.
+    """
+    examples_dir = Path(__file__).parent.parent / "examples"
+    example_path = examples_dir / "planning_agent.py"
+    # Use a unique key each load to prevent cross-test sys.modules caching
+    module_key = f"planning_agent_{id(object())}"
+    spec = importlib.util.spec_from_file_location(module_key, example_path)
+    assert spec is not None and spec.loader is not None, "Could not load example module spec"
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_key] = module
+    spec.loader.exec_module(module)  # type: ignore[union-attr]  # loader type narrowed by assert above
+    return module
+
+
+class TestPlanningAgentExample:
+    """AC-7: Planning agent example smoke tests."""
+
+    def test_main_runs_without_error(self) -> None:
+        """AC-1, AC-3: Example runs end-to-end without errors (no API key)."""
+        env = os.environ.copy()
+        env.pop("OPENAI_API_KEY", None)
+        with patch.dict("os.environ", env, clear=True):
+            module = _load_example_module()
+            module.main()
+
+    def test_example_module_importable(self) -> None:
+        """AC-4: Example has callable main() function."""
+        module = _load_example_module()
+        assert callable(module.main), "main() must be a callable function"
+
+    def test_exact_id_lookup_returns_task(self) -> None:
+        """AC-2: Exact-ID lookup returns a typed Task object."""
+        env = os.environ.copy()
+        env.pop("OPENAI_API_KEY", None)
+        with patch.dict("os.environ", env, clear=True):
+            module = _load_example_module()
+
+            # Wire a fresh observer and plan actor
+            observer = module._ExampleObserver()
+            plan_actor = observer._plan_actor
+            address = observer.myAddress
+
+            # Create tasks
+            module.create_sprint_tasks(plan_actor, address)
+
+            # Exact-ID lookup — must return a Task instance
+            result = plan_actor.get_planning_task(2)
+            assert isinstance(result, Task), f"Expected Task, got {type(result)}"
+            assert result.id == 2
+            assert result.description == "Implement authentication middleware"
+
+    def test_semantic_search_graceful_without_api_key(self) -> None:
+        """AC-3: Semantic search returns graceful message without API key."""
+        env = os.environ.copy()
+        env.pop("OPENAI_API_KEY", None)
+        with patch.dict("os.environ", env, clear=True):
+            module = _load_example_module()
+
+            observer = module._ExampleObserver()
+            plan_actor = observer._plan_actor
+            address = observer.myAddress
+
+            module.create_sprint_tasks(plan_actor, address)
+
+            result = plan_actor.get_planning_task("login security")
+            assert isinstance(result, str)
+            assert "unavailable" in result.lower()


### PR DESCRIPTION
## Summary

- Add `planning_agent.py` example demonstrating end-to-end `PlanningTool` usage with task creation, exact-ID lookup, semantic search, and agent-scoped system prompt
- Add companion docs (`planning_agent.md`, `knowledge_agent.md`) and rewrite `README.md` to catalog template format
- Add 4 smoke tests validating example runs without errors and exact-ID lookup returns typed `Task`
- Code review fixes: `_MockAddress.team_id` ABC compliance, assert→TypeError, actor lifecycle shutdown, test module cleanup

Closes #31

## Test plan

- [x] `pytest packages/akgentic-tool/tests/test_planning_agent_example.py -v` — 4 tests pass
- [x] `pytest packages/akgentic-tool/tests/ --cov=akgentic.tool --cov-branch --cov-fail-under=80` — 414 pass, 84.37% coverage
- [x] `ruff check` — all checks passed
- [x] Example runs without `OPENAI_API_KEY` — graceful fallback confirmed