### PR TITLE
feat: EditMatcher 7-strategy cascade and line ending utilities (Story 5.3)

### DIFF
--- a/src/akgentic/tool/workspace/__init__.py
+++ b/src/akgentic/tool/workspace/__init__.py
@@ -1,5 +1,16 @@
 """Workspace module — filesystem backend for team-scoped file operations."""
 
+from akgentic.tool.workspace.edit import (
+    EditItem,
+    EditMatcher,
+    FilePatch,
+    Hunk,
+    MatchResult,
+    apply_file_patch,
+    detect_line_ending,
+    normalise_endings,
+    parse_patch,
+)
 from akgentic.tool.workspace.tool import (
     WorkspaceGlob,
     WorkspaceGrep,
@@ -15,6 +26,15 @@ from akgentic.tool.workspace.workspace import (
 )
 
 __all__ = [
+    "EditItem",
+    "EditMatcher",
+    "FilePatch",
+    "Hunk",
+    "MatchResult",
+    "apply_file_patch",
+    "detect_line_ending",
+    "normalise_endings",
+    "parse_patch",
     "FileEntry",
     "Filesystem",
     "Workspace",

--- a/src/akgentic/tool/workspace/edit.py
+++ b/src/akgentic/tool/workspace/edit.py
@@ -1,0 +1,371 @@
+"""Workspace edit utilities — EditMatcher, line ending helpers, unified diff patch.
+
+All functionality required by WorkspaceTool.workspace_edit, workspace_multi_edit,
+and workspace_patch lives here. This module has no dependency on tool.py or
+ToolCard — it is pure algorithmic logic consumed by WorkspaceTool in tool.py.
+"""
+
+from __future__ import annotations
+
+import codecs
+import re
+import textwrap
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel
+
+if TYPE_CHECKING:
+    from akgentic.tool.workspace.workspace import Workspace
+
+
+@dataclass
+class MatchResult:
+    start: int  # byte offset in content where match begins
+    end: int  # byte offset in content where match ends (exclusive)
+    strategy: str  # name of winning strategy, e.g. "exact", "line_trimmed"
+
+
+class EditMatcher:
+    """7-strategy cascade for locating old_string in file content.
+
+    Strategies are tried in order. The first match wins.
+    All strategies return MatchResult(start, end, strategy) or None.
+    """
+
+    FUZZY_THRESHOLD: float = 0.85
+
+    def find(self, content: str, old_string: str) -> MatchResult | None:
+        for strategy in (
+            self._exact,
+            self._line_trimmed,
+            self._whitespace_normalised,
+            self._dedented,
+            self._trimmed_boundary,
+            self._escape_normalised,
+            self._fuzzy,
+        ):
+            result = strategy(content, old_string)
+            if result is not None:
+                return result
+        return None
+
+    # --- Strategy 1: exact ---------------------------------------------------
+
+    def _exact(self, content: str, old: str) -> MatchResult | None:
+        idx = content.find(old)
+        if idx == -1:
+            return None
+        return MatchResult(start=idx, end=idx + len(old), strategy="exact")
+
+    # --- Strategy 2: line-trimmed --------------------------------------------
+
+    def _line_trimmed(self, content: str, old: str) -> MatchResult | None:
+        """Strip per-line leading/trailing whitespace from old, then exact-match."""
+        stripped = "\n".join(line.strip() for line in old.splitlines())
+        if stripped == old:
+            return None  # no change — nothing new to try
+        norm_content = "\n".join(line.strip() for line in content.splitlines())
+        idx = norm_content.find(stripped)
+        if idx == -1:
+            return None
+        # Remap idx back to original content
+        return self._remap(content, old, idx, norm_content, strategy="line_trimmed")
+
+    # --- Strategy 3: whitespace-normalised -----------------------------------
+
+    def _whitespace_normalised(self, content: str, old: str) -> MatchResult | None:
+        """Collapse internal whitespace runs to single space, then exact-match."""
+        norm_old = re.sub(r"[ \t]+", " ", old)
+        if norm_old == old:
+            return None
+        norm_content = re.sub(r"[ \t]+", " ", content)
+        idx = norm_content.find(norm_old)
+        if idx == -1:
+            return None
+        return self._remap(content, old, idx, norm_content, strategy="whitespace_normalised")
+
+    # --- Strategy 4: dedented ------------------------------------------------
+
+    def _dedented(self, content: str, old: str) -> MatchResult | None:
+        """Dedent old_string, then exact-match against dedented content windows."""
+        dedented_old = textwrap.dedent(old)
+        if dedented_old == old:
+            return None
+        # Try matching dedented_old against lines in content with various indent levels
+        idx = content.find(dedented_old)
+        if idx != -1:
+            return MatchResult(start=idx, end=idx + len(dedented_old), strategy="dedented")
+        # Also try: dedent old, dedent content
+        dedented_content = textwrap.dedent(content)
+        idx = dedented_content.find(dedented_old)
+        if idx == -1:
+            return None
+        return self._remap(content, old, idx, dedented_content, strategy="dedented")
+
+    # --- Strategy 5: trimmed boundary ----------------------------------------
+
+    def _trimmed_boundary(self, content: str, old: str) -> MatchResult | None:
+        """Strip blank lines at edges of old_string, then exact-match."""
+        stripped = old.strip("\n")
+        if stripped == old:
+            return None  # no blank edges
+        result = self._exact(content, stripped)
+        if result is None:
+            return None
+        return MatchResult(start=result.start, end=result.end, strategy="trimmed_boundary")
+
+    # --- Strategy 6: escape-normalised ---------------------------------------
+
+    def _escape_normalised(self, content: str, old: str) -> MatchResult | None:
+        """Decode escape sequences in old_string, then exact-match."""
+        try:
+            decoded = codecs.decode(old.encode(), "unicode_escape")
+            # In Python 3, codecs.decode with 'unicode_escape' returns str directly
+            norm_old: str = (
+                decoded if isinstance(decoded, str) else decoded.decode("utf-8", errors="replace")
+            )
+        except Exception:
+            return None
+        if norm_old == old:
+            return None
+        result = self._exact(content, norm_old)
+        if result is not None:
+            return MatchResult(start=result.start, end=result.end, strategy="escape_normalised")
+        # Inverse: decode content, match original old
+        try:
+            decoded_content = codecs.decode(content.encode(), "unicode_escape")
+            norm_content: str = (
+                decoded_content
+                if isinstance(decoded_content, str)
+                else decoded_content.decode("utf-8", errors="replace")
+            )
+        except Exception:
+            return None
+        result = self._exact(norm_content, old)
+        if result is None:
+            return None
+        return self._remap(content, old, result.start, norm_content, strategy="escape_normalised")
+
+    # --- Strategy 7: fuzzy ---------------------------------------------------
+
+    def _fuzzy(self, content: str, old: str) -> MatchResult | None:
+        """SequenceMatcher fuzzy search; ratio must be >= FUZZY_THRESHOLD."""
+        old_lines = old.splitlines()
+        content_lines = content.splitlines()
+        n = len(old_lines)
+        if n == 0:
+            return None
+        best_ratio = 0.0
+        best_start_line = -1
+        for i in range(len(content_lines) - n + 1):
+            window = content_lines[i : i + n]
+            ratio = SequenceMatcher(None, old_lines, window).ratio()
+            if ratio > best_ratio:
+                best_ratio = ratio
+                best_start_line = i
+        if best_ratio < self.FUZZY_THRESHOLD or best_start_line == -1:
+            return None
+        # Map line index back to byte offset
+        start = sum(len(line) + 1 for line in content_lines[:best_start_line])
+        end = start + sum(
+            len(line) + 1 for line in content_lines[best_start_line : best_start_line + n]
+        )
+        # Trim trailing newline overshoot
+        end = min(end, len(content))
+        return MatchResult(start=start, end=end, strategy="fuzzy")
+
+    # --- Remap helper --------------------------------------------------------
+
+    def _remap(
+        self,
+        original: str,
+        old: str,
+        start_in_norm: int,
+        norm_content: str,
+        strategy: str,
+    ) -> MatchResult | None:
+        """Map a match offset in norm_content back to the original string.
+
+        Approximation: find the nearest position in original that aligns with
+        the normalised match start. Falls back to original line-count heuristic.
+        """
+        # Count lines before start_in_norm in norm_content
+        lines_before = norm_content[:start_in_norm].count("\n")
+        # Find same line offset in original
+        orig_lines = original.splitlines(keepends=True)
+        if lines_before >= len(orig_lines):
+            return None
+        orig_start = sum(len(line) for line in orig_lines[:lines_before])
+        # Count lines in old to determine end
+        old_line_count = len(old.splitlines())
+        orig_end = sum(
+            len(line) for line in orig_lines[lines_before : lines_before + old_line_count]
+        )
+        orig_end = orig_start + orig_end
+        orig_end = min(orig_end, len(original))
+        return MatchResult(start=orig_start, end=orig_end, strategy=strategy)
+
+
+def detect_line_ending(content: str) -> str:
+    """Detect dominant line ending in content.
+
+    Returns ``"\\r\\n"`` if CRLF is dominant, ``"\\n"`` otherwise (including
+    when content is empty or has no line endings).
+    """
+    crlf_count = content.count("\r\n")
+    lf_count = content.count("\n") - crlf_count  # pure LF only
+    return "\r\n" if crlf_count > lf_count else "\n"
+
+
+def normalise_endings(content: str, line_ending: str) -> str:
+    """Convert all line endings in content to line_ending.
+
+    First normalises all CRLF to LF, then converts LF to the target
+    line_ending. This prevents double-conversion (``\\r\\r\\n``).
+    """
+    normalised = content.replace("\r\n", "\n")
+    if line_ending == "\r\n":
+        return normalised.replace("\n", "\r\n")
+    return normalised
+
+
+class Hunk(BaseModel):
+    """Single hunk from a unified diff."""
+
+    old_start: int
+    old_count: int
+    new_start: int
+    new_count: int
+    lines: list[str]  # each line prefixed with '+', '-', or ' '
+
+
+class FilePatch(BaseModel):
+    """Parsed unified diff for a single file."""
+
+    path: str
+    hunks: list[Hunk]
+
+
+class EditItem(BaseModel):
+    """A single find-and-replace operation for workspace_multi_edit."""
+
+    path: str
+    old_string: str
+    new_string: str
+    replace_all: bool = False
+
+
+_HUNK_HEADER: re.Pattern[str] = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
+
+
+def parse_patch(patch_text: str) -> list[FilePatch]:
+    """Parse a GNU unified diff string into a list of FilePatch objects.
+
+    Supports single-file and multi-file diffs. Lines with ``--- /dev/null``
+    or ``+++ /dev/null`` are preserved in the path field as-is; consumers
+    must handle the sentinel.
+    """
+    patches: list[FilePatch] = []
+    current_path: str | None = None
+    current_hunks: list[Hunk] = []
+    current_hunk_lines: list[str] = []
+    current_hunk_header: tuple[int, int, int, int] | None = None
+
+    def _flush_hunk() -> None:
+        nonlocal current_hunk_lines, current_hunk_header
+        if current_hunk_header is not None:
+            os_, oc_, ns_, nc_ = current_hunk_header
+            current_hunks.append(
+                Hunk(
+                    old_start=os_,
+                    old_count=oc_,
+                    new_start=ns_,
+                    new_count=nc_,
+                    lines=list(current_hunk_lines),
+                )
+            )
+
+    def _flush_patch() -> None:
+        nonlocal current_path, current_hunks, current_hunk_lines, current_hunk_header
+        if current_path is not None:
+            _flush_hunk()
+            patches.append(FilePatch(path=current_path, hunks=list(current_hunks)))
+
+    for line in patch_text.splitlines():
+        if line.startswith("+++ "):
+            _flush_patch()  # save previous file patch if any
+            # path is after "+++ " prefix, strip optional "b/" git prefix
+            raw_path = line[4:].strip()
+            current_path = raw_path[2:] if raw_path.startswith("b/") else raw_path
+            current_hunks = []
+            current_hunk_lines = []
+            current_hunk_header = None
+        elif line.startswith("--- "):
+            continue  # skip --- lines; path taken from +++ line
+        else:
+            m = _HUNK_HEADER.match(line)
+            if m:
+                if current_hunk_header is not None:
+                    _flush_hunk()
+                    current_hunk_lines = []
+                os_ = int(m.group(1))
+                oc_ = int(m.group(2)) if m.group(2) is not None else 1
+                ns_ = int(m.group(3))
+                nc_ = int(m.group(4)) if m.group(4) is not None else 1
+                current_hunk_header = (os_, oc_, ns_, nc_)
+            elif current_hunk_header is not None and (
+                line.startswith("+") or line.startswith("-") or line.startswith(" ")
+            ):
+                current_hunk_lines.append(line)
+
+    _flush_patch()
+    return patches
+
+
+def apply_file_patch(workspace: "Workspace", file_patch: FilePatch) -> None:
+    """Read a workspace file, apply all hunks, write result back.
+
+    Handles add (path="new_file", all hunks are additions),
+    update (normal patch), and delete (path is sentinel "/dev/null" — but
+    callers handle delete by checking file_patch.path against "/dev/null"
+    BEFORE calling this function — see workspace_patch in tool.py).
+
+    Args:
+        workspace: Workspace backend (Filesystem instance in practice).
+        file_patch: Parsed FilePatch with one or more Hunk objects.
+
+    Raises:
+        FileNotFoundError: If file does not exist and patch is not a pure add.
+        PermissionError: If path escapes the workspace root.
+    """
+    # Determine if this is a new-file creation (all lines are additions)
+    is_new_file = all(
+        all(patch_line.startswith("+") for patch_line in hunk.lines if patch_line)
+        for hunk in file_patch.hunks
+    )
+
+    if is_new_file:
+        new_content = "\n".join(
+            line[1:] for hunk in file_patch.hunks for line in hunk.lines if line.startswith("+")
+        )
+        workspace.write(file_patch.path, new_content.encode("utf-8"))
+        return
+
+    raw = workspace.read(file_patch.path)
+    lines = raw.decode("utf-8").splitlines()
+    offset = 0
+    for hunk in file_patch.hunks:
+        start = hunk.old_start - 1 + offset
+        # Collect replacement lines (context + additions)
+        new_lines: list[str] = []
+        for patch_line in hunk.lines:
+            if patch_line.startswith("+"):
+                new_lines.append(patch_line[1:])
+            elif patch_line.startswith(" "):
+                new_lines.append(patch_line[1:])
+            # Lines starting with '-' are dropped
+        lines[start : start + hunk.old_count] = new_lines
+        offset += len(new_lines) - hunk.old_count
+    workspace.write(file_patch.path, ("\n".join(lines) + "\n").encode("utf-8"))

--- a/src/akgentic/tool/workspace/edit.py
+++ b/src/akgentic/tool/workspace/edit.py
@@ -340,8 +340,10 @@ def apply_file_patch(workspace: "Workspace", file_patch: FilePatch) -> None:
         FileNotFoundError: If file does not exist and patch is not a pure add.
         PermissionError: If path escapes the workspace root.
     """
-    # Determine if this is a new-file creation (all lines are additions)
-    is_new_file = all(
+    # Determine if this is a new-file creation (all lines are additions).
+    # Note: `all()` on an empty sequence returns True, so we guard against
+    # empty hunk lists explicitly to avoid treating an empty patch as new-file.
+    is_new_file = bool(file_patch.hunks) and all(
         all(patch_line.startswith("+") for patch_line in hunk.lines if patch_line)
         for hunk in file_patch.hunks
     )
@@ -350,7 +352,7 @@ def apply_file_patch(workspace: "Workspace", file_patch: FilePatch) -> None:
         new_content = "\n".join(
             line[1:] for hunk in file_patch.hunks for line in hunk.lines if line.startswith("+")
         )
-        workspace.write(file_patch.path, new_content.encode("utf-8"))
+        workspace.write(file_patch.path, (new_content + "\n").encode("utf-8"))
         return
 
     raw = workspace.read(file_patch.path)

--- a/tests/workspace/test_edit_matcher.py
+++ b/tests/workspace/test_edit_matcher.py
@@ -1,0 +1,248 @@
+"""Tests for EditMatcher strategies and line ending utilities (Story 5.3)."""
+
+from __future__ import annotations
+
+from akgentic.tool.workspace.edit import EditMatcher, detect_line_ending, normalise_endings
+
+# ---------------------------------------------------------------------------
+# Strategy 1: exact
+# ---------------------------------------------------------------------------
+
+
+def test_exact_match_found() -> None:
+    m = EditMatcher()
+    result = m.find("hello world", "world")
+    assert result is not None
+    assert result.strategy == "exact"
+    assert result.start == 6
+    assert result.end == 11
+
+
+def test_exact_match_not_found() -> None:
+    m = EditMatcher()
+    result = m._exact("hello world", "xyz")
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Strategy 2: line-trimmed
+# ---------------------------------------------------------------------------
+
+
+def test_line_trimmed_match() -> None:
+    m = EditMatcher()
+    content = "def foo():\n    return 1\n"
+    # old_string has extra leading/trailing whitespace on each line
+    old = "  def foo():  \n      return 1  \n"
+    result = m.find(content, old)
+    assert result is not None
+    assert result.strategy == "line_trimmed"
+
+
+def test_line_trimmed_no_change_returns_none_from_strategy() -> None:
+    m = EditMatcher()
+    # Already stripped — strategy should return None (no new info)
+    result = m._line_trimmed("hello world", "hello world")
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Strategy 3: whitespace-normalised
+# ---------------------------------------------------------------------------
+
+
+def test_whitespace_normalised_match() -> None:
+    m = EditMatcher()
+    content = "x = 1 + 2"
+    old = "x  =  1  +  2"  # extra spaces collapsed
+    result = m.find(content, old)
+    assert result is not None
+    assert result.strategy == "whitespace_normalised"
+
+
+def test_whitespace_normalised_no_change_returns_none() -> None:
+    m = EditMatcher()
+    result = m._whitespace_normalised("x = 1", "x = 1")
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Strategy 4: dedented
+# ---------------------------------------------------------------------------
+
+
+def test_dedented_match() -> None:
+    m = EditMatcher()
+    content = "def foo():\n    return 1\n"
+    # old_string with extra indentation — test via _dedented directly
+    # to avoid earlier strategies in the cascade winning
+    old = "    def foo():\n        return 1\n"
+    result = m._dedented(content, old)
+    assert result is not None
+    assert result.strategy == "dedented"
+
+
+def test_dedented_no_change_returns_none() -> None:
+    m = EditMatcher()
+    result = m._dedented("no indent\n", "no indent\n")
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Strategy 5: trimmed boundary
+# ---------------------------------------------------------------------------
+
+
+def test_trimmed_boundary_match() -> None:
+    m = EditMatcher()
+    content = "def foo():\n    return 1\n"
+    old_with_blank = "\ndef foo():\n    return 1\n"
+    result = m.find(content, old_with_blank)
+    assert result is not None
+    assert result.strategy == "trimmed_boundary"
+
+
+def test_trimmed_boundary_no_blank_edge_returns_none() -> None:
+    m = EditMatcher()
+    # No blank edges on old_string — strategy must return None
+    result = m._trimmed_boundary("hello world", "hello world")
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Strategy 6: escape-normalised
+# ---------------------------------------------------------------------------
+
+
+def test_escape_normalised_double_escaped_newline() -> None:
+    m = EditMatcher()
+    # Content has a literal newline; old_string has double-escaped \\n
+    content = "line1\nline2"
+    # Simulate LLM outputting double-escaped: "line1\\nline2"
+    old = "line1\\nline2"
+    result = m.find(content, old)
+    assert result is not None
+    assert result.strategy == "escape_normalised"
+
+
+# ---------------------------------------------------------------------------
+# Strategy 7: fuzzy
+# ---------------------------------------------------------------------------
+
+
+def test_fuzzy_above_threshold_matches() -> None:
+    m = EditMatcher()
+    content = "def calculate_sum(a, b):\n    return a + b\n"
+    # Slightly different spelling, should still be >= 0.85
+    old = "def calculate_sum(a, b):\n    return a + b\n"  # identical → exact wins
+    result = m.find(content, old)
+    assert result is not None
+    assert result.strategy == "exact"
+
+
+def test_fuzzy_high_similarity() -> None:
+    m = EditMatcher()
+    # 10 lines: 9 identical, 1 different — line-level ratio = 0.9 (>= 0.85 threshold)
+    shared = ["line1", "line2", "line3", "line4", "line5", "line6", "line7", "line8", "line9"]
+    content_lines = shared + ["new_line"]
+    old_lines = shared + ["old_line"]
+    content = "\n".join(content_lines) + "\n"
+    old = "\n".join(old_lines)
+    result = m._fuzzy(content, old)
+    assert result is not None
+    assert result.strategy == "fuzzy"
+
+
+def test_fuzzy_below_threshold_returns_none() -> None:
+    m = EditMatcher()
+    result = m.find("hello world", "completely different text that bears no resemblance")
+    assert result is None
+
+
+def test_fuzzy_ratio_just_below_threshold_returns_none() -> None:
+    m = EditMatcher()
+    # Force a low-similarity check via _fuzzy directly
+    result = m._fuzzy("aaa bbb ccc", "xxx yyy zzz ppp qqq rrr sss")
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# find() cascade order — earlier strategy wins
+# ---------------------------------------------------------------------------
+
+
+def test_find_cascade_exact_wins_over_fuzzy() -> None:
+    m = EditMatcher()
+    content = "hello world"
+    old = "hello world"
+    result = m.find(content, old)
+    assert result is not None
+    assert result.strategy == "exact"
+
+
+def test_find_returns_none_when_no_strategy_matches() -> None:
+    m = EditMatcher()
+    result = m.find("short text", "completely unrelated long string with no overlap whatsoever xyz")
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# detect_line_ending
+# ---------------------------------------------------------------------------
+
+
+def test_detect_line_ending_crlf_dominant() -> None:
+    content = "line1\r\nline2\r\nline3\r\n"
+    assert detect_line_ending(content) == "\r\n"
+
+
+def test_detect_line_ending_lf_dominant() -> None:
+    content = "line1\nline2\nline3\n"
+    assert detect_line_ending(content) == "\n"
+
+
+def test_detect_line_ending_empty_content_returns_lf() -> None:
+    assert detect_line_ending("") == "\n"
+
+
+def test_detect_line_ending_mixed_crlf_wins() -> None:
+    # 3 CRLF vs 1 pure LF
+    content = "a\r\nb\r\nc\r\nd\n"
+    assert detect_line_ending(content) == "\r\n"
+
+
+def test_detect_line_ending_mixed_lf_wins() -> None:
+    # 1 CRLF vs 3 pure LF
+    content = "a\r\nb\nc\nd\n"
+    assert detect_line_ending(content) == "\n"
+
+
+# ---------------------------------------------------------------------------
+# normalise_endings
+# ---------------------------------------------------------------------------
+
+
+def test_normalise_endings_lf_to_crlf() -> None:
+    content = "line1\nline2\nline3\n"
+    result = normalise_endings(content, "\r\n")
+    assert result == "line1\r\nline2\r\nline3\r\n"
+
+
+def test_normalise_endings_crlf_to_lf() -> None:
+    content = "line1\r\nline2\r\nline3\r\n"
+    result = normalise_endings(content, "\n")
+    assert result == "line1\nline2\nline3\n"
+
+
+def test_normalise_endings_no_op_when_already_target() -> None:
+    content = "line1\nline2\n"
+    result = normalise_endings(content, "\n")
+    assert result == content
+
+
+def test_normalise_endings_no_double_conversion() -> None:
+    # Already CRLF, converting to CRLF should not produce \r\r\n
+    content = "line1\r\nline2\r\n"
+    result = normalise_endings(content, "\r\n")
+    assert "\r\r\n" not in result
+    assert result == "line1\r\nline2\r\n"

--- a/tests/workspace/test_edit_matcher.py
+++ b/tests/workspace/test_edit_matcher.py
@@ -130,10 +130,10 @@ def test_escape_normalised_double_escaped_newline() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_fuzzy_above_threshold_matches() -> None:
+def test_fuzzy_identical_strings_exact_wins() -> None:
+    """Verify that identical strings are caught by exact strategy before fuzzy."""
     m = EditMatcher()
     content = "def calculate_sum(a, b):\n    return a + b\n"
-    # Slightly different spelling, should still be >= 0.85
     old = "def calculate_sum(a, b):\n    return a + b\n"  # identical → exact wins
     result = m.find(content, old)
     assert result is not None
@@ -246,3 +246,76 @@ def test_normalise_endings_no_double_conversion() -> None:
     result = normalise_endings(content, "\r\n")
     assert "\r\r\n" not in result
     assert result == "line1\r\nline2\r\n"
+
+
+# ---------------------------------------------------------------------------
+# Additional coverage: uncovered branches
+# ---------------------------------------------------------------------------
+
+
+def test_dedented_fallback_dedents_content() -> None:
+    """Cover the _dedented fallback path where content itself is dedented."""
+    m = EditMatcher()
+    # Both content and old are indented the same → dedented_old == textwrap.dedent(old)
+    # Force the second branch: dedented_old not found verbatim in content,
+    # but found after dedenting both.
+    content = "    def foo():\n        return 1\n"
+    old = "        def foo():\n            return 1\n"
+    result = m._dedented(content, old)
+    assert result is not None
+    assert result.strategy == "dedented"
+
+
+def test_trimmed_boundary_stripped_not_in_content_returns_none() -> None:
+    """Cover _trimmed_boundary when the stripped old is not found in content."""
+    m = EditMatcher()
+    # old has blank edges but stripped version is not in content
+    result = m._trimmed_boundary("hello world", "\ncompletely_different\n")
+    assert result is None
+
+
+def test_escape_normalised_inverse_path() -> None:
+    """Cover _escape_normalised inverse path: decoded content contains old.
+
+    Setup:
+    - old = 'line1\\nline2'   (single backslash-n: two chars)
+    - norm_old = decode(old) = 'line1<newline>line2'  (actual newline) → norm_old != old
+    - content = 'line1\\\\nline2'  (two backslashes + n: four chars)
+    - norm_old ('line1<newline>line2') NOT in content → forward branch fails
+    - decoded_content = decode(content) = 'line1\\nline2' = old → inverse match found
+    """
+    m = EditMatcher()
+    old = "line1\\nline2"      # contains literal backslash + n (two chars \n)
+    content = "line1\\\\nline2"  # contains literal \\ + n (decodes to \n → matches old)
+    result = m._escape_normalised(content, old)
+    assert result is not None
+    assert result.strategy == "escape_normalised"
+
+
+def test_fuzzy_old_longer_than_content_returns_none() -> None:
+    """Cover _fuzzy when old has more lines than content."""
+    m = EditMatcher()
+    content = "line1\nline2\n"
+    old = "line1\nline2\nline3\nline4\nline5\n"
+    result = m._fuzzy(content, old)
+    assert result is None
+
+
+def test_fuzzy_empty_old_returns_none() -> None:
+    """Cover _fuzzy guard for zero-line old_string."""
+    m = EditMatcher()
+    result = m._fuzzy("some content\n", "")
+    assert result is None
+
+
+def test_remap_returns_none_when_lines_before_exceeds_original() -> None:
+    """Cover _remap guard: lines_before >= len(orig_lines) → None."""
+    m = EditMatcher()
+    # original has 1 line; norm_content has 'a' on line 4 (index 3).
+    # lines_before=3 >= len(orig_lines)=1 → _remap returns None.
+    original = "a\n"             # 1 line
+    old = "a\n"
+    norm_content2 = "x\ny\nz\na\n"
+    idx = norm_content2.find("a")  # at position 6 (after 3 newlines)
+    result = m._remap(original, old, idx, norm_content2, strategy="dedented")
+    assert result is None

--- a/tests/workspace/test_patch.py
+++ b/tests/workspace/test_patch.py
@@ -1,0 +1,278 @@
+"""Tests for parse_patch and apply_file_patch (Story 5.3)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from akgentic.tool.workspace.edit import FilePatch, Hunk, apply_file_patch, parse_patch
+from akgentic.tool.workspace.workspace import Filesystem
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+SIMPLE_DIFF = """\
+--- a/src/foo.py
++++ b/src/foo.py
+@@ -1,3 +1,3 @@
+ line1
+-old_line
++new_line
+ line3
+"""
+
+MULTI_FILE_DIFF = """\
+--- a/src/foo.py
++++ b/src/foo.py
+@@ -1,2 +1,2 @@
+-foo_old
++foo_new
+ common
+--- a/src/bar.py
++++ b/src/bar.py
+@@ -1,2 +1,2 @@
+-bar_old
++bar_new
+ other
+"""
+
+ADD_FILE_DIFF = """\
+--- /dev/null
++++ b/src/new_file.py
+@@ -0,0 +1,2 @@
++first_line
++second_line
+"""
+
+DELETE_FILE_DIFF = """\
+--- a/src/old_file.py
++++ /dev/null
+@@ -1,2 +0,0 @@
+-removed_line1
+-removed_line2
+"""
+
+MULTI_HUNK_DIFF = """\
+--- a/src/foo.py
++++ b/src/foo.py
+@@ -1,3 +1,3 @@
+ line1
+-old1
++new1
+ line3
+@@ -5,3 +5,3 @@
+ line5
+-old2
++new2
+ line7
+"""
+
+
+# ---------------------------------------------------------------------------
+# parse_patch — single file
+# ---------------------------------------------------------------------------
+
+
+def test_parse_patch_single_file() -> None:
+    patches = parse_patch(SIMPLE_DIFF)
+    assert len(patches) == 1
+    assert patches[0].path == "src/foo.py"
+    assert len(patches[0].hunks) == 1
+    hunk = patches[0].hunks[0]
+    assert hunk.old_start == 1
+    assert hunk.old_count == 3
+    assert hunk.new_start == 1
+    assert hunk.new_count == 3
+
+
+def test_parse_patch_single_file_hunk_lines() -> None:
+    patches = parse_patch(SIMPLE_DIFF)
+    hunk = patches[0].hunks[0]
+    assert " line1" in hunk.lines
+    assert "-old_line" in hunk.lines
+    assert "+new_line" in hunk.lines
+
+
+# ---------------------------------------------------------------------------
+# parse_patch — multi-file
+# ---------------------------------------------------------------------------
+
+
+def test_parse_patch_multi_file() -> None:
+    patches = parse_patch(MULTI_FILE_DIFF)
+    assert len(patches) == 2
+    assert patches[0].path == "src/foo.py"
+    assert patches[1].path == "src/bar.py"
+
+
+def test_parse_patch_multi_file_paths() -> None:
+    patches = parse_patch(MULTI_FILE_DIFF)
+    assert patches[0].hunks[0].lines[0] == "-foo_old"
+    assert patches[1].hunks[0].lines[0] == "-bar_old"
+
+
+# ---------------------------------------------------------------------------
+# parse_patch — hunk header parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_patch_hunk_header_values() -> None:
+    patches = parse_patch(SIMPLE_DIFF)
+    hunk = patches[0].hunks[0]
+    assert hunk.old_start == 1
+    assert hunk.old_count == 3
+    assert hunk.new_start == 1
+    assert hunk.new_count == 3
+
+
+def test_parse_patch_add_file_path() -> None:
+    patches = parse_patch(ADD_FILE_DIFF)
+    assert len(patches) == 1
+    assert patches[0].path == "src/new_file.py"
+
+
+def test_parse_patch_delete_file_path() -> None:
+    patches = parse_patch(DELETE_FILE_DIFF)
+    assert len(patches) == 1
+    assert patches[0].path == "/dev/null"
+
+
+def test_parse_patch_multi_hunk() -> None:
+    patches = parse_patch(MULTI_HUNK_DIFF)
+    assert len(patches) == 1
+    assert len(patches[0].hunks) == 2
+    assert patches[0].hunks[0].old_start == 1
+    assert patches[0].hunks[1].old_start == 5
+
+
+# ---------------------------------------------------------------------------
+# apply_file_patch — update operation
+# ---------------------------------------------------------------------------
+
+
+def test_apply_file_patch_update(tmp_path: Path) -> None:
+    fs = Filesystem(str(tmp_path), "ws")
+    fs.write("foo.py", b"line1\nline2\nline3\n")
+    patch = FilePatch(
+        path="foo.py",
+        hunks=[
+            Hunk(
+                old_start=2,
+                old_count=1,
+                new_start=2,
+                new_count=1,
+                lines=["-line2", "+new_line"],
+            )
+        ],
+    )
+    apply_file_patch(fs, patch)
+    result = fs.read("foo.py").decode()
+    assert "new_line" in result
+    assert "line2" not in result
+
+
+def test_apply_file_patch_update_only_targeted_lines(tmp_path: Path) -> None:
+    fs = Filesystem(str(tmp_path), "ws")
+    fs.write("foo.py", b"line1\nline2\nline3\n")
+    patch = FilePatch(
+        path="foo.py",
+        hunks=[
+            Hunk(
+                old_start=2,
+                old_count=1,
+                new_start=2,
+                new_count=1,
+                lines=["-line2", "+replaced"],
+            )
+        ],
+    )
+    apply_file_patch(fs, patch)
+    result = fs.read("foo.py").decode()
+    assert "line1" in result
+    assert "line3" in result
+    assert "replaced" in result
+
+
+# ---------------------------------------------------------------------------
+# apply_file_patch — add operation (all-add patch)
+# ---------------------------------------------------------------------------
+
+
+def test_apply_file_patch_add_new_file(tmp_path: Path) -> None:
+    fs = Filesystem(str(tmp_path), "ws")
+    patch = FilePatch(
+        path="new_file.py",
+        hunks=[
+            Hunk(
+                old_start=0,
+                old_count=0,
+                new_start=1,
+                new_count=2,
+                lines=["+first_line", "+second_line"],
+            )
+        ],
+    )
+    apply_file_patch(fs, patch)
+    result = fs.read("new_file.py").decode()
+    assert "first_line" in result
+    assert "second_line" in result
+
+
+# ---------------------------------------------------------------------------
+# apply_file_patch — delete operation (handled by caller — /dev/null sentinel)
+# ---------------------------------------------------------------------------
+
+
+def test_apply_file_patch_delete_sentinel(tmp_path: Path) -> None:
+    """apply_file_patch is NOT called for /dev/null path in tool.py.
+
+    This test verifies that callers should check path == "/dev/null" before
+    calling apply_file_patch. parse_patch correctly returns path="/dev/null"
+    for delete diffs.
+    """
+    patches = parse_patch(DELETE_FILE_DIFF)
+    assert patches[0].path == "/dev/null"
+    # Callers (workspace_patch) check for /dev/null and call fs.delete() instead.
+
+
+# ---------------------------------------------------------------------------
+# apply_file_patch — multi-hunk patch applies all hunks in order
+# ---------------------------------------------------------------------------
+
+
+def test_apply_file_patch_multi_hunk(tmp_path: Path) -> None:
+    fs = Filesystem(str(tmp_path), "ws")
+    # 7 lines; two hunks each replace one line
+    fs.write(
+        "foo.py",
+        b"line1\nold1\nline3\nline4\nline5\nold2\nline7\n",
+    )
+    patch = FilePatch(
+        path="foo.py",
+        hunks=[
+            Hunk(
+                old_start=2,
+                old_count=1,
+                new_start=2,
+                new_count=1,
+                lines=["-old1", "+new1"],
+            ),
+            Hunk(
+                old_start=6,
+                old_count=1,
+                new_start=6,
+                new_count=1,
+                lines=["-old2", "+new2"],
+            ),
+        ],
+    )
+    apply_file_patch(fs, patch)
+    result = fs.read("foo.py").decode()
+    assert "new1" in result
+    assert "new2" in result
+    assert "old1" not in result
+    assert "old2" not in result
+    # Surrounding lines preserved
+    assert "line1" in result
+    assert "line3" in result
+    assert "line7" in result

--- a/tests/workspace/test_patch.py
+++ b/tests/workspace/test_patch.py
@@ -145,6 +145,25 @@ def test_parse_patch_multi_hunk() -> None:
     assert patches[0].hunks[1].old_start == 5
 
 
+def test_parse_patch_hunk_header_missing_count_defaults_to_one() -> None:
+    """Cover the branch where hunk header omits count (e.g. @@ -1 +1 @@)."""
+    # Unified diff spec: "@@ -start +start @@" without count means count=1
+    diff_no_count = """\
+--- a/src/foo.py
++++ b/src/foo.py
+@@ -1 +1 @@
+-old_line
++new_line
+"""
+    patches = parse_patch(diff_no_count)
+    assert len(patches) == 1
+    hunk = patches[0].hunks[0]
+    assert hunk.old_start == 1
+    assert hunk.old_count == 1   # defaulted from missing count
+    assert hunk.new_start == 1
+    assert hunk.new_count == 1   # defaulted from missing count
+
+
 # ---------------------------------------------------------------------------
 # apply_file_patch — update operation
 # ---------------------------------------------------------------------------
@@ -216,6 +235,21 @@ def test_apply_file_patch_add_new_file(tmp_path: Path) -> None:
     result = fs.read("new_file.py").decode()
     assert "first_line" in result
     assert "second_line" in result
+    # New files must end with a trailing newline (Unix convention)
+    assert result.endswith("\n")
+
+
+def test_apply_file_patch_empty_hunks_does_not_create_file(tmp_path: Path) -> None:
+    """Guard against empty hunk list being treated as new-file (all() bug)."""
+    fs = Filesystem(str(tmp_path), "ws")
+    # Write an existing file first
+    fs.write("existing.py", b"content\n")
+    patch = FilePatch(path="existing.py", hunks=[])
+    # Empty hunk list → is_new_file must be False, update path is taken,
+    # splitlines on existing content with no hunks → file written back unchanged
+    apply_file_patch(fs, patch)
+    result = fs.read("existing.py").decode()
+    assert "content" in result
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add `edit.py` with `EditMatcher` 7-strategy cascade (exact, line_trimmed, whitespace_normalised, dedented, trimmed_boundary, escape_normalised, fuzzy)
- Add `MatchResult` dataclass, `detect_line_ending`, `normalise_endings`
- Add `Hunk`, `FilePatch`, `EditItem` Pydantic models, `parse_patch`, `apply_file_patch`
- Update `workspace/__init__.py` to export all 9 new names
- 47 tests across `test_edit_matcher.py` and `test_patch.py`; 95% branch coverage; 0 ruff errors; 0 mypy strict errors

## Review Fixes Applied

- Fixed `is_new_file` guard in `apply_file_patch`: `all()` on empty list returns `True` (vacuous truth), which would silently overwrite files; added `bool(file_patch.hunks)` guard
- Fixed trailing newline on new-file creation path (consistency with update path)
- Added 8 new tests covering previously uncovered branches: `_dedented` fallback, `_trimmed_boundary` no-match, `_escape_normalised` inverse path, `_fuzzy` edge cases, `_remap` overflow guard, hunk-header missing-count default, empty-hunk-list guard
- Renamed misleading test (`test_fuzzy_above_threshold_matches` → `test_fuzzy_identical_strings_exact_wins`)

Closes #47