### PR TITLE
WorkspaceTool — write and delete (Story 5.4)

### DIFF
--- a/src/akgentic/tool/__init__.py
+++ b/src/akgentic/tool/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 # Submodules with their own __init__ files
 from . import mcp, planning, search, team, workspace  # noqa: F401
-from .workspace.tool import WorkspaceReadTool  # noqa: F401
+from .workspace.tool import WorkspaceReadTool, WorkspaceTool  # noqa: F401
 from .core import (  # noqa: F401
     COMMAND,
     SYSTEM_PROMPT,
@@ -53,6 +53,7 @@ __all__ = [
     "team",
     "workspace",
     "WorkspaceReadTool",
+    "WorkspaceTool",
 ]
 
 if _VECTOR_SEARCH_AVAILABLE:

--- a/src/akgentic/tool/__init__.py
+++ b/src/akgentic/tool/__init__.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 # Submodules with their own __init__ files
-from . import mcp, planning, search, team  # noqa: F401
+from . import mcp, planning, search, team, workspace  # noqa: F401
+from .workspace.tool import WorkspaceReadTool  # noqa: F401
 from .core import (  # noqa: F401
     COMMAND,
     SYSTEM_PROMPT,
@@ -50,6 +51,8 @@ __all__ = [
     "planning",
     "search",
     "team",
+    "workspace",
+    "WorkspaceReadTool",
 ]
 
 if _VECTOR_SEARCH_AVAILABLE:

--- a/src/akgentic/tool/workspace/__init__.py
+++ b/src/akgentic/tool/workspace/__init__.py
@@ -1,0 +1,27 @@
+"""Workspace module — filesystem backend for team-scoped file operations."""
+
+from akgentic.tool.workspace.tool import (
+    WorkspaceGlob,
+    WorkspaceGrep,
+    WorkspaceList,
+    WorkspaceRead,
+    WorkspaceReadTool,
+)
+from akgentic.tool.workspace.workspace import (
+    FileEntry,
+    Filesystem,
+    Workspace,
+    get_workspace,
+)
+
+__all__ = [
+    "FileEntry",
+    "Filesystem",
+    "Workspace",
+    "get_workspace",
+    "WorkspaceRead",
+    "WorkspaceList",
+    "WorkspaceGlob",
+    "WorkspaceGrep",
+    "WorkspaceReadTool",
+]

--- a/src/akgentic/tool/workspace/__init__.py
+++ b/src/akgentic/tool/workspace/__init__.py
@@ -12,11 +12,14 @@ from akgentic.tool.workspace.edit import (
     parse_patch,
 )
 from akgentic.tool.workspace.tool import (
+    WorkspaceDelete,
     WorkspaceGlob,
     WorkspaceGrep,
     WorkspaceList,
     WorkspaceRead,
     WorkspaceReadTool,
+    WorkspaceTool,
+    WorkspaceWrite,
 )
 from akgentic.tool.workspace.workspace import (
     FileEntry,
@@ -44,4 +47,7 @@ __all__ = [
     "WorkspaceGlob",
     "WorkspaceGrep",
     "WorkspaceReadTool",
+    "WorkspaceWrite",
+    "WorkspaceDelete",
+    "WorkspaceTool",
 ]

--- a/src/akgentic/tool/workspace/__init__.py
+++ b/src/akgentic/tool/workspace/__init__.py
@@ -1,5 +1,16 @@
 """Workspace module — filesystem backend for team-scoped file operations."""
 
+from akgentic.tool.workspace.edit import (
+    EditItem,
+    EditMatcher,
+    FilePatch,
+    Hunk,
+    MatchResult,
+    apply_file_patch,
+    detect_line_ending,
+    normalise_endings,
+    parse_patch,
+)
 from akgentic.tool.workspace.tool import (
     WorkspaceGlob,
     WorkspaceGrep,
@@ -15,6 +26,15 @@ from akgentic.tool.workspace.workspace import (
 )
 
 __all__ = [
+    "EditItem",
+    "EditMatcher",
+    "FilePatch",
+    "Hunk",
+    "MatchResult",
+    "apply_file_patch",
+    "detect_line_ending",
+    "normalise_endings",
+    "parse_patch",
     "FileEntry",
     "Filesystem",
     "Workspace",

--- a/src/akgentic/tool/workspace/edit.py
+++ b/src/akgentic/tool/workspace/edit.py
@@ -1,0 +1,371 @@
+"""Workspace edit utilities — EditMatcher, line ending helpers, unified diff patch.
+
+All functionality required by WorkspaceTool.workspace_edit, workspace_multi_edit,
+and workspace_patch lives here. This module has no dependency on tool.py or
+ToolCard — it is pure algorithmic logic consumed by WorkspaceTool in tool.py.
+"""
+
+from __future__ import annotations
+
+import codecs
+import re
+import textwrap
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel
+
+if TYPE_CHECKING:
+    from akgentic.tool.workspace.workspace import Workspace
+
+
+@dataclass
+class MatchResult:
+    start: int  # byte offset in content where match begins
+    end: int  # byte offset in content where match ends (exclusive)
+    strategy: str  # name of winning strategy, e.g. "exact", "line_trimmed"
+
+
+class EditMatcher:
+    """7-strategy cascade for locating old_string in file content.
+
+    Strategies are tried in order. The first match wins.
+    All strategies return MatchResult(start, end, strategy) or None.
+    """
+
+    FUZZY_THRESHOLD: float = 0.85
+
+    def find(self, content: str, old_string: str) -> MatchResult | None:
+        for strategy in (
+            self._exact,
+            self._line_trimmed,
+            self._whitespace_normalised,
+            self._dedented,
+            self._trimmed_boundary,
+            self._escape_normalised,
+            self._fuzzy,
+        ):
+            result = strategy(content, old_string)
+            if result is not None:
+                return result
+        return None
+
+    # --- Strategy 1: exact ---------------------------------------------------
+
+    def _exact(self, content: str, old: str) -> MatchResult | None:
+        idx = content.find(old)
+        if idx == -1:
+            return None
+        return MatchResult(start=idx, end=idx + len(old), strategy="exact")
+
+    # --- Strategy 2: line-trimmed --------------------------------------------
+
+    def _line_trimmed(self, content: str, old: str) -> MatchResult | None:
+        """Strip per-line leading/trailing whitespace from old, then exact-match."""
+        stripped = "\n".join(line.strip() for line in old.splitlines())
+        if stripped == old:
+            return None  # no change — nothing new to try
+        norm_content = "\n".join(line.strip() for line in content.splitlines())
+        idx = norm_content.find(stripped)
+        if idx == -1:
+            return None
+        # Remap idx back to original content
+        return self._remap(content, old, idx, norm_content, strategy="line_trimmed")
+
+    # --- Strategy 3: whitespace-normalised -----------------------------------
+
+    def _whitespace_normalised(self, content: str, old: str) -> MatchResult | None:
+        """Collapse internal whitespace runs to single space, then exact-match."""
+        norm_old = re.sub(r"[ \t]+", " ", old)
+        if norm_old == old:
+            return None
+        norm_content = re.sub(r"[ \t]+", " ", content)
+        idx = norm_content.find(norm_old)
+        if idx == -1:
+            return None
+        return self._remap(content, old, idx, norm_content, strategy="whitespace_normalised")
+
+    # --- Strategy 4: dedented ------------------------------------------------
+
+    def _dedented(self, content: str, old: str) -> MatchResult | None:
+        """Dedent old_string, then exact-match against dedented content windows."""
+        dedented_old = textwrap.dedent(old)
+        if dedented_old == old:
+            return None
+        # Try matching dedented_old against lines in content with various indent levels
+        idx = content.find(dedented_old)
+        if idx != -1:
+            return MatchResult(start=idx, end=idx + len(dedented_old), strategy="dedented")
+        # Also try: dedent old, dedent content
+        dedented_content = textwrap.dedent(content)
+        idx = dedented_content.find(dedented_old)
+        if idx == -1:
+            return None
+        return self._remap(content, old, idx, dedented_content, strategy="dedented")
+
+    # --- Strategy 5: trimmed boundary ----------------------------------------
+
+    def _trimmed_boundary(self, content: str, old: str) -> MatchResult | None:
+        """Strip blank lines at edges of old_string, then exact-match."""
+        stripped = old.strip("\n")
+        if stripped == old:
+            return None  # no blank edges
+        result = self._exact(content, stripped)
+        if result is None:
+            return None
+        return MatchResult(start=result.start, end=result.end, strategy="trimmed_boundary")
+
+    # --- Strategy 6: escape-normalised ---------------------------------------
+
+    def _escape_normalised(self, content: str, old: str) -> MatchResult | None:
+        """Decode escape sequences in old_string, then exact-match."""
+        try:
+            decoded = codecs.decode(old.encode(), "unicode_escape")
+            # In Python 3, codecs.decode with 'unicode_escape' returns str directly
+            norm_old: str = (
+                decoded if isinstance(decoded, str) else decoded.decode("utf-8", errors="replace")
+            )
+        except Exception:
+            return None
+        if norm_old == old:
+            return None
+        result = self._exact(content, norm_old)
+        if result is not None:
+            return MatchResult(start=result.start, end=result.end, strategy="escape_normalised")
+        # Inverse: decode content, match original old
+        try:
+            decoded_content = codecs.decode(content.encode(), "unicode_escape")
+            norm_content: str = (
+                decoded_content
+                if isinstance(decoded_content, str)
+                else decoded_content.decode("utf-8", errors="replace")
+            )
+        except Exception:
+            return None
+        result = self._exact(norm_content, old)
+        if result is None:
+            return None
+        return self._remap(content, old, result.start, norm_content, strategy="escape_normalised")
+
+    # --- Strategy 7: fuzzy ---------------------------------------------------
+
+    def _fuzzy(self, content: str, old: str) -> MatchResult | None:
+        """SequenceMatcher fuzzy search; ratio must be >= FUZZY_THRESHOLD."""
+        old_lines = old.splitlines()
+        content_lines = content.splitlines()
+        n = len(old_lines)
+        if n == 0:
+            return None
+        best_ratio = 0.0
+        best_start_line = -1
+        for i in range(len(content_lines) - n + 1):
+            window = content_lines[i : i + n]
+            ratio = SequenceMatcher(None, old_lines, window).ratio()
+            if ratio > best_ratio:
+                best_ratio = ratio
+                best_start_line = i
+        if best_ratio < self.FUZZY_THRESHOLD or best_start_line == -1:
+            return None
+        # Map line index back to byte offset
+        start = sum(len(line) + 1 for line in content_lines[:best_start_line])
+        end = start + sum(
+            len(line) + 1 for line in content_lines[best_start_line : best_start_line + n]
+        )
+        # Trim trailing newline overshoot
+        end = min(end, len(content))
+        return MatchResult(start=start, end=end, strategy="fuzzy")
+
+    # --- Remap helper --------------------------------------------------------
+
+    def _remap(
+        self,
+        original: str,
+        old: str,
+        start_in_norm: int,
+        norm_content: str,
+        strategy: str,
+    ) -> MatchResult | None:
+        """Map a match offset in norm_content back to the original string.
+
+        Approximation: find the nearest position in original that aligns with
+        the normalised match start. Falls back to original line-count heuristic.
+        """
+        # Count lines before start_in_norm in norm_content
+        lines_before = norm_content[:start_in_norm].count("\n")
+        # Find same line offset in original
+        orig_lines = original.splitlines(keepends=True)
+        if lines_before >= len(orig_lines):
+            return None
+        orig_start = sum(len(line) for line in orig_lines[:lines_before])
+        # Count lines in old to determine end
+        old_line_count = len(old.splitlines())
+        orig_end = sum(
+            len(line) for line in orig_lines[lines_before : lines_before + old_line_count]
+        )
+        orig_end = orig_start + orig_end
+        orig_end = min(orig_end, len(original))
+        return MatchResult(start=orig_start, end=orig_end, strategy=strategy)
+
+
+def detect_line_ending(content: str) -> str:
+    """Detect dominant line ending in content.
+
+    Returns ``"\\r\\n"`` if CRLF is dominant, ``"\\n"`` otherwise (including
+    when content is empty or has no line endings).
+    """
+    crlf_count = content.count("\r\n")
+    lf_count = content.count("\n") - crlf_count  # pure LF only
+    return "\r\n" if crlf_count > lf_count else "\n"
+
+
+def normalise_endings(content: str, line_ending: str) -> str:
+    """Convert all line endings in content to line_ending.
+
+    First normalises all CRLF to LF, then converts LF to the target
+    line_ending. This prevents double-conversion (``\\r\\r\\n``).
+    """
+    normalised = content.replace("\r\n", "\n")
+    if line_ending == "\r\n":
+        return normalised.replace("\n", "\r\n")
+    return normalised
+
+
+class Hunk(BaseModel):
+    """Single hunk from a unified diff."""
+
+    old_start: int
+    old_count: int
+    new_start: int
+    new_count: int
+    lines: list[str]  # each line prefixed with '+', '-', or ' '
+
+
+class FilePatch(BaseModel):
+    """Parsed unified diff for a single file."""
+
+    path: str
+    hunks: list[Hunk]
+
+
+class EditItem(BaseModel):
+    """A single find-and-replace operation for workspace_multi_edit."""
+
+    path: str
+    old_string: str
+    new_string: str
+    replace_all: bool = False
+
+
+_HUNK_HEADER: re.Pattern[str] = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
+
+
+def parse_patch(patch_text: str) -> list[FilePatch]:
+    """Parse a GNU unified diff string into a list of FilePatch objects.
+
+    Supports single-file and multi-file diffs. Lines with ``--- /dev/null``
+    or ``+++ /dev/null`` are preserved in the path field as-is; consumers
+    must handle the sentinel.
+    """
+    patches: list[FilePatch] = []
+    current_path: str | None = None
+    current_hunks: list[Hunk] = []
+    current_hunk_lines: list[str] = []
+    current_hunk_header: tuple[int, int, int, int] | None = None
+
+    def _flush_hunk() -> None:
+        nonlocal current_hunk_lines, current_hunk_header
+        if current_hunk_header is not None:
+            os_, oc_, ns_, nc_ = current_hunk_header
+            current_hunks.append(
+                Hunk(
+                    old_start=os_,
+                    old_count=oc_,
+                    new_start=ns_,
+                    new_count=nc_,
+                    lines=list(current_hunk_lines),
+                )
+            )
+
+    def _flush_patch() -> None:
+        nonlocal current_path, current_hunks, current_hunk_lines, current_hunk_header
+        if current_path is not None:
+            _flush_hunk()
+            patches.append(FilePatch(path=current_path, hunks=list(current_hunks)))
+
+    for line in patch_text.splitlines():
+        if line.startswith("+++ "):
+            _flush_patch()  # save previous file patch if any
+            # path is after "+++ " prefix, strip optional "b/" git prefix
+            raw_path = line[4:].strip()
+            current_path = raw_path[2:] if raw_path.startswith("b/") else raw_path
+            current_hunks = []
+            current_hunk_lines = []
+            current_hunk_header = None
+        elif line.startswith("--- "):
+            continue  # skip --- lines; path taken from +++ line
+        else:
+            m = _HUNK_HEADER.match(line)
+            if m:
+                if current_hunk_header is not None:
+                    _flush_hunk()
+                    current_hunk_lines = []
+                os_ = int(m.group(1))
+                oc_ = int(m.group(2)) if m.group(2) is not None else 1
+                ns_ = int(m.group(3))
+                nc_ = int(m.group(4)) if m.group(4) is not None else 1
+                current_hunk_header = (os_, oc_, ns_, nc_)
+            elif current_hunk_header is not None and (
+                line.startswith("+") or line.startswith("-") or line.startswith(" ")
+            ):
+                current_hunk_lines.append(line)
+
+    _flush_patch()
+    return patches
+
+
+def apply_file_patch(workspace: "Workspace", file_patch: FilePatch) -> None:
+    """Read a workspace file, apply all hunks, write result back.
+
+    Handles add (path="new_file", all hunks are additions),
+    update (normal patch), and delete (path is sentinel "/dev/null" — but
+    callers handle delete by checking file_patch.path against "/dev/null"
+    BEFORE calling this function — see workspace_patch in tool.py).
+
+    Args:
+        workspace: Workspace backend (Filesystem instance in practice).
+        file_patch: Parsed FilePatch with one or more Hunk objects.
+
+    Raises:
+        FileNotFoundError: If file does not exist and patch is not a pure add.
+        PermissionError: If path escapes the workspace root.
+    """
+    # Determine if this is a new-file creation (all lines are additions)
+    is_new_file = all(
+        all(patch_line.startswith("+") for patch_line in hunk.lines if patch_line)
+        for hunk in file_patch.hunks
+    )
+
+    if is_new_file:
+        new_content = "\n".join(
+            line[1:] for hunk in file_patch.hunks for line in hunk.lines if line.startswith("+")
+        )
+        workspace.write(file_patch.path, new_content.encode("utf-8"))
+        return
+
+    raw = workspace.read(file_patch.path)
+    lines = raw.decode("utf-8").splitlines()
+    offset = 0
+    for hunk in file_patch.hunks:
+        start = hunk.old_start - 1 + offset
+        # Collect replacement lines (context + additions)
+        new_lines: list[str] = []
+        for patch_line in hunk.lines:
+            if patch_line.startswith("+"):
+                new_lines.append(patch_line[1:])
+            elif patch_line.startswith(" "):
+                new_lines.append(patch_line[1:])
+            # Lines starting with '-' are dropped
+        lines[start : start + hunk.old_count] = new_lines
+        offset += len(new_lines) - hunk.old_count
+    workspace.write(file_patch.path, ("\n".join(lines) + "\n").encode("utf-8"))

--- a/src/akgentic/tool/workspace/edit.py
+++ b/src/akgentic/tool/workspace/edit.py
@@ -340,8 +340,10 @@ def apply_file_patch(workspace: "Workspace", file_patch: FilePatch) -> None:
         FileNotFoundError: If file does not exist and patch is not a pure add.
         PermissionError: If path escapes the workspace root.
     """
-    # Determine if this is a new-file creation (all lines are additions)
-    is_new_file = all(
+    # Determine if this is a new-file creation (all lines are additions).
+    # Note: `all()` on an empty sequence returns True, so we guard against
+    # empty hunk lists explicitly to avoid treating an empty patch as new-file.
+    is_new_file = bool(file_patch.hunks) and all(
         all(patch_line.startswith("+") for patch_line in hunk.lines if patch_line)
         for hunk in file_patch.hunks
     )
@@ -350,7 +352,7 @@ def apply_file_patch(workspace: "Workspace", file_patch: FilePatch) -> None:
         new_content = "\n".join(
             line[1:] for hunk in file_patch.hunks for line in hunk.lines if line.startswith("+")
         )
-        workspace.write(file_patch.path, new_content.encode("utf-8"))
+        workspace.write(file_patch.path, (new_content + "\n").encode("utf-8"))
         return
 
     raw = workspace.read(file_patch.path)

--- a/src/akgentic/tool/workspace/tool.py
+++ b/src/akgentic/tool/workspace/tool.py
@@ -1,9 +1,10 @@
-"""WorkspaceReadTool — read-only workspace access: read, list, glob, grep.
+"""Workspace ToolCards — read-only and full read/write/delete access.
 
-Provides a ToolCard that exposes four read-only workspace operations as
-LLM-callable tools.  All operations are anchored to a team-scoped
-:class:`~akgentic.tool.workspace.workspace.Filesystem` backend obtained via
-:func:`~akgentic.tool.workspace.workspace.get_workspace`.
+:class:`WorkspaceReadTool` exposes four read-only workspace operations as
+LLM-callable tools.  :class:`WorkspaceTool` extends it with ``workspace_write``
+and ``workspace_delete`` capabilities.  All operations are anchored to a
+team-scoped :class:`~akgentic.tool.workspace.workspace.Filesystem` backend
+obtained via :func:`~akgentic.tool.workspace.workspace.get_workspace`.
 """
 
 from __future__ import annotations
@@ -483,8 +484,8 @@ class WorkspaceTool(WorkspaceReadTool):
                 existing = backend.read(path).decode("utf-8")
                 line_ending = detect_line_ending(existing)
                 normalised = normalise_endings(content, line_ending)
-            except FileNotFoundError:
-                normalised = content  # new file — use content as-is
+            except (FileNotFoundError, UnicodeDecodeError):
+                normalised = content  # new file or non-UTF-8 — use content as-is
             backend.write(path, normalised.encode("utf-8"))
             return f"Written: {path}"
 

--- a/src/akgentic/tool/workspace/tool.py
+++ b/src/akgentic/tool/workspace/tool.py
@@ -1,0 +1,391 @@
+"""WorkspaceReadTool — read-only workspace access: read, list, glob, grep.
+
+Provides a ToolCard that exposes four read-only workspace operations as
+LLM-callable tools.  All operations are anchored to a team-scoped
+:class:`~akgentic.tool.workspace.workspace.Filesystem` backend obtained via
+:func:`~akgentic.tool.workspace.workspace.get_workspace`.
+"""
+
+from __future__ import annotations
+
+import re as _re
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any, Callable
+
+from pydantic import PrivateAttr
+
+from akgentic.tool.core import TOOL_CALL, BaseToolParam, Channels, ToolCard, _resolve
+from akgentic.tool.event import ActorToolObserver
+from akgentic.tool.workspace.workspace import Filesystem, get_workspace
+
+
+class WorkspaceRead(BaseToolParam):
+    """Read a file from the team workspace with pagination support."""
+
+    expose: set[Channels] = {TOOL_CALL}
+    default_limit: int = 2000
+
+
+class WorkspaceList(BaseToolParam):
+    """List immediate children of a directory in the team workspace."""
+
+    expose: set[Channels] = {TOOL_CALL}
+
+
+class WorkspaceGlob(BaseToolParam):
+    """Find files matching a glob pattern in the team workspace."""
+
+    expose: set[Channels] = {TOOL_CALL}
+    max_results: int = 100
+
+
+class WorkspaceGrep(BaseToolParam):
+    """Search file contents by regex in the team workspace."""
+
+    expose: set[Channels] = {TOOL_CALL}
+    max_results: int = 100
+    max_line_length: int = 2000
+
+
+def _grep_python(
+    root: Path,
+    pattern: str,
+    include_glob: str,
+    max_results: int,
+    max_line_len: int,
+) -> list[tuple[Path, int, str]]:
+    """Search files using Python regex — no external dependencies required.
+
+    Args:
+        root: Filesystem root to search within.
+        pattern: Python regex pattern.
+        include_glob: Glob to restrict which files are searched (empty = all).
+        max_results: Maximum number of matching lines to return.
+        max_line_len: Truncate matching lines to this many characters.
+
+    Returns:
+        List of (file_path, line_number, line_text) tuples.
+    """
+    compiled = _re.compile(pattern)
+    results: list[tuple[Path, int, str]] = []
+    candidates = sorted(
+        root.rglob(include_glob or "*"),
+        key=lambda p: p.stat().st_mtime if p.is_file() else 0,
+        reverse=True,
+    )
+    for fpath in candidates:
+        if not fpath.is_file():
+            continue
+        try:
+            text = fpath.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if compiled.search(line):
+                results.append((fpath, lineno, line[:max_line_len]))
+                if len(results) >= max_results:
+                    return results
+    return results
+
+
+def _grep_rg(
+    root: Path,
+    pattern: str,
+    include_glob: str,
+    max_results: int,
+) -> list[tuple[Path, int, str]] | None:
+    """Try ripgrep; return None if rg is not on PATH or exits with error.
+
+    Args:
+        root: Filesystem root to search within.
+        pattern: Python regex pattern (ripgrep uses the same RE2 syntax).
+        include_glob: Glob to restrict which files are searched (empty = all).
+        max_results: Maximum number of matching lines to return.
+
+    Returns:
+        List of (file_path, line_number, line_text) tuples, or None if rg
+        is unavailable or encounters an error.
+    """
+    if shutil.which("rg") is None:
+        return None
+    cmd = [
+        "rg",
+        "--line-number",
+        "--no-heading",
+        "--hidden",
+        "--no-messages",
+        "--max-count",
+        str(max_results),
+    ]
+    if include_glob:
+        cmd += ["--glob", include_glob]
+    cmd += [pattern, str(root)]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=15)
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    if result.returncode not in (0, 1):
+        return None
+    matches: list[tuple[Path, int, str]] = []
+    for line in result.stdout.splitlines():
+        parts = line.split(":", 2)
+        if len(parts) == 3:
+            try:
+                matches.append((Path(parts[0]), int(parts[1]), parts[2]))
+            except ValueError:
+                continue
+    return matches
+
+
+class WorkspaceReadTool(ToolCard):
+    """Read-only workspace access: read, list, glob, grep."""
+
+    name: str = "WorkspaceRead"
+    description: str = "Read files, list directories, and search the team workspace"
+
+    workspace_id: str | None = None
+    workspace_read: WorkspaceRead | bool = True
+    workspace_list: WorkspaceList | bool = True
+    workspace_glob: WorkspaceGlob | bool = True
+    workspace_grep: WorkspaceGrep | bool = True
+
+    # Private runtime state — not part of the serialised config
+    _workspace: Filesystem = PrivateAttr()
+
+    def observer(  # type: ignore[override]
+        self, observer: ActorToolObserver
+    ) -> "WorkspaceReadTool":
+        """Attach observer and initialise the workspace backend.
+
+        Args:
+            observer: Actor tool observer; must have a non-None orchestrator.
+
+        Returns:
+            Self, enabling method chaining.
+
+        Raises:
+            ValueError: If ``observer.orchestrator`` is None.
+        """
+        self._observer = observer
+        if observer.orchestrator is None:
+            raise ValueError("WorkspaceReadTool requires access to the orchestrator.")
+        ws_name = self.workspace_id or str(observer._team_id)  # type: ignore[attr-defined]
+        self._workspace = get_workspace(ws_name)
+        return self
+
+    @property
+    def workspace(self) -> Filesystem:
+        """Return the workspace backend (set after :meth:`observer` is called)."""
+        return self._workspace
+
+    def get_tools(self) -> list[Callable[..., Any]]:
+        """Return enabled read-only workspace tool callables.
+
+        Returns:
+            List of callables for the capabilities not disabled via ``False``.
+        """
+        tools: list[Callable[..., Any]] = []
+        pr = _resolve(self.workspace_read, WorkspaceRead)
+        if pr is not None and TOOL_CALL in pr.expose:
+            tools.append(self._read_factory(pr))
+        pl = _resolve(self.workspace_list, WorkspaceList)
+        if pl is not None and TOOL_CALL in pl.expose:
+            tools.append(self._list_factory(pl))
+        pg = _resolve(self.workspace_glob, WorkspaceGlob)
+        if pg is not None and TOOL_CALL in pg.expose:
+            tools.append(self._glob_factory(pg))
+        pgr = _resolve(self.workspace_grep, WorkspaceGrep)
+        if pgr is not None and TOOL_CALL in pgr.expose:
+            tools.append(self._grep_factory(pgr))
+        return tools
+
+    def _read_factory(self, params: WorkspaceRead) -> Callable[..., Any]:
+        """Create the ``workspace_read`` tool callable.
+
+        Args:
+            params: Read capability configuration.
+
+        Returns:
+            Callable that reads a workspace file with pagination.
+        """
+        backend = self.workspace
+
+        def workspace_read(path: str, offset: int = 1, limit: int = params.default_limit) -> str:
+            """Read a file from the team workspace.
+
+            Args:
+                path: Relative path from workspace root (e.g. "src/main.py").
+                offset: First line to return, 1-indexed. Defaults to 1.
+                limit: Maximum lines to return. Defaults to 2000.
+
+            Returns:
+                File contents with 1-indexed line numbers prefixed.
+                Truncated files include a trailing notice.
+
+            Raises:
+                FileNotFoundError: If the path does not exist.
+                PermissionError: If the path escapes the workspace root.
+            """
+            raw = backend.read(path).decode("utf-8")
+            lines = raw.splitlines()
+            total = len(lines)
+            start = max(0, offset - 1)
+            end = min(start + limit, total)
+            numbered = "\n".join(
+                f"{start + i + 1:<6}{line}" for i, line in enumerate(lines[start:end])
+            )
+            if end < total:
+                numbered += (
+                    f"\n[... truncated: {total} lines total, showing {start + 1}-{end} ...]"
+                )
+            return numbered
+
+        workspace_read.__doc__ = params.format_docstring(workspace_read.__doc__)
+        return workspace_read
+
+    def _list_factory(self, params: WorkspaceList) -> Callable[..., Any]:
+        """Create the ``workspace_list`` tool callable.
+
+        Args:
+            params: List capability configuration.
+
+        Returns:
+            Callable that lists workspace directory contents.
+        """
+        backend = self.workspace
+
+        def workspace_list(path: str = "") -> str:
+            """List the contents of a directory in the team workspace.
+
+            Args:
+                path: Relative directory path. Defaults to workspace root.
+
+            Returns:
+                Newline-separated entries with ``[dir]`` / ``[file]`` prefixes
+                and byte sizes for files.  Returns "Empty directory." if the
+                directory contains no entries.
+
+            Raises:
+                PermissionError: If path escapes the workspace root.
+            """
+            entries = backend.list(path)
+            if not entries:
+                return "Empty directory."
+            entry_lines: list[str] = []
+            for entry in entries:
+                if entry.is_dir:
+                    entry_lines.append(f"[dir]  {entry.name}")
+                else:
+                    entry_lines.append(f"[file] {entry.name}  ({entry.size} bytes)")
+            return "\n".join(entry_lines)
+
+        workspace_list.__doc__ = params.format_docstring(workspace_list.__doc__)
+        return workspace_list
+
+    def _glob_factory(self, params: WorkspaceGlob) -> Callable[..., Any]:
+        """Create the ``workspace_glob`` tool callable.
+
+        Args:
+            params: Glob capability configuration.
+
+        Returns:
+            Callable that searches the workspace via glob patterns.
+        """
+        backend = self.workspace
+        max_results = params.max_results
+
+        def workspace_glob(pattern: str, path: str = "") -> str:
+            """Find files matching a glob pattern in the team workspace.
+
+            Args:
+                pattern: Glob pattern (e.g. "**/*.py", "src/**/*.ts").
+                path: Subdirectory to search within. Defaults to workspace root.
+
+            Returns:
+                Newline-separated list of relative file paths, or "No files found."
+                Includes truncation notice if more than max_results files matched.
+
+            Raises:
+                PermissionError: If path escapes the workspace root.
+            """
+            if path:
+                search_root = (backend._root / path).resolve()
+                if not search_root.is_relative_to(backend._root.resolve()):
+                    raise PermissionError(f"Path '{path}' escapes workspace root")
+            else:
+                search_root = backend._root
+            all_matches = sorted(
+                (match for match in search_root.glob(pattern) if match.is_file()),
+                key=lambda match: match.stat().st_mtime,
+                reverse=True,
+            )
+            truncated = len(all_matches) > max_results
+            shown = [str(m.relative_to(backend._root)) for m in all_matches[:max_results]]
+            if not shown:
+                return "No files found."
+            result = "\n".join(shown)
+            if truncated:
+                result += (
+                    f"\n[... truncated: {len(all_matches)} total,"
+                    f" showing first {max_results} ...]"
+                )
+            return result
+
+        workspace_glob.__doc__ = params.format_docstring(workspace_glob.__doc__)
+        return workspace_glob
+
+    def _grep_factory(self, params: WorkspaceGrep) -> Callable[..., Any]:
+        """Create the ``workspace_grep`` tool callable.
+
+        Args:
+            params: Grep capability configuration.
+
+        Returns:
+            Callable that searches workspace file contents by regex.
+        """
+        backend = self.workspace
+        max_results = params.max_results
+        max_line_len = params.max_line_length
+
+        def workspace_grep(pattern: str, path: str = "", include: str = "") -> str:
+            """Search file contents using a regex pattern in the team workspace.
+
+            Args:
+                pattern: Regular expression pattern (Python re syntax).
+                path: Subdirectory to search within. Defaults to workspace root.
+                include: Glob pattern to restrict which files are searched
+                    (e.g. "*.py", "*.ts"). Empty = all files.
+
+            Returns:
+                Formatted results grouped by file, or "No matches found."
+
+            Raises:
+                re.error: If pattern is not a valid regex.
+                PermissionError: If path escapes the workspace root.
+            """
+            if path:
+                search_root = (backend._root / path).resolve()
+                if not search_root.is_relative_to(backend._root.resolve()):
+                    raise PermissionError(f"Path '{path}' escapes workspace root")
+            else:
+                search_root = backend._root
+
+            raw_matches = _grep_rg(search_root, pattern, include, max_results)
+            if raw_matches is None:
+                raw_matches = _grep_python(
+                    search_root, pattern, include, max_results, max_line_len
+                )
+
+            if not raw_matches:
+                return "No matches found."
+
+            result_lines = [
+                f"{fpath.relative_to(backend._root)}:{lineno}: {line}"
+                for fpath, lineno, line in raw_matches
+            ]
+            return "\n".join(result_lines)
+
+        workspace_grep.__doc__ = params.format_docstring(workspace_grep.__doc__)
+        return workspace_grep

--- a/src/akgentic/tool/workspace/tool.py
+++ b/src/akgentic/tool/workspace/tool.py
@@ -151,8 +151,10 @@ class WorkspaceReadTool(ToolCard):
     workspace_glob: WorkspaceGlob | bool = True
     workspace_grep: WorkspaceGrep | bool = True
 
-    # Private runtime state — not part of the serialised config
-    _workspace: Filesystem = PrivateAttr()
+    # Private runtime state — not part of the serialised config.
+    # Default None sentinel lets the workspace property detect uninitialized state
+    # reliably under both normal execution and coverage instrumentation.
+    _workspace: Filesystem | None = PrivateAttr(default=None)
 
     def observer(  # type: ignore[override]
         self, observer: ActorToolObserver
@@ -168,16 +170,24 @@ class WorkspaceReadTool(ToolCard):
         Raises:
             ValueError: If ``observer.orchestrator`` is None.
         """
-        self._observer = observer
         if observer.orchestrator is None:
             raise ValueError("WorkspaceReadTool requires access to the orchestrator.")
+        self._observer = observer
         ws_name = self.workspace_id or str(observer._team_id)  # type: ignore[attr-defined]
         self._workspace = get_workspace(ws_name)
         return self
 
     @property
     def workspace(self) -> Filesystem:
-        """Return the workspace backend (set after :meth:`observer` is called)."""
+        """Return the workspace backend (set after :meth:`observer` is called).
+
+        Raises:
+            RuntimeError: If :meth:`observer` has not been called yet.
+        """
+        if not isinstance(self._workspace, Filesystem):
+            raise RuntimeError(
+                "WorkspaceReadTool.workspace accessed before observer() was called."
+            )
         return self._workspace
 
     def get_tools(self) -> list[Callable[..., Any]]:

--- a/src/akgentic/tool/workspace/tool.py
+++ b/src/akgentic/tool/workspace/tool.py
@@ -18,6 +18,7 @@ from pydantic import PrivateAttr
 
 from akgentic.tool.core import TOOL_CALL, BaseToolParam, Channels, ToolCard, _resolve
 from akgentic.tool.event import ActorToolObserver
+from akgentic.tool.workspace.edit import detect_line_ending, normalise_endings
 from akgentic.tool.workspace.workspace import Filesystem, get_workspace
 
 
@@ -399,3 +400,123 @@ class WorkspaceReadTool(ToolCard):
 
         workspace_grep.__doc__ = params.format_docstring(workspace_grep.__doc__)
         return workspace_grep
+
+
+class WorkspaceWrite(BaseToolParam):
+    """Write content to a file in the team workspace."""
+
+    expose: set[Channels] = {TOOL_CALL}
+
+
+class WorkspaceDelete(BaseToolParam):
+    """Delete a file from the team workspace."""
+
+    expose: set[Channels] = {TOOL_CALL}
+
+
+class WorkspaceTool(WorkspaceReadTool):
+    """Full workspace access: read + write + delete."""
+
+    name: str = "Workspace"
+    description: str = (
+        "Read, write, and delete files in the team workspace. "
+        "For SWE agents with full file I/O access."
+    )
+
+    workspace_write: WorkspaceWrite | bool = True
+    workspace_delete: WorkspaceDelete | bool = True
+
+    def observer(  # type: ignore[override]
+        self, observer: ActorToolObserver
+    ) -> "WorkspaceTool":
+        """Delegate to WorkspaceReadTool.observer(), return self typed as WorkspaceTool.
+
+        Args:
+            observer: Actor tool observer; must have a non-None orchestrator.
+
+        Returns:
+            Self, enabling method chaining.
+        """
+        super().observer(observer)
+        return self
+
+    def get_tools(self) -> list[Callable[..., Any]]:
+        """Return read tools from super() plus write and delete tools.
+
+        Returns:
+            List of callables for all enabled capabilities.
+        """
+        tools = super().get_tools()
+        pw = _resolve(self.workspace_write, WorkspaceWrite)
+        if pw is not None and TOOL_CALL in pw.expose:
+            tools.append(self._write_factory(pw))
+        pd = _resolve(self.workspace_delete, WorkspaceDelete)
+        if pd is not None and TOOL_CALL in pd.expose:
+            tools.append(self._delete_factory(pd))
+        return tools
+
+    def _write_factory(self, params: WorkspaceWrite) -> Callable[..., Any]:
+        """Create the ``workspace_write`` tool callable.
+
+        Args:
+            params: Write capability configuration.
+
+        Returns:
+            Callable that writes content to a workspace file.
+        """
+        backend = self.workspace
+
+        def workspace_write(path: str, content: str) -> str:
+            """Write content to a file in the team workspace.
+
+            Args:
+                path: Relative path from workspace root (e.g. "src/main.py").
+                content: Text content to write.
+
+            Returns:
+                Confirmation string "Written: <path>".
+
+            Raises:
+                PermissionError: If the path escapes the workspace root.
+            """
+            try:
+                existing = backend.read(path).decode("utf-8")
+                line_ending = detect_line_ending(existing)
+                normalised = normalise_endings(content, line_ending)
+            except FileNotFoundError:
+                normalised = content  # new file — use content as-is
+            backend.write(path, normalised.encode("utf-8"))
+            return f"Written: {path}"
+
+        workspace_write.__doc__ = params.format_docstring(workspace_write.__doc__)
+        return workspace_write
+
+    def _delete_factory(self, params: WorkspaceDelete) -> Callable[..., Any]:
+        """Create the ``workspace_delete`` tool callable.
+
+        Args:
+            params: Delete capability configuration.
+
+        Returns:
+            Callable that deletes a file from the workspace.
+        """
+        backend = self.workspace
+
+        def workspace_delete(path: str) -> str:
+            """Delete a file from the team workspace.
+
+            Args:
+                path: Relative path from workspace root (e.g. "src/old.py").
+
+            Returns:
+                Confirmation string "Deleted: <path>".
+
+            Raises:
+                FileNotFoundError: If the path does not exist.
+                PermissionError: If the path escapes the workspace root.
+            """
+            backend.delete(path)
+            return f"Deleted: {path}"
+
+        workspace_delete.__doc__ = params.format_docstring(workspace_delete.__doc__)
+        return workspace_delete

--- a/src/akgentic/tool/workspace/workspace.py
+++ b/src/akgentic/tool/workspace/workspace.py
@@ -1,0 +1,139 @@
+"""Workspace Protocol, Filesystem implementation, and get_workspace() factory.
+
+Provides a secure, team-scoped filesystem backend for workspace tools.
+All path operations validate that the resolved path stays within the workspace root
+to prevent directory traversal attacks.
+
+Unknown WORKSPACE_MODE values raise KeyError intentionally (fail-fast behaviour).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+from pydantic import BaseModel
+
+
+class FileEntry(BaseModel):
+    """Metadata for a single filesystem entry inside a workspace."""
+
+    name: str
+    is_dir: bool
+    size: int  # bytes; 0 for directories
+
+
+@runtime_checkable
+class Workspace(Protocol):
+    """Protocol that all workspace backends must satisfy."""
+
+    def read(self, path: str) -> bytes: ...
+
+    def write(self, path: str, data: bytes) -> None: ...
+
+    def delete(self, path: str) -> None: ...
+
+    def list(self, path: str = "") -> list[FileEntry]: ...
+
+
+class Filesystem:
+    """Local filesystem backend for a single team workspace.
+
+    All paths are anchored to ``<base_path>/<workspace_name>``.  Any attempt to
+    escape that root (via ``../`` traversal or symlinks that resolve outside) is
+    rejected with :exc:`PermissionError`.
+    """
+
+    def __init__(self, base_path: str, workspace_name: str) -> None:
+        self._root = Path(base_path) / workspace_name
+        self._root.mkdir(parents=True, exist_ok=True)
+
+    def _validate_path(self, path: str) -> Path:
+        """Resolve *path* relative to the workspace root and validate it.
+
+        Uses :meth:`Path.is_relative_to` (Python 3.9+) for component-level
+        comparison, which prevents false positives when a sibling workspace name
+        begins with the same characters (e.g. ``team-1`` vs ``team-11``).
+
+        Raises:
+            PermissionError: if the resolved path escapes the workspace root.
+        """
+        resolved = (self._root / path).resolve()
+        if not resolved.is_relative_to(self._root.resolve()):
+            raise PermissionError(f"Path '{path}' escapes workspace root")
+        return resolved
+
+    def read(self, path: str) -> bytes:
+        """Return the contents of *path* as bytes.
+
+        Raises:
+            FileNotFoundError: if the file does not exist.
+            PermissionError: if *path* escapes the workspace root.
+        """
+        resolved = self._validate_path(path)
+        return resolved.read_bytes()
+
+    def write(self, path: str, data: bytes) -> None:
+        """Write *data* to *path*, creating missing parent directories.
+
+        Raises:
+            PermissionError: if *path* escapes the workspace root.
+        """
+        resolved = self._validate_path(path)
+        resolved.parent.mkdir(parents=True, exist_ok=True)
+        resolved.write_bytes(data)
+
+    def delete(self, path: str) -> None:
+        """Delete the file at *path*.
+
+        Raises:
+            FileNotFoundError: if the file does not exist.
+            PermissionError: if *path* escapes the workspace root.
+        """
+        resolved = self._validate_path(path)
+        resolved.unlink()
+
+    def list(self, path: str = "") -> list[FileEntry]:
+        """List immediate children of *path* (non-recursive).
+
+        Returns directories first (alphabetically), then files (alphabetically).
+        ``size`` is 0 for directories and the file byte count for regular files.
+
+        Raises:
+            PermissionError: if *path* escapes the workspace root.
+        """
+        resolved = self._validate_path(path) if path else self._root
+        entries: list[FileEntry] = []
+        dirs: list[FileEntry] = []
+        files: list[FileEntry] = []
+        for child in resolved.iterdir():
+            if child.is_dir():
+                dirs.append(FileEntry(name=child.name, is_dir=True, size=0))
+            else:
+                files.append(
+                    FileEntry(name=child.name, is_dir=False, size=child.stat().st_size)
+                )
+        dirs.sort(key=lambda e: e.name)
+        files.sort(key=lambda e: e.name)
+        entries = dirs + files
+        return entries
+
+
+def get_workspace(workspace_name: str) -> Filesystem:
+    """Return a :class:`Filesystem` for *workspace_name* using the current mode.
+
+    The base path is selected from ``WORKSPACE_MODE`` environment variable:
+
+    - ``local`` (default, or unset): ``./workspaces``
+    - ``docker``: ``/workspaces``
+
+    Raises:
+        KeyError: if ``WORKSPACE_MODE`` is set to an unknown value (fail-fast).
+    """
+    mode = os.environ.get("WORKSPACE_MODE", "local")
+    base_path = {
+        "local": "./workspaces",
+        "docker": "/workspaces",
+    }[mode]
+    return Filesystem(base_path=base_path, workspace_name=workspace_name)

--- a/tests/workspace/test_edit_matcher.py
+++ b/tests/workspace/test_edit_matcher.py
@@ -1,0 +1,248 @@
+"""Tests for EditMatcher strategies and line ending utilities (Story 5.3)."""
+
+from __future__ import annotations
+
+from akgentic.tool.workspace.edit import EditMatcher, detect_line_ending, normalise_endings
+
+# ---------------------------------------------------------------------------
+# Strategy 1: exact
+# ---------------------------------------------------------------------------
+
+
+def test_exact_match_found() -> None:
+    m = EditMatcher()
+    result = m.find("hello world", "world")
+    assert result is not None
+    assert result.strategy == "exact"
+    assert result.start == 6
+    assert result.end == 11
+
+
+def test_exact_match_not_found() -> None:
+    m = EditMatcher()
+    result = m._exact("hello world", "xyz")
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Strategy 2: line-trimmed
+# ---------------------------------------------------------------------------
+
+
+def test_line_trimmed_match() -> None:
+    m = EditMatcher()
+    content = "def foo():\n    return 1\n"
+    # old_string has extra leading/trailing whitespace on each line
+    old = "  def foo():  \n      return 1  \n"
+    result = m.find(content, old)
+    assert result is not None
+    assert result.strategy == "line_trimmed"
+
+
+def test_line_trimmed_no_change_returns_none_from_strategy() -> None:
+    m = EditMatcher()
+    # Already stripped — strategy should return None (no new info)
+    result = m._line_trimmed("hello world", "hello world")
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Strategy 3: whitespace-normalised
+# ---------------------------------------------------------------------------
+
+
+def test_whitespace_normalised_match() -> None:
+    m = EditMatcher()
+    content = "x = 1 + 2"
+    old = "x  =  1  +  2"  # extra spaces collapsed
+    result = m.find(content, old)
+    assert result is not None
+    assert result.strategy == "whitespace_normalised"
+
+
+def test_whitespace_normalised_no_change_returns_none() -> None:
+    m = EditMatcher()
+    result = m._whitespace_normalised("x = 1", "x = 1")
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Strategy 4: dedented
+# ---------------------------------------------------------------------------
+
+
+def test_dedented_match() -> None:
+    m = EditMatcher()
+    content = "def foo():\n    return 1\n"
+    # old_string with extra indentation — test via _dedented directly
+    # to avoid earlier strategies in the cascade winning
+    old = "    def foo():\n        return 1\n"
+    result = m._dedented(content, old)
+    assert result is not None
+    assert result.strategy == "dedented"
+
+
+def test_dedented_no_change_returns_none() -> None:
+    m = EditMatcher()
+    result = m._dedented("no indent\n", "no indent\n")
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Strategy 5: trimmed boundary
+# ---------------------------------------------------------------------------
+
+
+def test_trimmed_boundary_match() -> None:
+    m = EditMatcher()
+    content = "def foo():\n    return 1\n"
+    old_with_blank = "\ndef foo():\n    return 1\n"
+    result = m.find(content, old_with_blank)
+    assert result is not None
+    assert result.strategy == "trimmed_boundary"
+
+
+def test_trimmed_boundary_no_blank_edge_returns_none() -> None:
+    m = EditMatcher()
+    # No blank edges on old_string — strategy must return None
+    result = m._trimmed_boundary("hello world", "hello world")
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Strategy 6: escape-normalised
+# ---------------------------------------------------------------------------
+
+
+def test_escape_normalised_double_escaped_newline() -> None:
+    m = EditMatcher()
+    # Content has a literal newline; old_string has double-escaped \\n
+    content = "line1\nline2"
+    # Simulate LLM outputting double-escaped: "line1\\nline2"
+    old = "line1\\nline2"
+    result = m.find(content, old)
+    assert result is not None
+    assert result.strategy == "escape_normalised"
+
+
+# ---------------------------------------------------------------------------
+# Strategy 7: fuzzy
+# ---------------------------------------------------------------------------
+
+
+def test_fuzzy_above_threshold_matches() -> None:
+    m = EditMatcher()
+    content = "def calculate_sum(a, b):\n    return a + b\n"
+    # Slightly different spelling, should still be >= 0.85
+    old = "def calculate_sum(a, b):\n    return a + b\n"  # identical → exact wins
+    result = m.find(content, old)
+    assert result is not None
+    assert result.strategy == "exact"
+
+
+def test_fuzzy_high_similarity() -> None:
+    m = EditMatcher()
+    # 10 lines: 9 identical, 1 different — line-level ratio = 0.9 (>= 0.85 threshold)
+    shared = ["line1", "line2", "line3", "line4", "line5", "line6", "line7", "line8", "line9"]
+    content_lines = shared + ["new_line"]
+    old_lines = shared + ["old_line"]
+    content = "\n".join(content_lines) + "\n"
+    old = "\n".join(old_lines)
+    result = m._fuzzy(content, old)
+    assert result is not None
+    assert result.strategy == "fuzzy"
+
+
+def test_fuzzy_below_threshold_returns_none() -> None:
+    m = EditMatcher()
+    result = m.find("hello world", "completely different text that bears no resemblance")
+    assert result is None
+
+
+def test_fuzzy_ratio_just_below_threshold_returns_none() -> None:
+    m = EditMatcher()
+    # Force a low-similarity check via _fuzzy directly
+    result = m._fuzzy("aaa bbb ccc", "xxx yyy zzz ppp qqq rrr sss")
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# find() cascade order — earlier strategy wins
+# ---------------------------------------------------------------------------
+
+
+def test_find_cascade_exact_wins_over_fuzzy() -> None:
+    m = EditMatcher()
+    content = "hello world"
+    old = "hello world"
+    result = m.find(content, old)
+    assert result is not None
+    assert result.strategy == "exact"
+
+
+def test_find_returns_none_when_no_strategy_matches() -> None:
+    m = EditMatcher()
+    result = m.find("short text", "completely unrelated long string with no overlap whatsoever xyz")
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# detect_line_ending
+# ---------------------------------------------------------------------------
+
+
+def test_detect_line_ending_crlf_dominant() -> None:
+    content = "line1\r\nline2\r\nline3\r\n"
+    assert detect_line_ending(content) == "\r\n"
+
+
+def test_detect_line_ending_lf_dominant() -> None:
+    content = "line1\nline2\nline3\n"
+    assert detect_line_ending(content) == "\n"
+
+
+def test_detect_line_ending_empty_content_returns_lf() -> None:
+    assert detect_line_ending("") == "\n"
+
+
+def test_detect_line_ending_mixed_crlf_wins() -> None:
+    # 3 CRLF vs 1 pure LF
+    content = "a\r\nb\r\nc\r\nd\n"
+    assert detect_line_ending(content) == "\r\n"
+
+
+def test_detect_line_ending_mixed_lf_wins() -> None:
+    # 1 CRLF vs 3 pure LF
+    content = "a\r\nb\nc\nd\n"
+    assert detect_line_ending(content) == "\n"
+
+
+# ---------------------------------------------------------------------------
+# normalise_endings
+# ---------------------------------------------------------------------------
+
+
+def test_normalise_endings_lf_to_crlf() -> None:
+    content = "line1\nline2\nline3\n"
+    result = normalise_endings(content, "\r\n")
+    assert result == "line1\r\nline2\r\nline3\r\n"
+
+
+def test_normalise_endings_crlf_to_lf() -> None:
+    content = "line1\r\nline2\r\nline3\r\n"
+    result = normalise_endings(content, "\n")
+    assert result == "line1\nline2\nline3\n"
+
+
+def test_normalise_endings_no_op_when_already_target() -> None:
+    content = "line1\nline2\n"
+    result = normalise_endings(content, "\n")
+    assert result == content
+
+
+def test_normalise_endings_no_double_conversion() -> None:
+    # Already CRLF, converting to CRLF should not produce \r\r\n
+    content = "line1\r\nline2\r\n"
+    result = normalise_endings(content, "\r\n")
+    assert "\r\r\n" not in result
+    assert result == "line1\r\nline2\r\n"

--- a/tests/workspace/test_edit_matcher.py
+++ b/tests/workspace/test_edit_matcher.py
@@ -130,10 +130,10 @@ def test_escape_normalised_double_escaped_newline() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_fuzzy_above_threshold_matches() -> None:
+def test_fuzzy_identical_strings_exact_wins() -> None:
+    """Verify that identical strings are caught by exact strategy before fuzzy."""
     m = EditMatcher()
     content = "def calculate_sum(a, b):\n    return a + b\n"
-    # Slightly different spelling, should still be >= 0.85
     old = "def calculate_sum(a, b):\n    return a + b\n"  # identical → exact wins
     result = m.find(content, old)
     assert result is not None
@@ -246,3 +246,76 @@ def test_normalise_endings_no_double_conversion() -> None:
     result = normalise_endings(content, "\r\n")
     assert "\r\r\n" not in result
     assert result == "line1\r\nline2\r\n"
+
+
+# ---------------------------------------------------------------------------
+# Additional coverage: uncovered branches
+# ---------------------------------------------------------------------------
+
+
+def test_dedented_fallback_dedents_content() -> None:
+    """Cover the _dedented fallback path where content itself is dedented."""
+    m = EditMatcher()
+    # Both content and old are indented the same → dedented_old == textwrap.dedent(old)
+    # Force the second branch: dedented_old not found verbatim in content,
+    # but found after dedenting both.
+    content = "    def foo():\n        return 1\n"
+    old = "        def foo():\n            return 1\n"
+    result = m._dedented(content, old)
+    assert result is not None
+    assert result.strategy == "dedented"
+
+
+def test_trimmed_boundary_stripped_not_in_content_returns_none() -> None:
+    """Cover _trimmed_boundary when the stripped old is not found in content."""
+    m = EditMatcher()
+    # old has blank edges but stripped version is not in content
+    result = m._trimmed_boundary("hello world", "\ncompletely_different\n")
+    assert result is None
+
+
+def test_escape_normalised_inverse_path() -> None:
+    """Cover _escape_normalised inverse path: decoded content contains old.
+
+    Setup:
+    - old = 'line1\\nline2'   (single backslash-n: two chars)
+    - norm_old = decode(old) = 'line1<newline>line2'  (actual newline) → norm_old != old
+    - content = 'line1\\\\nline2'  (two backslashes + n: four chars)
+    - norm_old ('line1<newline>line2') NOT in content → forward branch fails
+    - decoded_content = decode(content) = 'line1\\nline2' = old → inverse match found
+    """
+    m = EditMatcher()
+    old = "line1\\nline2"      # contains literal backslash + n (two chars \n)
+    content = "line1\\\\nline2"  # contains literal \\ + n (decodes to \n → matches old)
+    result = m._escape_normalised(content, old)
+    assert result is not None
+    assert result.strategy == "escape_normalised"
+
+
+def test_fuzzy_old_longer_than_content_returns_none() -> None:
+    """Cover _fuzzy when old has more lines than content."""
+    m = EditMatcher()
+    content = "line1\nline2\n"
+    old = "line1\nline2\nline3\nline4\nline5\n"
+    result = m._fuzzy(content, old)
+    assert result is None
+
+
+def test_fuzzy_empty_old_returns_none() -> None:
+    """Cover _fuzzy guard for zero-line old_string."""
+    m = EditMatcher()
+    result = m._fuzzy("some content\n", "")
+    assert result is None
+
+
+def test_remap_returns_none_when_lines_before_exceeds_original() -> None:
+    """Cover _remap guard: lines_before >= len(orig_lines) → None."""
+    m = EditMatcher()
+    # original has 1 line; norm_content has 'a' on line 4 (index 3).
+    # lines_before=3 >= len(orig_lines)=1 → _remap returns None.
+    original = "a\n"             # 1 line
+    old = "a\n"
+    norm_content2 = "x\ny\nz\na\n"
+    idx = norm_content2.find("a")  # at position 6 (after 3 newlines)
+    result = m._remap(original, old, idx, norm_content2, strategy="dedented")
+    assert result is None

--- a/tests/workspace/test_patch.py
+++ b/tests/workspace/test_patch.py
@@ -1,0 +1,278 @@
+"""Tests for parse_patch and apply_file_patch (Story 5.3)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from akgentic.tool.workspace.edit import FilePatch, Hunk, apply_file_patch, parse_patch
+from akgentic.tool.workspace.workspace import Filesystem
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+SIMPLE_DIFF = """\
+--- a/src/foo.py
++++ b/src/foo.py
+@@ -1,3 +1,3 @@
+ line1
+-old_line
++new_line
+ line3
+"""
+
+MULTI_FILE_DIFF = """\
+--- a/src/foo.py
++++ b/src/foo.py
+@@ -1,2 +1,2 @@
+-foo_old
++foo_new
+ common
+--- a/src/bar.py
++++ b/src/bar.py
+@@ -1,2 +1,2 @@
+-bar_old
++bar_new
+ other
+"""
+
+ADD_FILE_DIFF = """\
+--- /dev/null
++++ b/src/new_file.py
+@@ -0,0 +1,2 @@
++first_line
++second_line
+"""
+
+DELETE_FILE_DIFF = """\
+--- a/src/old_file.py
++++ /dev/null
+@@ -1,2 +0,0 @@
+-removed_line1
+-removed_line2
+"""
+
+MULTI_HUNK_DIFF = """\
+--- a/src/foo.py
++++ b/src/foo.py
+@@ -1,3 +1,3 @@
+ line1
+-old1
++new1
+ line3
+@@ -5,3 +5,3 @@
+ line5
+-old2
++new2
+ line7
+"""
+
+
+# ---------------------------------------------------------------------------
+# parse_patch — single file
+# ---------------------------------------------------------------------------
+
+
+def test_parse_patch_single_file() -> None:
+    patches = parse_patch(SIMPLE_DIFF)
+    assert len(patches) == 1
+    assert patches[0].path == "src/foo.py"
+    assert len(patches[0].hunks) == 1
+    hunk = patches[0].hunks[0]
+    assert hunk.old_start == 1
+    assert hunk.old_count == 3
+    assert hunk.new_start == 1
+    assert hunk.new_count == 3
+
+
+def test_parse_patch_single_file_hunk_lines() -> None:
+    patches = parse_patch(SIMPLE_DIFF)
+    hunk = patches[0].hunks[0]
+    assert " line1" in hunk.lines
+    assert "-old_line" in hunk.lines
+    assert "+new_line" in hunk.lines
+
+
+# ---------------------------------------------------------------------------
+# parse_patch — multi-file
+# ---------------------------------------------------------------------------
+
+
+def test_parse_patch_multi_file() -> None:
+    patches = parse_patch(MULTI_FILE_DIFF)
+    assert len(patches) == 2
+    assert patches[0].path == "src/foo.py"
+    assert patches[1].path == "src/bar.py"
+
+
+def test_parse_patch_multi_file_paths() -> None:
+    patches = parse_patch(MULTI_FILE_DIFF)
+    assert patches[0].hunks[0].lines[0] == "-foo_old"
+    assert patches[1].hunks[0].lines[0] == "-bar_old"
+
+
+# ---------------------------------------------------------------------------
+# parse_patch — hunk header parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_patch_hunk_header_values() -> None:
+    patches = parse_patch(SIMPLE_DIFF)
+    hunk = patches[0].hunks[0]
+    assert hunk.old_start == 1
+    assert hunk.old_count == 3
+    assert hunk.new_start == 1
+    assert hunk.new_count == 3
+
+
+def test_parse_patch_add_file_path() -> None:
+    patches = parse_patch(ADD_FILE_DIFF)
+    assert len(patches) == 1
+    assert patches[0].path == "src/new_file.py"
+
+
+def test_parse_patch_delete_file_path() -> None:
+    patches = parse_patch(DELETE_FILE_DIFF)
+    assert len(patches) == 1
+    assert patches[0].path == "/dev/null"
+
+
+def test_parse_patch_multi_hunk() -> None:
+    patches = parse_patch(MULTI_HUNK_DIFF)
+    assert len(patches) == 1
+    assert len(patches[0].hunks) == 2
+    assert patches[0].hunks[0].old_start == 1
+    assert patches[0].hunks[1].old_start == 5
+
+
+# ---------------------------------------------------------------------------
+# apply_file_patch — update operation
+# ---------------------------------------------------------------------------
+
+
+def test_apply_file_patch_update(tmp_path: Path) -> None:
+    fs = Filesystem(str(tmp_path), "ws")
+    fs.write("foo.py", b"line1\nline2\nline3\n")
+    patch = FilePatch(
+        path="foo.py",
+        hunks=[
+            Hunk(
+                old_start=2,
+                old_count=1,
+                new_start=2,
+                new_count=1,
+                lines=["-line2", "+new_line"],
+            )
+        ],
+    )
+    apply_file_patch(fs, patch)
+    result = fs.read("foo.py").decode()
+    assert "new_line" in result
+    assert "line2" not in result
+
+
+def test_apply_file_patch_update_only_targeted_lines(tmp_path: Path) -> None:
+    fs = Filesystem(str(tmp_path), "ws")
+    fs.write("foo.py", b"line1\nline2\nline3\n")
+    patch = FilePatch(
+        path="foo.py",
+        hunks=[
+            Hunk(
+                old_start=2,
+                old_count=1,
+                new_start=2,
+                new_count=1,
+                lines=["-line2", "+replaced"],
+            )
+        ],
+    )
+    apply_file_patch(fs, patch)
+    result = fs.read("foo.py").decode()
+    assert "line1" in result
+    assert "line3" in result
+    assert "replaced" in result
+
+
+# ---------------------------------------------------------------------------
+# apply_file_patch — add operation (all-add patch)
+# ---------------------------------------------------------------------------
+
+
+def test_apply_file_patch_add_new_file(tmp_path: Path) -> None:
+    fs = Filesystem(str(tmp_path), "ws")
+    patch = FilePatch(
+        path="new_file.py",
+        hunks=[
+            Hunk(
+                old_start=0,
+                old_count=0,
+                new_start=1,
+                new_count=2,
+                lines=["+first_line", "+second_line"],
+            )
+        ],
+    )
+    apply_file_patch(fs, patch)
+    result = fs.read("new_file.py").decode()
+    assert "first_line" in result
+    assert "second_line" in result
+
+
+# ---------------------------------------------------------------------------
+# apply_file_patch — delete operation (handled by caller — /dev/null sentinel)
+# ---------------------------------------------------------------------------
+
+
+def test_apply_file_patch_delete_sentinel(tmp_path: Path) -> None:
+    """apply_file_patch is NOT called for /dev/null path in tool.py.
+
+    This test verifies that callers should check path == "/dev/null" before
+    calling apply_file_patch. parse_patch correctly returns path="/dev/null"
+    for delete diffs.
+    """
+    patches = parse_patch(DELETE_FILE_DIFF)
+    assert patches[0].path == "/dev/null"
+    # Callers (workspace_patch) check for /dev/null and call fs.delete() instead.
+
+
+# ---------------------------------------------------------------------------
+# apply_file_patch — multi-hunk patch applies all hunks in order
+# ---------------------------------------------------------------------------
+
+
+def test_apply_file_patch_multi_hunk(tmp_path: Path) -> None:
+    fs = Filesystem(str(tmp_path), "ws")
+    # 7 lines; two hunks each replace one line
+    fs.write(
+        "foo.py",
+        b"line1\nold1\nline3\nline4\nline5\nold2\nline7\n",
+    )
+    patch = FilePatch(
+        path="foo.py",
+        hunks=[
+            Hunk(
+                old_start=2,
+                old_count=1,
+                new_start=2,
+                new_count=1,
+                lines=["-old1", "+new1"],
+            ),
+            Hunk(
+                old_start=6,
+                old_count=1,
+                new_start=6,
+                new_count=1,
+                lines=["-old2", "+new2"],
+            ),
+        ],
+    )
+    apply_file_patch(fs, patch)
+    result = fs.read("foo.py").decode()
+    assert "new1" in result
+    assert "new2" in result
+    assert "old1" not in result
+    assert "old2" not in result
+    # Surrounding lines preserved
+    assert "line1" in result
+    assert "line3" in result
+    assert "line7" in result

--- a/tests/workspace/test_patch.py
+++ b/tests/workspace/test_patch.py
@@ -145,6 +145,25 @@ def test_parse_patch_multi_hunk() -> None:
     assert patches[0].hunks[1].old_start == 5
 
 
+def test_parse_patch_hunk_header_missing_count_defaults_to_one() -> None:
+    """Cover the branch where hunk header omits count (e.g. @@ -1 +1 @@)."""
+    # Unified diff spec: "@@ -start +start @@" without count means count=1
+    diff_no_count = """\
+--- a/src/foo.py
++++ b/src/foo.py
+@@ -1 +1 @@
+-old_line
++new_line
+"""
+    patches = parse_patch(diff_no_count)
+    assert len(patches) == 1
+    hunk = patches[0].hunks[0]
+    assert hunk.old_start == 1
+    assert hunk.old_count == 1   # defaulted from missing count
+    assert hunk.new_start == 1
+    assert hunk.new_count == 1   # defaulted from missing count
+
+
 # ---------------------------------------------------------------------------
 # apply_file_patch — update operation
 # ---------------------------------------------------------------------------
@@ -216,6 +235,21 @@ def test_apply_file_patch_add_new_file(tmp_path: Path) -> None:
     result = fs.read("new_file.py").decode()
     assert "first_line" in result
     assert "second_line" in result
+    # New files must end with a trailing newline (Unix convention)
+    assert result.endswith("\n")
+
+
+def test_apply_file_patch_empty_hunks_does_not_create_file(tmp_path: Path) -> None:
+    """Guard against empty hunk list being treated as new-file (all() bug)."""
+    fs = Filesystem(str(tmp_path), "ws")
+    # Write an existing file first
+    fs.write("existing.py", b"content\n")
+    patch = FilePatch(path="existing.py", hunks=[])
+    # Empty hunk list → is_new_file must be False, update path is taken,
+    # splitlines on existing content with no hunks → file written back unchanged
+    apply_file_patch(fs, patch)
+    result = fs.read("existing.py").decode()
+    assert "content" in result
 
 
 # ---------------------------------------------------------------------------

--- a/tests/workspace/test_read_tool.py
+++ b/tests/workspace/test_read_tool.py
@@ -1,0 +1,476 @@
+"""Tests for akgentic.tool.workspace.tool module (Story 5.2)."""
+
+from __future__ import annotations
+
+import time
+import uuid
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from akgentic.tool.workspace.tool import (
+    WorkspaceGlob,
+    WorkspaceGrep,
+    WorkspaceList,
+    WorkspaceRead,
+    WorkspaceReadTool,
+    _grep_python,
+    _grep_rg,
+)
+from akgentic.tool.workspace.workspace import Filesystem
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_observer(
+    orchestrator_is_none: bool = False,
+    team_id: uuid.UUID | None = None,
+) -> MagicMock:
+    """Build a minimal mock ActorToolObserver."""
+    observer = MagicMock()
+    observer.orchestrator = None if orchestrator_is_none else MagicMock()
+    observer._team_id = team_id or uuid.uuid4()
+    return observer
+
+
+def make_tool(tmp_path: Path, team_id: uuid.UUID | None = None) -> WorkspaceReadTool:
+    """Build a WorkspaceReadTool wired to a Filesystem rooted at tmp_path."""
+    tid = team_id or uuid.uuid4()
+    fs = Filesystem(str(tmp_path), str(tid))
+    observer = make_observer(team_id=tid)
+    tool = WorkspaceReadTool()
+    with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
+        tool.observer(observer)
+    return tool
+
+
+# ---------------------------------------------------------------------------
+# Task 1: WorkspaceReadTool fields (AC 1)
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceReadToolFields:
+    def test_default_fields(self) -> None:
+        tool = WorkspaceReadTool()
+        assert tool.name == "WorkspaceRead"
+        assert tool.workspace_id is None
+        assert tool.workspace_read is True
+        assert tool.workspace_list is True
+        assert tool.workspace_glob is True
+        assert tool.workspace_grep is True
+
+    def test_workspace_id_set(self) -> None:
+        tool = WorkspaceReadTool(workspace_id="my-workspace")
+        assert tool.workspace_id == "my-workspace"
+
+    def test_capabilities_accept_param_models(self) -> None:
+        tool = WorkspaceReadTool(
+            workspace_read=WorkspaceRead(default_limit=500),
+            workspace_list=WorkspaceList(),
+            workspace_glob=WorkspaceGlob(max_results=50),
+            workspace_grep=WorkspaceGrep(max_results=50),
+        )
+        assert isinstance(tool.workspace_read, WorkspaceRead)
+        assert tool.workspace_read.default_limit == 500
+
+
+# ---------------------------------------------------------------------------
+# Task 1: observer() wiring (AC 2, 3)
+# ---------------------------------------------------------------------------
+
+
+class TestObserverWiring:
+    def test_observer_raises_when_orchestrator_is_none(self, tmp_path: Path) -> None:
+        observer = make_observer(orchestrator_is_none=True)
+        tool = WorkspaceReadTool()
+        with pytest.raises(ValueError, match="orchestrator"):
+            tool.observer(observer)
+
+    def test_observer_sets_workspace_from_team_id(self, tmp_path: Path) -> None:
+        team_id = uuid.uuid4()
+        observer = make_observer(team_id=team_id)
+        fs = Filesystem(str(tmp_path), str(team_id))
+        tool = WorkspaceReadTool()
+        with patch(
+            "akgentic.tool.workspace.tool.get_workspace", return_value=fs
+        ) as mock_gw:
+            result = tool.observer(observer)
+            mock_gw.assert_called_once_with(str(team_id))
+            assert tool.workspace is fs
+            assert result is tool
+
+    def test_observer_uses_explicit_workspace_id(self, tmp_path: Path) -> None:
+        observer = make_observer()
+        fs = Filesystem(str(tmp_path), "explicit-ws")
+        tool = WorkspaceReadTool(workspace_id="explicit-ws")
+        with patch(
+            "akgentic.tool.workspace.tool.get_workspace", return_value=fs
+        ) as mock_gw:
+            tool.observer(observer)
+            mock_gw.assert_called_once_with("explicit-ws")
+
+    def test_observer_returns_self(self, tmp_path: Path) -> None:
+        team_id = uuid.uuid4()
+        observer = make_observer(team_id=team_id)
+        fs = Filesystem(str(tmp_path), str(team_id))
+        tool = WorkspaceReadTool()
+        with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
+            result = tool.observer(observer)
+        assert result is tool
+
+
+# ---------------------------------------------------------------------------
+# Task 2: workspace_read pagination (AC 4, 5)
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceRead:
+    def _make_file(self, root: Path, name: str, n_lines: int) -> None:
+        content = "\n".join(f"line {i}" for i in range(1, n_lines + 1))
+        (root / name).write_text(content, encoding="utf-8")
+
+    def test_default_window_returns_first_2000_lines(self, tmp_path: Path) -> None:
+        team_id = uuid.uuid4()
+        fs = Filesystem(str(tmp_path), str(team_id))
+        root = fs._root
+        self._make_file(root, "big.txt", 3500)
+        tool = WorkspaceReadTool()
+        observer = make_observer(team_id=team_id)
+        with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
+            tool.observer(observer)
+        fn = tool.get_tools()[0]  # workspace_read
+        result = fn("big.txt")
+        lines = result.split("\n")
+        # first 2000 numbered lines + truncation notice
+        assert lines[0].startswith("1     ")
+        assert "2000" in lines[1999]
+        assert "truncated" in lines[-1]
+        assert "3500 lines total" in lines[-1]
+
+    def test_offset_and_limit(self, tmp_path: Path) -> None:
+        team_id = uuid.uuid4()
+        fs = Filesystem(str(tmp_path), str(team_id))
+        root = fs._root
+        self._make_file(root, "file.txt", 200)
+        tool = WorkspaceReadTool()
+        observer = make_observer(team_id=team_id)
+        with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
+            tool.observer(observer)
+        fn = tool.get_tools()[0]
+        result = fn("file.txt", offset=100, limit=50)
+        lines = [ln for ln in result.split("\n") if not ln.startswith("[")]
+        assert lines[0].startswith("100   ")
+        assert lines[-1].startswith("149   ")
+        assert len(lines) == 50
+
+    def test_no_truncation_when_file_fits(self, tmp_path: Path) -> None:
+        team_id = uuid.uuid4()
+        fs = Filesystem(str(tmp_path), str(team_id))
+        root = fs._root
+        self._make_file(root, "small.txt", 10)
+        tool = WorkspaceReadTool()
+        observer = make_observer(team_id=team_id)
+        with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
+            tool.observer(observer)
+        fn = tool.get_tools()[0]
+        result = fn("small.txt")
+        assert "truncated" not in result
+        assert result.split("\n")[0].startswith("1     ")
+
+    def test_line_numbers_are_correct(self, tmp_path: Path) -> None:
+        team_id = uuid.uuid4()
+        fs = Filesystem(str(tmp_path), str(team_id))
+        (fs._root / "abc.txt").write_text("alpha\nbeta\ngamma", encoding="utf-8")
+        tool = WorkspaceReadTool()
+        observer = make_observer(team_id=team_id)
+        with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
+            tool.observer(observer)
+        fn = tool.get_tools()[0]
+        result = fn("abc.txt")
+        assert "1     alpha" in result
+        assert "2     beta" in result
+        assert "3     gamma" in result
+
+
+# ---------------------------------------------------------------------------
+# Task 3: workspace_list (AC 6)
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceList:
+    def test_list_shows_dir_and_file_entries(self, tmp_path: Path) -> None:
+        tool = make_tool(tmp_path)
+        root = tool.workspace._root
+        (root / "src").mkdir()
+        (root / "README.md").write_bytes(b"hello")
+        fn = tool.get_tools()[1]  # workspace_list
+        result = fn()
+        assert "[dir]  src" in result
+        assert "[file] README.md  (5 bytes)" in result
+
+    def test_list_empty_directory(self, tmp_path: Path) -> None:
+        tool = make_tool(tmp_path)
+        fn = tool.get_tools()[1]
+        assert fn() == "Empty directory."
+
+    def test_list_subdirectory(self, tmp_path: Path) -> None:
+        tool = make_tool(tmp_path)
+        root = tool.workspace._root
+        sub = root / "pkg"
+        sub.mkdir()
+        (sub / "mod.py").write_bytes(b"pass")
+        fn = tool.get_tools()[1]
+        result = fn("pkg")
+        assert "[file] mod.py  (4 bytes)" in result
+
+    def test_list_format_bytes(self, tmp_path: Path) -> None:
+        tool = make_tool(tmp_path)
+        root = tool.workspace._root
+        (root / "data.bin").write_bytes(b"1234567890")
+        fn = tool.get_tools()[1]
+        result = fn()
+        assert "10 bytes" in result
+
+
+# ---------------------------------------------------------------------------
+# Task 4: workspace_glob (AC 7, 8)
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceGlob:
+    def test_glob_returns_matching_files(self, tmp_path: Path) -> None:
+        tool = make_tool(tmp_path)
+        root = tool.workspace._root
+        (root / "a.py").write_bytes(b"a")
+        (root / "b.py").write_bytes(b"b")
+        (root / "c.txt").write_bytes(b"c")
+        fn = tool.get_tools()[2]  # workspace_glob
+        result = fn("**/*.py")
+        assert "a.py" in result
+        assert "b.py" in result
+        assert "c.txt" not in result
+
+    def test_glob_sorted_by_mtime_newest_first(self, tmp_path: Path) -> None:
+        tool = make_tool(tmp_path)
+        root = tool.workspace._root
+        old_file = root / "old.py"
+        new_file = root / "new.py"
+        old_file.write_bytes(b"old")
+        time.sleep(0.01)
+        new_file.write_bytes(b"new")
+        fn = tool.get_tools()[2]
+        result = fn("**/*.py")
+        lines = result.split("\n")
+        assert lines[0] == "new.py"
+        assert lines[1] == "old.py"
+
+    def test_glob_cap_at_max_results_with_truncation(self, tmp_path: Path) -> None:
+        tool = WorkspaceReadTool(workspace_glob=WorkspaceGlob(max_results=3))
+        team_id = uuid.uuid4()
+        fs = Filesystem(str(tmp_path), str(team_id))
+        root = fs._root
+        for i in range(5):
+            (root / f"f{i}.py").write_bytes(b"x")
+        observer = make_observer(team_id=team_id)
+        with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
+            tool.observer(observer)
+        fn = tool.get_tools()[2]
+        result = fn("**/*.py")
+        lines = [ln for ln in result.split("\n") if not ln.startswith("[")]
+        assert len(lines) == 3
+        assert "truncated" in result
+        assert "5 total" in result
+
+    def test_glob_no_files_returns_no_files_found(self, tmp_path: Path) -> None:
+        tool = make_tool(tmp_path)
+        fn = tool.get_tools()[2]
+        assert fn("**/*.xyz") == "No files found."
+
+    def test_glob_path_escape_raises_permission_error(self, tmp_path: Path) -> None:
+        tool = make_tool(tmp_path)
+        fn = tool.get_tools()[2]
+        with pytest.raises(PermissionError, match="escapes workspace root"):
+            fn("**/*.py", path="../../etc")
+
+    def test_glob_no_truncation_when_under_cap(self, tmp_path: Path) -> None:
+        tool = make_tool(tmp_path)
+        root = tool.workspace._root
+        for i in range(3):
+            (root / f"f{i}.py").write_bytes(b"x")
+        fn = tool.get_tools()[2]
+        result = fn("**/*.py")
+        assert "truncated" not in result
+
+
+# ---------------------------------------------------------------------------
+# Task 5: _grep_python helper
+# ---------------------------------------------------------------------------
+
+
+class TestGrepPython:
+    def test_finds_matching_lines(self, tmp_path: Path) -> None:
+        (tmp_path / "a.py").write_text("import os\nimport sys\n", encoding="utf-8")
+        results = _grep_python(tmp_path, "import os", "", 100, 2000)
+        assert len(results) == 1
+        path, lineno, line = results[0]
+        assert lineno == 1
+        assert "import os" in line
+
+    def test_respects_include_glob(self, tmp_path: Path) -> None:
+        (tmp_path / "a.py").write_text("import os\n", encoding="utf-8")
+        (tmp_path / "b.txt").write_text("import os\n", encoding="utf-8")
+        results = _grep_python(tmp_path, "import os", "*.py", 100, 2000)
+        paths = [r[0].name for r in results]
+        assert "a.py" in paths
+        assert "b.txt" not in paths
+
+    def test_no_matches_returns_empty(self, tmp_path: Path) -> None:
+        (tmp_path / "x.py").write_text("nothing here\n", encoding="utf-8")
+        results = _grep_python(tmp_path, "xyzzy_does_not_exist", "", 100, 2000)
+        assert results == []
+
+    def test_max_results_cap(self, tmp_path: Path) -> None:
+        content = "\n".join(["match"] * 10)
+        (tmp_path / "a.py").write_text(content, encoding="utf-8")
+        results = _grep_python(tmp_path, "match", "", 3, 2000)
+        assert len(results) == 3
+
+    def test_line_truncation(self, tmp_path: Path) -> None:
+        (tmp_path / "a.py").write_text("x" * 100 + "\n", encoding="utf-8")
+        results = _grep_python(tmp_path, "xxx", "", 100, 10)
+        assert len(results[0][2]) <= 10
+
+
+# ---------------------------------------------------------------------------
+# Task 5: _grep_rg helper
+# ---------------------------------------------------------------------------
+
+
+class TestGrepRg:
+    def test_returns_none_when_rg_not_on_path(self, tmp_path: Path) -> None:
+        with patch("shutil.which", return_value=None):
+            result = _grep_rg(tmp_path, "pattern", "", 100)
+        assert result is None
+
+    def test_returns_none_on_subprocess_error(self, tmp_path: Path) -> None:
+        with patch("shutil.which", return_value="/usr/bin/rg"), patch(
+            "subprocess.run", side_effect=OSError("no rg")
+        ):
+            result = _grep_rg(tmp_path, "pattern", "", 100)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Task 5: workspace_grep integration (AC 9, 10, 11)
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceGrep:
+    def test_grep_python_fallback_finds_matches(self, tmp_path: Path) -> None:
+        tool = make_tool(tmp_path)
+        root = tool.workspace._root
+        (root / "main.py").write_text("import os\npass\n", encoding="utf-8")
+        fn = tool.get_tools()[3]  # workspace_grep
+        with patch("akgentic.tool.workspace.tool._grep_rg", return_value=None):
+            result = fn("import os")
+        assert "main.py" in result
+        assert "import os" in result
+
+    def test_grep_no_matches_returns_no_matches_found(self, tmp_path: Path) -> None:
+        tool = make_tool(tmp_path)
+        root = tool.workspace._root
+        (root / "x.py").write_text("nothing\n", encoding="utf-8")
+        fn = tool.get_tools()[3]
+        with patch("akgentic.tool.workspace.tool._grep_rg", return_value=None):
+            result = fn("xyzzy_not_found")
+        assert result == "No matches found."
+
+    def test_grep_with_include_filter(self, tmp_path: Path) -> None:
+        tool = make_tool(tmp_path)
+        root = tool.workspace._root
+        (root / "a.py").write_text("needle\n", encoding="utf-8")
+        (root / "b.txt").write_text("needle\n", encoding="utf-8")
+        fn = tool.get_tools()[3]
+        with patch("akgentic.tool.workspace.tool._grep_rg", return_value=None):
+            result = fn("needle", include="*.py")
+        assert "a.py" in result
+        assert "b.txt" not in result
+
+    def test_grep_path_escape_raises_permission_error(self, tmp_path: Path) -> None:
+        tool = make_tool(tmp_path)
+        fn = tool.get_tools()[3]
+        with pytest.raises(PermissionError, match="escapes workspace root"):
+            fn("pattern", path="../../etc")
+
+    def test_grep_uses_rg_when_available(self, tmp_path: Path) -> None:
+        """When rg returns results, _grep_python must NOT be called."""
+        tool = make_tool(tmp_path)
+        root = tool.workspace._root
+        fake_match = (root / "x.py", 1, "import os")
+        fn = tool.get_tools()[3]
+        with patch(
+            "akgentic.tool.workspace.tool._grep_rg", return_value=[fake_match]
+        ) as mock_rg, patch(
+            "akgentic.tool.workspace.tool._grep_python"
+        ) as mock_py:
+            result = fn("import os")
+        mock_rg.assert_called_once()
+        mock_py.assert_not_called()
+        assert "x.py" in result
+
+
+# ---------------------------------------------------------------------------
+# Capability toggling (AC 12)
+# ---------------------------------------------------------------------------
+
+
+class TestCapabilityToggling:
+    def test_all_enabled_returns_four_tools(self, tmp_path: Path) -> None:
+        tool = make_tool(tmp_path)
+        assert len(tool.get_tools()) == 4
+
+    def test_glob_and_grep_disabled_returns_two_tools(self, tmp_path: Path) -> None:
+        team_id = uuid.uuid4()
+        fs = Filesystem(str(tmp_path), str(team_id))
+        observer = make_observer(team_id=team_id)
+        tool = WorkspaceReadTool(workspace_glob=False, workspace_grep=False)
+        with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
+            tool.observer(observer)
+        tools = tool.get_tools()
+        assert len(tools) == 2
+        names = [t.__name__ for t in tools]
+        assert "workspace_read" in names
+        assert "workspace_list" in names
+
+    def test_all_disabled_returns_empty_list(self, tmp_path: Path) -> None:
+        team_id = uuid.uuid4()
+        fs = Filesystem(str(tmp_path), str(team_id))
+        observer = make_observer(team_id=team_id)
+        tool = WorkspaceReadTool(
+            workspace_read=False,
+            workspace_list=False,
+            workspace_glob=False,
+            workspace_grep=False,
+        )
+        with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
+            tool.observer(observer)
+        assert tool.get_tools() == []
+
+    def test_single_capability_enabled(self, tmp_path: Path) -> None:
+        team_id = uuid.uuid4()
+        fs = Filesystem(str(tmp_path), str(team_id))
+        observer = make_observer(team_id=team_id)
+        tool = WorkspaceReadTool(
+            workspace_read=False,
+            workspace_list=False,
+            workspace_glob=WorkspaceGlob(),
+            workspace_grep=False,
+        )
+        with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
+            tool.observer(observer)
+        tools = tool.get_tools()
+        assert len(tools) == 1
+        assert tools[0].__name__ == "workspace_glob"

--- a/tests/workspace/test_read_tool.py
+++ b/tests/workspace/test_read_tool.py
@@ -121,6 +121,23 @@ class TestObserverWiring:
             result = tool.observer(observer)
         assert result is tool
 
+    def test_observer_failed_call_does_not_set_internal_observer(self) -> None:
+        """When observer() raises, _observer must NOT be set (no partial init)."""
+        observer = make_observer(orchestrator_is_none=True)
+        tool = WorkspaceReadTool()
+        with pytest.raises(ValueError):
+            tool.observer(observer)
+        # _observer must remain unset — check via __pydantic_private__
+        assert tool.__pydantic_private__ is None or "_observer" not in (
+            tool.__pydantic_private__ or {}
+        )
+
+    def test_get_tools_raises_before_observer_called(self) -> None:
+        """Calling get_tools() before observer() raises RuntimeError from workspace property."""
+        tool = WorkspaceReadTool()
+        with pytest.raises(RuntimeError, match="observer\\(\\) was called"):
+            tool.get_tools()
+
 
 # ---------------------------------------------------------------------------
 # Task 2: workspace_read pagination (AC 4, 5)
@@ -343,6 +360,34 @@ class TestGrepPython:
         results = _grep_python(tmp_path, "xxx", "", 100, 10)
         assert len(results[0][2]) <= 10
 
+    def test_skips_directories_from_rglob(self, tmp_path: Path) -> None:
+        """rglob may yield directories; they must be skipped gracefully."""
+        sub = tmp_path / "subdir"
+        sub.mkdir()
+        (tmp_path / "a.py").write_text("match\n", encoding="utf-8")
+        results = _grep_python(tmp_path, "match", "", 100, 2000)
+        # Only the file should produce results, not the directory
+        assert all(r[0].is_file() for r in results)
+
+    def test_skips_unreadable_files(self, tmp_path: Path) -> None:
+        """OSError during read_text must be swallowed and the file skipped."""
+        good = tmp_path / "good.py"
+        bad = tmp_path / "bad.py"
+        good.write_text("match\n", encoding="utf-8")
+        bad.write_text("match\n", encoding="utf-8")
+        original_read_text = Path.read_text
+
+        def patched_read_text(self: Path, **kwargs: object) -> str:  # type: ignore[misc]
+            if self.name == "bad.py":
+                raise OSError("permission denied")
+            return original_read_text(self, **kwargs)  # type: ignore[arg-type]
+
+        with patch.object(Path, "read_text", patched_read_text):
+            results = _grep_python(tmp_path, "match", "", 100, 2000)
+        result_names = [r[0].name for r in results]
+        assert "good.py" in result_names
+        assert "bad.py" not in result_names
+
 
 # ---------------------------------------------------------------------------
 # Task 5: _grep_rg helper
@@ -361,6 +406,42 @@ class TestGrepRg:
         ):
             result = _grep_rg(tmp_path, "pattern", "", 100)
         assert result is None
+
+    def test_returns_none_on_timeout(self, tmp_path: Path) -> None:
+        import subprocess as _subprocess
+
+        with patch("shutil.which", return_value="/usr/bin/rg"), patch(
+            "subprocess.run",
+            side_effect=_subprocess.TimeoutExpired(cmd=["rg"], timeout=15),
+        ):
+            result = _grep_rg(tmp_path, "pattern", "", 100)
+        assert result is None
+
+    def test_returns_none_on_nonzero_returncode(self, tmp_path: Path) -> None:
+        mock_result = MagicMock()
+        mock_result.returncode = 2
+        mock_result.stdout = ""
+        with patch("shutil.which", return_value="/usr/bin/rg"), patch(
+            "subprocess.run", return_value=mock_result
+        ):
+            result = _grep_rg(tmp_path, "pattern", "", 100)
+        assert result is None
+
+    def test_parses_rg_output_into_tuples(self, tmp_path: Path) -> None:
+        fake_file = tmp_path / "x.py"
+        fake_file.write_bytes(b"")
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = f"{fake_file}:3:import os\n"
+        with patch("shutil.which", return_value="/usr/bin/rg"), patch(
+            "subprocess.run", return_value=mock_result
+        ):
+            result = _grep_rg(tmp_path, "import", "", 100)
+        assert result is not None
+        assert len(result) == 1
+        path, lineno, line = result[0]
+        assert lineno == 3
+        assert line == "import os"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/workspace/test_workspace.py
+++ b/tests/workspace/test_workspace.py
@@ -1,0 +1,313 @@
+"""Tests for akgentic.tool.workspace.workspace module (Story 5.1)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from akgentic.tool.workspace.workspace import (
+    FileEntry,
+    Filesystem,
+    Workspace,
+    get_workspace,
+)
+
+# ---------------------------------------------------------------------------
+# FileEntry model
+# ---------------------------------------------------------------------------
+
+
+class TestFileEntry:
+    def test_file_entry_fields(self) -> None:
+        entry = FileEntry(name="main.py", is_dir=False, size=42)
+        assert entry.name == "main.py"
+        assert entry.is_dir is False
+        assert entry.size == 42
+
+    def test_file_entry_directory(self) -> None:
+        entry = FileEntry(name="src", is_dir=True, size=0)
+        assert entry.is_dir is True
+        assert entry.size == 0
+
+
+# ---------------------------------------------------------------------------
+# Workspace Protocol — runtime_checkable
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceProtocol:
+    def test_filesystem_satisfies_workspace_protocol(self, tmp_path: Path) -> None:
+        fs = Filesystem(base_path=str(tmp_path), workspace_name="team-1")
+        assert isinstance(fs, Workspace)
+
+
+# ---------------------------------------------------------------------------
+# Filesystem construction
+# ---------------------------------------------------------------------------
+
+
+class TestFilesystemConstruction:
+    def test_root_is_base_path_slash_workspace_name(self, tmp_path: Path) -> None:
+        fs = Filesystem(base_path=str(tmp_path), workspace_name="team-1")
+        assert fs._root == tmp_path / "team-1"
+
+    def test_root_directory_is_created(self, tmp_path: Path) -> None:
+        root = tmp_path / "team-1"
+        assert not root.exists()
+        Filesystem(base_path=str(tmp_path), workspace_name="team-1")
+        assert root.is_dir()
+
+    def test_construction_is_idempotent(self, tmp_path: Path) -> None:
+        """Creating Filesystem twice does not raise (exist_ok=True)."""
+        Filesystem(base_path=str(tmp_path), workspace_name="team-1")
+        Filesystem(base_path=str(tmp_path), workspace_name="team-1")  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# _validate_path
+# ---------------------------------------------------------------------------
+
+
+class TestValidatePath:
+    def test_valid_relative_path_returns_resolved_path(self, tmp_path: Path) -> None:
+        fs = Filesystem(base_path=str(tmp_path), workspace_name="team-1")
+        result = fs._validate_path("foo/bar.txt")
+        assert result == (tmp_path / "team-1" / "foo" / "bar.txt").resolve()
+
+    def test_traversal_raises_permission_error(self, tmp_path: Path) -> None:
+        fs = Filesystem(base_path=str(tmp_path), workspace_name="team-1")
+        with pytest.raises(PermissionError, match="escapes workspace root"):
+            fs._validate_path("../../etc/passwd")
+
+    def test_traversal_via_double_dot_in_middle_raises(self, tmp_path: Path) -> None:
+        fs = Filesystem(base_path=str(tmp_path), workspace_name="team-1")
+        with pytest.raises(PermissionError):
+            fs._validate_path("src/../../../../../../etc/hosts")
+
+    def test_sibling_workspace_name_prefix_raises(self, tmp_path: Path) -> None:
+        """Sibling workspace 'team-11' must not pass validation for workspace 'team-1'.
+
+        A naive ``str.startswith`` check would incorrectly allow this because
+        ``str('/workspaces/team-11').startswith('/workspaces/team-1')`` is True.
+        """
+        sibling = tmp_path / "team-11"
+        sibling.mkdir()
+        (sibling / "secret.txt").write_bytes(b"secret")
+        fs = Filesystem(base_path=str(tmp_path), workspace_name="team-1")
+        # Construct a path that resolves to the sibling workspace
+        sibling_relative = "../team-11/secret.txt"
+        with pytest.raises(PermissionError, match="escapes workspace root"):
+            fs._validate_path(sibling_relative)
+
+    def test_absolute_path_injection_raises(self, tmp_path: Path) -> None:
+        """An absolute path supplied as the path argument must be rejected."""
+        fs = Filesystem(base_path=str(tmp_path), workspace_name="team-1")
+        with pytest.raises(PermissionError, match="escapes workspace root"):
+            fs._validate_path("/etc/passwd")
+
+
+# ---------------------------------------------------------------------------
+# Filesystem.read
+# ---------------------------------------------------------------------------
+
+
+class TestFilesystemRead:
+    def test_read_returns_bytes(self, tmp_path: Path) -> None:
+        fs = Filesystem(base_path=str(tmp_path), workspace_name="team-1")
+        root = tmp_path / "team-1"
+        (root / "hello.txt").write_bytes(b"hello world")
+        assert fs.read("hello.txt") == b"hello world"
+
+    def test_read_missing_file_raises_file_not_found(self, tmp_path: Path) -> None:
+        fs = Filesystem(base_path=str(tmp_path), workspace_name="team-1")
+        with pytest.raises(FileNotFoundError):
+            fs.read("nonexistent.txt")
+
+    def test_read_validates_path(self, tmp_path: Path) -> None:
+        fs = Filesystem(base_path=str(tmp_path), workspace_name="team-1")
+        with pytest.raises(PermissionError):
+            fs.read("../../etc/passwd")
+
+
+# ---------------------------------------------------------------------------
+# Filesystem.write
+# ---------------------------------------------------------------------------
+
+
+class TestFilesystemWrite:
+    def test_write_creates_file(self, tmp_path: Path) -> None:
+        fs = Filesystem(base_path=str(tmp_path), workspace_name="team-1")
+        fs.write("output.txt", b"data")
+        assert (tmp_path / "team-1" / "output.txt").read_bytes() == b"data"
+
+    def test_write_creates_missing_parent_dirs(self, tmp_path: Path) -> None:
+        fs = Filesystem(base_path=str(tmp_path), workspace_name="team-1")
+        fs.write("src/subdir/file.py", b"# code")
+        assert (tmp_path / "team-1" / "src" / "subdir" / "file.py").read_bytes() == b"# code"
+
+    def test_write_overwrites_existing_file(self, tmp_path: Path) -> None:
+        fs = Filesystem(base_path=str(tmp_path), workspace_name="team-1")
+        fs.write("a.txt", b"first")
+        fs.write("a.txt", b"second")
+        assert (tmp_path / "team-1" / "a.txt").read_bytes() == b"second"
+
+    def test_write_validates_path(self, tmp_path: Path) -> None:
+        fs = Filesystem(base_path=str(tmp_path), workspace_name="team-1")
+        with pytest.raises(PermissionError):
+            fs.write("../../evil.txt", b"x")
+
+
+# ---------------------------------------------------------------------------
+# Filesystem.delete
+# ---------------------------------------------------------------------------
+
+
+class TestFilesystemDelete:
+    def test_delete_removes_file(self, tmp_path: Path) -> None:
+        fs = Filesystem(base_path=str(tmp_path), workspace_name="team-1")
+        root = tmp_path / "team-1"
+        target = root / "to_delete.txt"
+        target.write_bytes(b"bye")
+        fs.delete("to_delete.txt")
+        assert not target.exists()
+
+    def test_delete_missing_file_raises_file_not_found(self, tmp_path: Path) -> None:
+        fs = Filesystem(base_path=str(tmp_path), workspace_name="team-1")
+        with pytest.raises(FileNotFoundError):
+            fs.delete("ghost.txt")
+
+    def test_delete_validates_path(self, tmp_path: Path) -> None:
+        fs = Filesystem(base_path=str(tmp_path), workspace_name="team-1")
+        with pytest.raises(PermissionError):
+            fs.delete("../../etc/passwd")
+
+
+# ---------------------------------------------------------------------------
+# Filesystem.list
+# ---------------------------------------------------------------------------
+
+
+class TestFilesystemList:
+    def test_list_root_returns_file_entries(self, tmp_path: Path) -> None:
+        fs = Filesystem(base_path=str(tmp_path), workspace_name="team-1")
+        root = tmp_path / "team-1"
+        (root / "file.txt").write_bytes(b"abc")
+        (root / "subdir").mkdir()
+        entries = fs.list("")
+        names = [e.name for e in entries]
+        assert "file.txt" in names
+        assert "subdir" in names
+
+    def test_list_dirs_come_before_files(self, tmp_path: Path) -> None:
+        fs = Filesystem(base_path=str(tmp_path), workspace_name="team-1")
+        root = tmp_path / "team-1"
+        (root / "z_file.txt").write_bytes(b"z")
+        (root / "a_dir").mkdir()
+        entries = fs.list("")
+        assert entries[0].is_dir is True
+        assert entries[0].name == "a_dir"
+
+    def test_list_file_size_matches_content(self, tmp_path: Path) -> None:
+        fs = Filesystem(base_path=str(tmp_path), workspace_name="team-1")
+        root = tmp_path / "team-1"
+        (root / "data.bin").write_bytes(b"12345")
+        entries = fs.list("")
+        file_entry = next(e for e in entries if e.name == "data.bin")
+        assert file_entry.size == 5
+
+    def test_list_directory_size_is_zero(self, tmp_path: Path) -> None:
+        fs = Filesystem(base_path=str(tmp_path), workspace_name="team-1")
+        root = tmp_path / "team-1"
+        sub = root / "mydir"
+        sub.mkdir()
+        (sub / "inner.txt").write_bytes(b"content")
+        entries = fs.list("")
+        dir_entry = next(e for e in entries if e.name == "mydir")
+        assert dir_entry.size == 0
+
+    def test_list_empty_directory(self, tmp_path: Path) -> None:
+        fs = Filesystem(base_path=str(tmp_path), workspace_name="team-1")
+        entries = fs.list("")
+        assert entries == []
+
+    def test_list_subdirectory(self, tmp_path: Path) -> None:
+        fs = Filesystem(base_path=str(tmp_path), workspace_name="team-1")
+        root = tmp_path / "team-1"
+        sub = root / "src"
+        sub.mkdir()
+        (sub / "main.py").write_bytes(b"pass")
+        entries = fs.list("src")
+        assert len(entries) == 1
+        assert entries[0].name == "main.py"
+
+    def test_list_is_non_recursive(self, tmp_path: Path) -> None:
+        fs = Filesystem(base_path=str(tmp_path), workspace_name="team-1")
+        root = tmp_path / "team-1"
+        nested = root / "a" / "b"
+        nested.mkdir(parents=True)
+        (nested / "deep.txt").write_bytes(b"deep")
+        entries = fs.list("")
+        # Should only see "a", not "b" or "deep.txt"
+        assert len(entries) == 1
+        assert entries[0].name == "a"
+
+    def test_list_validates_path(self, tmp_path: Path) -> None:
+        fs = Filesystem(base_path=str(tmp_path), workspace_name="team-1")
+        with pytest.raises(PermissionError):
+            fs.list("../../etc")
+
+    def test_list_alphabetical_within_dirs_and_files(self, tmp_path: Path) -> None:
+        fs = Filesystem(base_path=str(tmp_path), workspace_name="team-1")
+        root = tmp_path / "team-1"
+        (root / "z.txt").write_bytes(b"z")
+        (root / "a.txt").write_bytes(b"a")
+        (root / "m_dir").mkdir()
+        (root / "b_dir").mkdir()
+        entries = fs.list("")
+        dir_names = [e.name for e in entries if e.is_dir]
+        file_names = [e.name for e in entries if not e.is_dir]
+        assert dir_names == ["b_dir", "m_dir"]
+        assert file_names == ["a.txt", "z.txt"]
+
+
+# ---------------------------------------------------------------------------
+# get_workspace factory
+# ---------------------------------------------------------------------------
+
+
+class TestGetWorkspace:
+    def test_get_workspace_local_mode_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("WORKSPACE_MODE", raising=False)
+        with patch("akgentic.tool.workspace.workspace.Filesystem") as mock_fs_cls:
+            mock_instance = MagicMock()
+            mock_fs_cls.return_value = mock_instance
+            result = get_workspace("team-1")
+            mock_fs_cls.assert_called_once_with(base_path="./workspaces", workspace_name="team-1")
+            assert result is mock_instance
+
+    def test_get_workspace_local_mode_explicit(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("WORKSPACE_MODE", "local")
+        with patch("akgentic.tool.workspace.workspace.Filesystem") as mock_fs_cls:
+            mock_instance = MagicMock()
+            mock_fs_cls.return_value = mock_instance
+            result = get_workspace("team-2")
+            mock_fs_cls.assert_called_once_with(base_path="./workspaces", workspace_name="team-2")
+            assert result is mock_instance
+
+    def test_get_workspace_docker_mode(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("WORKSPACE_MODE", "docker")
+        with patch("akgentic.tool.workspace.workspace.Filesystem") as mock_fs_cls:
+            mock_instance = MagicMock()
+            mock_fs_cls.return_value = mock_instance
+            result = get_workspace("team-3")
+            mock_fs_cls.assert_called_once_with(base_path="/workspaces", workspace_name="team-3")
+            assert result is mock_instance
+
+    def test_get_workspace_unknown_mode_raises_key_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("WORKSPACE_MODE", "s3")
+        with pytest.raises(KeyError):
+            get_workspace("team-1")

--- a/tests/workspace/test_workspace_tool.py
+++ b/tests/workspace/test_workspace_tool.py
@@ -1,0 +1,246 @@
+"""Tests for WorkspaceTool — write and delete capabilities (Story 5.4)."""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from akgentic.tool.workspace.tool import WorkspaceTool
+from akgentic.tool.workspace.workspace import Filesystem
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_observer(
+    tmp_path: Path,
+    team_id: uuid.UUID | None = None,
+) -> tuple[MagicMock, Filesystem]:
+    """Create a mock observer and matching Filesystem for tests."""
+    tid = team_id or uuid.uuid4()
+    observer = MagicMock()
+    observer.orchestrator = MagicMock()
+    observer._team_id = tid
+    fs = Filesystem(str(tmp_path), str(tid))
+    return observer, fs
+
+
+def make_wired_tool(tmp_path: Path) -> tuple[WorkspaceTool, Filesystem]:
+    """Create a WorkspaceTool wired to a real tmp Filesystem."""
+    observer, fs = make_observer(tmp_path)
+    with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
+        tool = WorkspaceTool()
+        tool.observer(observer)
+    return tool, fs
+
+
+# ---------------------------------------------------------------------------
+# Task 2: observer() delegation (AC 1)
+# ---------------------------------------------------------------------------
+
+
+class TestObserverDelegation:
+    def test_observer_sets_workspace(self, tmp_path: Path) -> None:
+        """observer() via super() sets self.workspace correctly."""
+        tool, fs = make_wired_tool(tmp_path)
+        assert tool.workspace is fs
+
+    def test_observer_returns_self(self, tmp_path: Path) -> None:
+        """observer() returns self typed as WorkspaceTool."""
+        observer, fs = make_observer(tmp_path)
+        with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
+            tool = WorkspaceTool()
+            result = tool.observer(observer)
+        assert result is tool
+        assert isinstance(result, WorkspaceTool)
+
+    def test_observer_raises_when_orchestrator_none(self, tmp_path: Path) -> None:
+        """Inherited guard: observer with None orchestrator raises ValueError."""
+        observer = MagicMock()
+        observer.orchestrator = None
+        tool = WorkspaceTool()
+        with pytest.raises(ValueError, match="orchestrator"):
+            tool.observer(observer)
+
+
+# ---------------------------------------------------------------------------
+# Task 2 / Task 7: get_tools() count and names (AC 2)
+# ---------------------------------------------------------------------------
+
+
+class TestGetToolsDefault:
+    def test_default_count_is_six(self, tmp_path: Path) -> None:
+        """By default get_tools() returns 6 tools: 4 read + write + delete."""
+        tool, _ = make_wired_tool(tmp_path)
+        tools = tool.get_tools()
+        assert len(tools) == 6
+
+    def test_default_includes_all_read_tools(self, tmp_path: Path) -> None:
+        tool, _ = make_wired_tool(tmp_path)
+        names = [t.__name__ for t in tool.get_tools()]
+        assert "workspace_read" in names
+        assert "workspace_list" in names
+        assert "workspace_glob" in names
+        assert "workspace_grep" in names
+
+    def test_default_includes_write_and_delete(self, tmp_path: Path) -> None:
+        tool, _ = make_wired_tool(tmp_path)
+        names = [t.__name__ for t in tool.get_tools()]
+        assert "workspace_write" in names
+        assert "workspace_delete" in names
+
+
+# ---------------------------------------------------------------------------
+# Task 3: workspace_write — new file (AC 3)
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceWriteNewFile:
+    def test_write_new_file_creates_it(self, tmp_path: Path) -> None:
+        """workspace_write creates a new file with the given content."""
+        tool, fs = make_wired_tool(tmp_path)
+        write_fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_write")
+        result = write_fn("new_file.py", "print('hello')\n")
+        assert result == "Written: new_file.py"
+        assert (fs._root / "new_file.py").read_text(encoding="utf-8") == "print('hello')\n"
+
+    def test_write_new_file_creates_parent_dirs(self, tmp_path: Path) -> None:
+        """workspace_write creates missing parent directories."""
+        tool, fs = make_wired_tool(tmp_path)
+        write_fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_write")
+        result = write_fn("deep/nested/dir/file.py", "content\n")
+        assert result == "Written: deep/nested/dir/file.py"
+        assert (fs._root / "deep/nested/dir/file.py").exists()
+
+    def test_write_new_file_returns_written_path(self, tmp_path: Path) -> None:
+        tool, fs = make_wired_tool(tmp_path)
+        write_fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_write")
+        result = write_fn("src/module.py", "# empty\n")
+        assert result == "Written: src/module.py"
+
+
+# ---------------------------------------------------------------------------
+# Task 3: workspace_write — overwrite with line ending preservation (AC 4)
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceWriteLineEndingPreservation:
+    def test_write_preserves_crlf(self, tmp_path: Path) -> None:
+        """Overwriting a CRLF file with LF content normalises to CRLF."""
+        tool, fs = make_wired_tool(tmp_path)
+        fs.write("existing.py", b"line1\r\nline2\r\n")
+        write_fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_write")
+        result = write_fn("existing.py", "new_line1\nnew_line2\n")
+        assert result == "Written: existing.py"
+        written = fs.read("existing.py")
+        assert b"\r\n" in written
+        assert b"new_line1" in written
+
+    def test_write_preserves_lf(self, tmp_path: Path) -> None:
+        """Overwriting an LF file with LF content keeps LF."""
+        tool, fs = make_wired_tool(tmp_path)
+        fs.write("lf_file.py", b"line1\nline2\n")
+        write_fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_write")
+        result = write_fn("lf_file.py", "new_line1\nnew_line2\n")
+        assert result == "Written: lf_file.py"
+        written = fs.read("lf_file.py")
+        assert b"\r\n" not in written
+        assert b"new_line1" in written
+
+    def test_write_overwrite_no_crlf_difference(self, tmp_path: Path) -> None:
+        """Overwrite where content already matches line endings writes correctly."""
+        tool, fs = make_wired_tool(tmp_path)
+        fs.write("same.py", b"a\nb\n")
+        write_fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_write")
+        result = write_fn("same.py", "updated\n")
+        assert result == "Written: same.py"
+        assert b"updated" in fs.read("same.py")
+
+
+# ---------------------------------------------------------------------------
+# Task 4: workspace_delete — success and not-found (AC 5, 6)
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceDelete:
+    def test_delete_existing_file(self, tmp_path: Path) -> None:
+        """workspace_delete removes the file and returns confirmation."""
+        tool, fs = make_wired_tool(tmp_path)
+        fs.write("to_delete.py", b"# delete me\n")
+        delete_fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_delete")
+        result = delete_fn("to_delete.py")
+        assert result == "Deleted: to_delete.py"
+        assert not (fs._root / "to_delete.py").exists()
+
+    def test_delete_nonexistent_file_raises(self, tmp_path: Path) -> None:
+        """workspace_delete raises FileNotFoundError for missing files."""
+        tool, fs = make_wired_tool(tmp_path)
+        delete_fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_delete")
+        with pytest.raises(FileNotFoundError):
+            delete_fn("nonexistent.py")
+
+    def test_delete_returns_deleted_path(self, tmp_path: Path) -> None:
+        """Returned string includes the path that was deleted."""
+        tool, fs = make_wired_tool(tmp_path)
+        fs.write("src/old.py", b"pass\n")
+        delete_fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_delete")
+        result = delete_fn("src/old.py")
+        assert result == "Deleted: src/old.py"
+
+
+# ---------------------------------------------------------------------------
+# Capability toggling (AC 7)
+# ---------------------------------------------------------------------------
+
+
+class TestCapabilityToggling:
+    def test_workspace_delete_disabled_returns_five_tools(self, tmp_path: Path) -> None:
+        """WorkspaceTool(workspace_delete=False) exposes 5 tools."""
+        observer, fs = make_observer(tmp_path)
+        with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
+            tool = WorkspaceTool(workspace_delete=False)
+            tool.observer(observer)
+        tools = tool.get_tools()
+        names = [t.__name__ for t in tools]
+        assert "workspace_delete" not in names
+        assert "workspace_write" in names
+        assert len(tools) == 5
+
+    def test_workspace_write_disabled_returns_five_tools(self, tmp_path: Path) -> None:
+        """WorkspaceTool(workspace_write=False) exposes 5 tools."""
+        observer, fs = make_observer(tmp_path)
+        with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
+            tool = WorkspaceTool(workspace_write=False)
+            tool.observer(observer)
+        tools = tool.get_tools()
+        names = [t.__name__ for t in tools]
+        assert "workspace_write" not in names
+        assert "workspace_delete" in names
+        assert len(tools) == 5
+
+    def test_both_write_and_delete_disabled_returns_four_read_tools(
+        self, tmp_path: Path
+    ) -> None:
+        """WorkspaceTool(workspace_write=False, workspace_delete=False) returns 4 read tools."""
+        observer, fs = make_observer(tmp_path)
+        with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
+            tool = WorkspaceTool(workspace_write=False, workspace_delete=False)
+            tool.observer(observer)
+        tools = tool.get_tools()
+        names = [t.__name__ for t in tools]
+        assert "workspace_write" not in names
+        assert "workspace_delete" not in names
+        assert "workspace_read" in names
+        assert len(tools) == 4
+
+    def test_workspace_delete_false_count(self, tmp_path: Path) -> None:
+        """Repeated get_tools() call count is stable."""
+        observer, fs = make_observer(tmp_path)
+        with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
+            tool = WorkspaceTool(workspace_delete=False)
+            tool.observer(observer)
+        assert len(tool.get_tools()) == 5

--- a/tests/workspace/test_workspace_tool.py
+++ b/tests/workspace/test_workspace_tool.py
@@ -160,6 +160,16 @@ class TestWorkspaceWriteLineEndingPreservation:
         assert result == "Written: same.py"
         assert b"updated" in fs.read("same.py")
 
+    def test_write_non_utf8_existing_file_does_not_raise(self, tmp_path: Path) -> None:
+        """Overwriting a non-UTF-8 binary file writes content as-is without raising."""
+        tool, fs = make_wired_tool(tmp_path)
+        # Write a file with non-UTF-8 bytes (Windows-1252 / Latin-1 encoded)
+        fs.write("binary.dat", b"\xff\xfe binary garbage \x80\x81")
+        write_fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_write")
+        result = write_fn("binary.dat", "replacement\n")
+        assert result == "Written: binary.dat"
+        assert b"replacement" in fs.read("binary.dat")
+
 
 # ---------------------------------------------------------------------------
 # Task 4: workspace_delete — success and not-found (AC 5, 6)
@@ -244,3 +254,24 @@ class TestCapabilityToggling:
             tool = WorkspaceTool(workspace_delete=False)
             tool.observer(observer)
         assert len(tool.get_tools()) == 5
+
+
+# ---------------------------------------------------------------------------
+# Security: path traversal raises PermissionError
+# ---------------------------------------------------------------------------
+
+
+class TestPathSecurity:
+    def test_write_path_traversal_raises(self, tmp_path: Path) -> None:
+        """workspace_write raises PermissionError for paths escaping workspace root."""
+        tool, fs = make_wired_tool(tmp_path)
+        write_fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_write")
+        with pytest.raises(PermissionError):
+            write_fn("../escape.py", "malicious content\n")
+
+    def test_delete_path_traversal_raises(self, tmp_path: Path) -> None:
+        """workspace_delete raises PermissionError for paths escaping workspace root."""
+        tool, fs = make_wired_tool(tmp_path)
+        delete_fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_delete")
+        with pytest.raises(PermissionError):
+            delete_fn("../escape.py")


### PR DESCRIPTION
## Summary

- Adds `WorkspaceTool(WorkspaceReadTool)` with `workspace_write` and `workspace_delete` tools
- `workspace_write` detects and preserves existing CRLF/LF line endings before overwriting; creates missing parent directories via `Filesystem.write()`
- `workspace_delete` delegates fully to `Filesystem.delete()` which raises `FileNotFoundError` for missing files and `PermissionError` for path traversal
- Capability toggling via `WorkspaceTool(workspace_delete=False)` / `WorkspaceTool(workspace_write=False)` inherits `_resolve()` pattern from `WorkspaceReadTool`
- 22 tests covering all ACs, path-security traversal, non-UTF-8 file handling, and capability toggling — 97% branch coverage

## Review fixes applied

- `_write_factory`: catch `UnicodeDecodeError` alongside `FileNotFoundError` so overwriting non-UTF-8 files writes content as-is rather than propagating an unhandled exception
- Module docstring updated to reflect `WorkspaceTool`, `WorkspaceWrite`, and `WorkspaceDelete`
- `TestPathSecurity` class added: path-traversal `PermissionError` tests for both `workspace_write` and `workspace_delete`
- `test_write_non_utf8_existing_file_does_not_raise` covers the new `UnicodeDecodeError` branch

Closes #49