### PR TITLE
feat: owner/creator display in agent-scoped planning view (Story 4.1)

### DIFF
--- a/src/akgentic/tool/planning/planning.py
+++ b/src/akgentic/tool/planning/planning.py
@@ -174,9 +174,11 @@ class PlanningTool(ToolCard):
                         if task.owner != agent_name and task.creator == agent_name:
                             role_tag = " [created by you]"
                         output_part = f" — Output: {task.output}" if task.output else ""
+                        owner_label = task.owner or "unassigned"
+                        suffix = f" (Owner: {owner_label}, Creator: {task.creator})"
                         lines.append(
                             f"- ID {task.id} [{task.status}] {task.description}"
-                            f"{output_part}{role_tag}"
+                            f"{output_part}{role_tag}{suffix}"
                         )
                 else:
                     lines.append(
@@ -193,8 +195,8 @@ class PlanningTool(ToolCard):
                     )
 
             lines.append(
-                "\nUse get_planning_task(id) for exact lookup or "
-                "get_planning_task(query) for semantic search."
+                "\nUse get_planning_task(id) for exact ID lookup or "
+                "search_planning(...) to filter tasks."
             )
             return "\n".join(lines)
 

--- a/tests/test_planning_prompt.py
+++ b/tests/test_planning_prompt.py
@@ -164,6 +164,7 @@ class TestFilterByAgentTrue:
         result = fn()
         assert "Delegated" in result
         assert "[created by you]" in result
+        assert "[created by you] (Owner: @ArchAgent, Creator: @DevAgent)" in result
 
     def test_owned_task_has_no_created_by_tag(self) -> None:
         """AC4 inverse: When owner==agent, no [created by you] tag."""
@@ -174,6 +175,7 @@ class TestFilterByAgentTrue:
         result = fn()
         assert "Own task" in result
         assert "[created by you]" not in result
+        assert "(Owner: @DevAgent, Creator: @DevAgent)" in result
 
     def test_unassigned_tasks_excluded_from_own_list(self) -> None:
         """AC5: Tasks with empty owner not in own-task section even if creator matches."""
@@ -325,14 +327,12 @@ class TestOutputFieldRendering:
         # Verify ordering: output before tag
         task_line = next(line for line in result.splitlines() if "Review PR #42" in line)
         assert task_line.index("— Output:") < task_line.index("[created by you]")
+        assert "[created by you] (Owner: @ArchAgent, Creator: @DevAgent)" in task_line
 
 
 # --- Tests: navigation hint (AC#3, #8) ---
 
-_NAV_HINT = (
-    "Use get_planning_task(id) for exact lookup or "
-    "get_planning_task(query) for semantic search."
-)
+_NAV_HINT = "Use get_planning_task(id) for exact ID lookup or search_planning(...) to filter tasks."
 
 
 class TestNavigationHint:
@@ -457,3 +457,51 @@ class TestPlanningToolRoutingMethods:
         tools = tool.get_tools()
         # Default GetPlanningTask has TOOL_CALL in expose -> one entry
         assert any(callable(t) for t in tools)
+
+
+# --- Tests: owner/creator suffix in scoped view (AC#1, #2, #3) ---
+
+
+class TestScopedViewOwnerCreatorDisplay:
+    """AC1-AC3: Owner/creator suffix on task lines in filter_by_agent=True mode."""
+
+    def test_owned_task_shows_owner_creator_suffix(self) -> None:
+        """AC1: Task where owner==agent shows (Owner: ..., Creator: ...)."""
+        tasks = [
+            make_task(id=1, owner="@DevAgent", creator="@DevAgent", description="My task"),
+        ]
+        fn = make_prompt_fn(tasks, agent_name="@DevAgent")
+        result = fn()
+        assert "(Owner: @DevAgent, Creator: @DevAgent)" in result
+
+    def test_delegated_task_shows_created_by_before_owner_creator(self) -> None:
+        """AC2: Delegated task has [created by you] then (Owner:..., Creator:...)."""
+        tasks = [
+            make_task(id=1, owner="@ArchAgent", creator="@DevAgent", description="Delegated"),
+        ]
+        fn = make_prompt_fn(tasks, agent_name="@DevAgent")
+        result = fn()
+        task_line = next(line for line in result.splitlines() if "Delegated" in line)
+        assert "[created by you] (Owner: @ArchAgent, Creator: @DevAgent)" in task_line
+
+    def test_scoped_view_unassigned_owner_shown_as_unassigned(self) -> None:
+        """AC3: Task with empty owner in full-view renders 'unassigned'."""
+        # Edge case: unassigned tasks don't appear in scoped view (filter excludes them),
+        # so we verify via filter_by_agent=False that the label renders correctly.
+        tasks = [
+            make_task(id=1, owner="", creator="@DevAgent"),
+        ]
+        fn = make_prompt_fn(tasks, agent_name="@DevAgent", filter_by_agent=False)
+        result = fn()
+        assert "(Owner: unassigned, Creator: @DevAgent)" in result
+
+    def test_scoped_view_owner_label_unassigned_not_reachable_but_guarded(self) -> None:
+        """Guard: If a task with named owner enters own_tasks, suffix shows correct owner."""
+        # Confirms owner_label = task.owner or "unassigned" guard renders correctly
+        # for a task created by another agent but owned by the scoped agent.
+        tasks = [
+            make_task(id=2, owner="@DevAgent", creator="@OtherAgent", description="Assigned"),
+        ]
+        fn = make_prompt_fn(tasks, agent_name="@DevAgent")
+        result = fn()
+        assert "(Owner: @DevAgent, Creator: @OtherAgent)" in result

--- a/tests/test_planning_prompt.py
+++ b/tests/test_planning_prompt.py
@@ -484,10 +484,14 @@ class TestScopedViewOwnerCreatorDisplay:
         task_line = next(line for line in result.splitlines() if "Delegated" in line)
         assert "[created by you] (Owner: @ArchAgent, Creator: @DevAgent)" in task_line
 
-    def test_scoped_view_unassigned_owner_shown_as_unassigned(self) -> None:
-        """AC3: Task with empty owner in full-view renders 'unassigned'."""
-        # Edge case: unassigned tasks don't appear in scoped view (filter excludes them),
-        # so we verify via filter_by_agent=False that the label renders correctly.
+    def test_full_view_unassigned_owner_shown_as_unassigned(self) -> None:
+        """AC3: Task with empty owner in full-view (filter_by_agent=False) renders 'unassigned'.
+
+        Note: unassigned tasks are excluded from the scoped view (filter_by_agent=True) because
+        the filter requires task.owner == agent_name or (task.owner and task.creator == agent_name).
+        The owner_label guard in the scoped-view loop is defensive; this test covers the label via
+        the full-view branch where unassigned tasks are always rendered.
+        """
         tasks = [
             make_task(id=1, owner="", creator="@DevAgent"),
         ]
@@ -495,10 +499,8 @@ class TestScopedViewOwnerCreatorDisplay:
         result = fn()
         assert "(Owner: unassigned, Creator: @DevAgent)" in result
 
-    def test_scoped_view_owner_label_unassigned_not_reachable_but_guarded(self) -> None:
-        """Guard: If a task with named owner enters own_tasks, suffix shows correct owner."""
-        # Confirms owner_label = task.owner or "unassigned" guard renders correctly
-        # for a task created by another agent but owned by the scoped agent.
+    def test_scoped_view_owner_created_by_other_shows_correct_suffix(self) -> None:
+        """AC1 variant: Task created by a different agent but owned by the calling agent shows correct suffix."""
         tasks = [
             make_task(id=2, owner="@DevAgent", creator="@OtherAgent", description="Assigned"),
         ]


### PR DESCRIPTION
## Summary

- Extends `_planning_prompt_factory` in `planning.py` to append `(Owner: {owner_label}, Creator: {creator})` to every task line in the agent-scoped view (`filter_by_agent=True`), closing the display gap identified in Epic 4 FR-PI-1/2/3.
- When a task was created by the calling agent but owned by another, the `[created by you]` tag is inserted before the owner/creator suffix, matching the architecture spec ordering.
- Updates the navigation hint from the old `get_planning_task(query) for semantic search` text to `get_planning_task(id) for exact ID lookup or search_planning(...) to filter tasks`, consistent with Epic 4 (Story 4.2 removes semantic string overload, Story 4.3 adds `search_planning`).
- Adds `TestScopedViewOwnerCreatorDisplay` test class (4 tests) covering AC1-AC3; strengthens 3 existing tests with suffix-ordering assertions; updates `_NAV_HINT` constant.

## Results

- ruff: zero errors
- mypy: 12 pre-existing errors, 0 new
- pytest: 38 passed, 1 pre-existing failure (`test_kg_models.py` unrelated), coverage 90.60%

Closes #33