### PR TITLE
feat: workspace_mkdir + workspace_list depth/tree view (Story 5.6)

### DIFF
--- a/src/akgentic/tool/workspace/__init__.py
+++ b/src/akgentic/tool/workspace/__init__.py
@@ -17,6 +17,7 @@ from akgentic.tool.workspace.tool import (
     WorkspaceGlob,
     WorkspaceGrep,
     WorkspaceList,
+    WorkspaceMkdir,
     WorkspaceMultiEdit,
     WorkspacePatch,
     WorkspaceRead,
@@ -55,5 +56,6 @@ __all__ = [
     "WorkspaceEdit",
     "WorkspaceMultiEdit",
     "WorkspacePatch",
+    "WorkspaceMkdir",
     "WorkspaceTool",
 ]

--- a/src/akgentic/tool/workspace/tool.py
+++ b/src/akgentic/tool/workspace/tool.py
@@ -153,7 +153,6 @@ def _grep_rg(
 
 def _build_tree(
     root: Path,
-    ws_root: Path,
     prefix: str = "",
     current_depth: int = 0,
     max_depth: int = 0,
@@ -162,7 +161,6 @@ def _build_tree(
 
     Args:
         root: Filesystem path of the directory to render.
-        ws_root: Workspace root (unused in recursion but available for relative paths).
         prefix: Current indentation prefix string for rendering.
         current_depth: Current recursion depth (0 = top level).
         max_depth: Max depth to recurse (0 = unlimited, N = stop at N).
@@ -189,7 +187,7 @@ def _build_tree(
             if max_depth == 0 or current_depth + 1 < max_depth:
                 extension = "    " if is_last else "│   "
                 lines.extend(
-                    _build_tree(entry, ws_root, prefix + extension, current_depth + 1, max_depth)
+                    _build_tree(entry, prefix + extension, current_depth + 1, max_depth)
                 )
         else:
             size = entry.stat().st_size
@@ -360,7 +358,7 @@ class WorkspaceReadTool(ToolCard):
                 return "\n".join(lines)
             else:
                 # ASCII tree — depth=0 means unlimited, depth>1 means N levels
-                tree_lines = _build_tree(resolved, backend._root, max_depth=depth)
+                tree_lines = _build_tree(resolved, max_depth=depth)
                 return ".\n" + "\n".join(tree_lines) if tree_lines else "Empty directory."
 
         workspace_list.__doc__ = params.format_docstring(workspace_list.__doc__)
@@ -541,7 +539,7 @@ class WorkspaceTool(WorkspaceReadTool):
         return self
 
     def get_tools(self) -> list[Callable[..., Any]]:
-        """Return read tools from super() plus write, delete, edit, multi_edit, and patch tools.
+        """Return read tools plus write, delete, edit, multi_edit, patch, and mkdir tools.
 
         Returns:
             List of callables for all enabled capabilities.

--- a/src/akgentic/tool/workspace/tool.py
+++ b/src/akgentic/tool/workspace/tool.py
@@ -43,6 +43,7 @@ class WorkspaceList(BaseToolParam):
     """List immediate children of a directory in the team workspace."""
 
     expose: set[Channels] = {TOOL_CALL}
+    max_depth: int = 1  # 1 = flat list (default), 0 = unlimited, N = N levels deep
 
 
 class WorkspaceGlob(BaseToolParam):
@@ -148,6 +149,53 @@ def _grep_rg(
             except ValueError:
                 continue
     return matches
+
+
+def _build_tree(
+    root: Path,
+    ws_root: Path,
+    prefix: str = "",
+    current_depth: int = 0,
+    max_depth: int = 0,
+) -> list[str]:
+    """Render directory entries as an ASCII tree recursively.
+
+    Args:
+        root: Filesystem path of the directory to render.
+        ws_root: Workspace root (unused in recursion but available for relative paths).
+        prefix: Current indentation prefix string for rendering.
+        current_depth: Current recursion depth (0 = top level).
+        max_depth: Max depth to recurse (0 = unlimited, N = stop at N).
+
+    Returns:
+        List of rendered lines (one per entry, no trailing newline).
+    """
+    try:
+        children = list(root.iterdir())
+    except PermissionError:
+        return []
+
+    dirs = sorted([c for c in children if c.is_dir()], key=lambda c: c.name)
+    files = sorted([c for c in children if c.is_file()], key=lambda c: c.name)
+    entries = dirs + files
+
+    lines: list[str] = []
+    for i, entry in enumerate(entries):
+        is_last = i == len(entries) - 1
+        connector = "└── " if is_last else "├── "
+        if entry.is_dir():
+            lines.append(f"{prefix}{connector}{entry.name}/")
+            # Recurse if max_depth is unlimited (0) or we haven't reached the limit
+            if max_depth == 0 or current_depth + 1 < max_depth:
+                extension = "    " if is_last else "│   "
+                lines.extend(
+                    _build_tree(entry, ws_root, prefix + extension, current_depth + 1, max_depth)
+                )
+        else:
+            size = entry.stat().st_size
+            lines.append(f"{prefix}{connector}{entry.name} ({size} bytes)")
+
+    return lines
 
 
 class WorkspaceReadTool(ToolCard):
@@ -273,34 +321,47 @@ class WorkspaceReadTool(ToolCard):
             params: List capability configuration.
 
         Returns:
-            Callable that lists workspace directory contents.
+            Callable that lists workspace directory contents (flat or tree).
         """
         backend = self.workspace
 
-        def workspace_list(path: str = "") -> str:
+        def workspace_list(path: str = "", depth: int = params.max_depth) -> str:
             """List the contents of a directory in the team workspace.
 
             Args:
                 path: Relative directory path. Defaults to workspace root.
+                depth: Tree depth. 1 = flat list (default), 0 = unlimited tree,
+                    N > 1 = tree N levels deep.
 
             Returns:
-                Newline-separated entries with ``[dir]`` / ``[file]`` prefixes
-                and byte sizes for files.  Returns "Empty directory." if the
-                directory contains no entries.
+                Flat list or ASCII tree of entries. Directories shown as ``name/``,
+                files as ``name (N bytes)``. Returns "Empty directory." if no entries.
 
             Raises:
                 PermissionError: If path escapes the workspace root.
             """
+            if path:
+                resolved = backend._validate_path(path)
+            else:
+                resolved = backend._root
+
             entries = backend.list(path)
             if not entries:
                 return "Empty directory."
-            entry_lines: list[str] = []
-            for entry in entries:
-                if entry.is_dir:
-                    entry_lines.append(f"[dir]  {entry.name}")
-                else:
-                    entry_lines.append(f"[file] {entry.name}  ({entry.size} bytes)")
-            return "\n".join(entry_lines)
+
+            if depth == 1:
+                # Flat list — no tree connectors
+                lines: list[str] = []
+                for entry in entries:
+                    if entry.is_dir:
+                        lines.append(f"{entry.name}/")
+                    else:
+                        lines.append(f"{entry.name} ({entry.size} bytes)")
+                return "\n".join(lines)
+            else:
+                # ASCII tree — depth=0 means unlimited, depth>1 means N levels
+                tree_lines = _build_tree(resolved, backend._root, max_depth=depth)
+                return ".\n" + "\n".join(tree_lines) if tree_lines else "Empty directory."
 
         workspace_list.__doc__ = params.format_docstring(workspace_list.__doc__)
         return workspace_list
@@ -442,6 +503,12 @@ class WorkspacePatch(BaseToolParam):
     expose: set[Channels] = {TOOL_CALL}
 
 
+class WorkspaceMkdir(BaseToolParam):
+    """Create a directory (and parents) in the team workspace."""
+
+    expose: set[Channels] = {TOOL_CALL}
+
+
 class WorkspaceTool(WorkspaceReadTool):
     """Full workspace access: read + write + delete + edit + multi_edit + patch."""
 
@@ -457,6 +524,7 @@ class WorkspaceTool(WorkspaceReadTool):
     workspace_edit: WorkspaceEdit | bool = True
     workspace_multi_edit: WorkspaceMultiEdit | bool = True
     workspace_patch: WorkspacePatch | bool = True
+    workspace_mkdir: WorkspaceMkdir | bool = True
 
     def observer(  # type: ignore[override]
         self, observer: ActorToolObserver
@@ -494,6 +562,9 @@ class WorkspaceTool(WorkspaceReadTool):
         pp = _resolve(self.workspace_patch, WorkspacePatch)
         if pp is not None and TOOL_CALL in pp.expose:
             tools.append(self._patch_factory(pp))
+        pm = _resolve(self.workspace_mkdir, WorkspaceMkdir)
+        if pm is not None and TOOL_CALL in pm.expose:
+            tools.append(self._mkdir_factory(pm))
         return tools
 
     def _write_factory(self, params: WorkspaceWrite) -> Callable[..., Any]:
@@ -776,3 +847,32 @@ class WorkspaceTool(WorkspaceReadTool):
 
         workspace_patch.__doc__ = params.format_docstring(workspace_patch.__doc__)
         return workspace_patch
+
+    def _mkdir_factory(self, params: WorkspaceMkdir) -> Callable[..., Any]:
+        """Create the ``workspace_mkdir`` tool callable.
+
+        Args:
+            params: Mkdir capability configuration.
+
+        Returns:
+            Callable that creates a directory in the workspace.
+        """
+        backend = self.workspace
+
+        def workspace_mkdir(path: str) -> str:
+            """Create a directory and all missing parents in the team workspace.
+
+            Args:
+                path: Relative directory path from workspace root (e.g. "src/utils").
+
+            Returns:
+                Confirmation string "Created: <path>".
+
+            Raises:
+                PermissionError: If the path escapes the workspace root.
+            """
+            backend.mkdir(path)
+            return f"Created: {path}"
+
+        workspace_mkdir.__doc__ = params.format_docstring(workspace_mkdir.__doc__)
+        return workspace_mkdir

--- a/src/akgentic/tool/workspace/workspace.py
+++ b/src/akgentic/tool/workspace/workspace.py
@@ -36,6 +36,8 @@ class Workspace(Protocol):
 
     def list(self, path: str = "") -> list[FileEntry]: ...
 
+    def mkdir(self, path: str) -> None: ...
+
 
 class Filesystem:
     """Local filesystem backend for a single team workspace.
@@ -118,6 +120,17 @@ class Filesystem:
         files.sort(key=lambda e: e.name)
         entries = dirs + files
         return entries
+
+    def mkdir(self, path: str) -> None:
+        """Create directory *path* and all missing parents within the workspace.
+
+        Idempotent — calling on an existing directory is a no-op.
+
+        Raises:
+            PermissionError: if *path* escapes the workspace root.
+        """
+        resolved = self._validate_path(path)
+        resolved.mkdir(parents=True, exist_ok=True)
 
 
 def get_workspace(workspace_name: str) -> Filesystem:

--- a/tests/workspace/test_read_tool.py
+++ b/tests/workspace/test_read_tool.py
@@ -225,8 +225,8 @@ class TestWorkspaceList:
         (root / "README.md").write_bytes(b"hello")
         fn = tool.get_tools()[1]  # workspace_list
         result = fn()
-        assert "[dir]  src" in result
-        assert "[file] README.md  (5 bytes)" in result
+        assert "src/" in result
+        assert "README.md (5 bytes)" in result
 
     def test_list_empty_directory(self, tmp_path: Path) -> None:
         tool = make_tool(tmp_path)
@@ -241,7 +241,7 @@ class TestWorkspaceList:
         (sub / "mod.py").write_bytes(b"pass")
         fn = tool.get_tools()[1]
         result = fn("pkg")
-        assert "[file] mod.py  (4 bytes)" in result
+        assert "mod.py (4 bytes)" in result
 
     def test_list_format_bytes(self, tmp_path: Path) -> None:
         tool = make_tool(tmp_path)
@@ -555,3 +555,70 @@ class TestCapabilityToggling:
         tools = tool.get_tools()
         assert len(tools) == 1
         assert tools[0].__name__ == "workspace_glob"
+
+
+# ---------------------------------------------------------------------------
+# Story 5.6: workspace_list depth variants
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceListDepth:
+    def test_depth_1_returns_flat_list_format(self, tmp_path: Path) -> None:
+        tool = make_tool(tmp_path)
+        root = tool.workspace._root
+        (root / "src").mkdir()
+        (root / "README.md").write_bytes(b"hello")
+        fn = tool.get_tools()[1]  # workspace_list
+        result = fn()  # default depth=1
+        # Flat format: no tree connectors
+        assert "src/" in result
+        assert "README.md (5 bytes)" in result
+        assert "├──" not in result
+        assert "└──" not in result
+
+    def test_depth_2_returns_ascii_tree(self, tmp_path: Path) -> None:
+        tool = make_tool(tmp_path)
+        root = tool.workspace._root
+        src = root / "src"
+        src.mkdir()
+        (src / "main.py").write_bytes(b"pass")
+        fn = tool.get_tools()[1]
+        result = fn(depth=2)
+        assert result.startswith(".")
+        assert "src/" in result
+        assert "main.py" in result
+        # Tree connectors present
+        assert "├──" in result or "└──" in result
+
+    def test_depth_0_returns_unlimited_tree(self, tmp_path: Path) -> None:
+        tool = make_tool(tmp_path)
+        root = tool.workspace._root
+        deep = root / "a" / "b" / "c"
+        deep.mkdir(parents=True)
+        (deep / "file.txt").write_bytes(b"x")
+        fn = tool.get_tools()[1]
+        result = fn(depth=0)
+        assert result.startswith(".")
+        assert "file.txt" in result
+        assert "a/" in result
+        assert "b/" in result
+        assert "c/" in result
+
+    def test_depth_tree_ordering_dirs_before_files(self, tmp_path: Path) -> None:
+        tool = make_tool(tmp_path)
+        root = tool.workspace._root
+        (root / "zfile.txt").write_bytes(b"z")
+        (root / "adir").mkdir()
+        fn = tool.get_tools()[1]
+        result = fn(depth=2)
+        lines = result.split("\n")
+        # First non-root entry should be the directory
+        entry_lines = [line for line in lines if "├──" in line or "└──" in line]
+        assert "adir/" in entry_lines[0]
+        assert "zfile.txt" in entry_lines[1]
+
+    def test_empty_directory_any_depth_returns_empty(self, tmp_path: Path) -> None:
+        tool = make_tool(tmp_path)
+        fn = tool.get_tools()[1]
+        assert fn(depth=2) == "Empty directory."
+        assert fn(depth=0) == "Empty directory."

--- a/tests/workspace/test_workspace_tool.py
+++ b/tests/workspace/test_workspace_tool.py
@@ -74,10 +74,10 @@ class TestObserverDelegation:
 
 class TestGetToolsDefault:
     def test_default_count_is_nine(self, tmp_path: Path) -> None:
-        """By default get_tools() returns 9: 4 read + write + delete + edit + multi_edit + patch."""
+        """By default get_tools() returns 10: 4 read + write + delete + edit + multi_edit + patch + mkdir."""
         tool, _ = make_wired_tool(tmp_path)
         tools = tool.get_tools()
-        assert len(tools) == 9
+        assert len(tools) == 10
 
     def test_default_includes_all_read_tools(self, tmp_path: Path) -> None:
         tool, _ = make_wired_tool(tmp_path)
@@ -209,7 +209,7 @@ class TestWorkspaceDelete:
 
 class TestCapabilityToggling:
     def test_workspace_delete_disabled_returns_eight_tools(self, tmp_path: Path) -> None:
-        """WorkspaceTool(workspace_delete=False) exposes 8 tools."""
+        """WorkspaceTool(workspace_delete=False) exposes 9 tools."""
         observer, fs = make_observer(tmp_path)
         with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
             tool = WorkspaceTool(workspace_delete=False)
@@ -218,10 +218,10 @@ class TestCapabilityToggling:
         names = [t.__name__ for t in tools]
         assert "workspace_delete" not in names
         assert "workspace_write" in names
-        assert len(tools) == 8
+        assert len(tools) == 9
 
     def test_workspace_write_disabled_returns_eight_tools(self, tmp_path: Path) -> None:
-        """WorkspaceTool(workspace_write=False) exposes 8 tools."""
+        """WorkspaceTool(workspace_write=False) exposes 9 tools."""
         observer, fs = make_observer(tmp_path)
         with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
             tool = WorkspaceTool(workspace_write=False)
@@ -230,12 +230,12 @@ class TestCapabilityToggling:
         names = [t.__name__ for t in tools]
         assert "workspace_write" not in names
         assert "workspace_delete" in names
-        assert len(tools) == 8
+        assert len(tools) == 9
 
     def test_both_write_and_delete_disabled_returns_seven_tools(
         self, tmp_path: Path
     ) -> None:
-        """WorkspaceTool(workspace_write=False, workspace_delete=False) returns 7 tools."""
+        """WorkspaceTool(workspace_write=False, workspace_delete=False) returns 8 tools."""
         observer, fs = make_observer(tmp_path)
         with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
             tool = WorkspaceTool(workspace_write=False, workspace_delete=False)
@@ -245,7 +245,7 @@ class TestCapabilityToggling:
         assert "workspace_write" not in names
         assert "workspace_delete" not in names
         assert "workspace_read" in names
-        assert len(tools) == 7
+        assert len(tools) == 8
 
     def test_workspace_delete_false_count(self, tmp_path: Path) -> None:
         """Repeated get_tools() call count is stable."""
@@ -253,7 +253,7 @@ class TestCapabilityToggling:
         with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
             tool = WorkspaceTool(workspace_delete=False)
             tool.observer(observer)
-        assert len(tool.get_tools()) == 8
+        assert len(tool.get_tools()) == 9
 
 
 # ---------------------------------------------------------------------------
@@ -349,7 +349,7 @@ class TestWorkspaceEdit:
             tool.observer(observer)
         names = [t.__name__ for t in tool.get_tools()]
         assert "workspace_edit" not in names
-        assert len(tool.get_tools()) == 8
+        assert len(tool.get_tools()) == 9
 
 
 # ---------------------------------------------------------------------------
@@ -438,7 +438,7 @@ class TestWorkspaceMultiEdit:
             tool.observer(observer)
         names = [t.__name__ for t in tool.get_tools()]
         assert "workspace_multi_edit" not in names
-        assert len(tool.get_tools()) == 8
+        assert len(tool.get_tools()) == 9
 
 
 # ---------------------------------------------------------------------------
@@ -526,7 +526,7 @@ class TestWorkspacePatch:
             tool.observer(observer)
         names = [t.__name__ for t in tool.get_tools()]
         assert "workspace_patch" not in names
-        assert len(tool.get_tools()) == 8
+        assert len(tool.get_tools()) == 9
 
 
 # ---------------------------------------------------------------------------
@@ -536,33 +536,33 @@ class TestWorkspacePatch:
 
 class TestCapabilityTogglingStory55:
     def test_default_count_is_nine(self, tmp_path: Path) -> None:
-        """By default get_tools() returns 9: 4 read + write + delete + edit + multi_edit + patch."""
+        """By default get_tools() returns 10: 4 read + write + delete + edit + multi_edit + patch + mkdir."""
         tool, _ = make_wired_tool(tmp_path)
-        assert len(tool.get_tools()) == 9
+        assert len(tool.get_tools()) == 10
 
     def test_edit_disabled_count_is_eight(self, tmp_path: Path) -> None:
-        """WorkspaceTool(workspace_edit=False) returns 8 tools."""
+        """WorkspaceTool(workspace_edit=False) returns 9 tools."""
         observer, fs = make_observer(tmp_path)
         with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
             tool = WorkspaceTool(workspace_edit=False)
             tool.observer(observer)
-        assert len(tool.get_tools()) == 8
+        assert len(tool.get_tools()) == 9
 
     def test_multi_edit_disabled_count_is_eight(self, tmp_path: Path) -> None:
-        """WorkspaceTool(workspace_multi_edit=False) returns 8 tools."""
+        """WorkspaceTool(workspace_multi_edit=False) returns 9 tools."""
         observer, fs = make_observer(tmp_path)
         with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
             tool = WorkspaceTool(workspace_multi_edit=False)
             tool.observer(observer)
-        assert len(tool.get_tools()) == 8
+        assert len(tool.get_tools()) == 9
 
     def test_patch_disabled_count_is_eight(self, tmp_path: Path) -> None:
-        """WorkspaceTool(workspace_patch=False) returns 8 tools."""
+        """WorkspaceTool(workspace_patch=False) returns 9 tools."""
         observer, fs = make_observer(tmp_path)
         with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
             tool = WorkspaceTool(workspace_patch=False)
             tool.observer(observer)
-        assert len(tool.get_tools()) == 8
+        assert len(tool.get_tools()) == 9
 
     def test_all_new_tools_present_by_default(self, tmp_path: Path) -> None:
         """workspace_edit, workspace_multi_edit, workspace_patch all in default get_tools()."""
@@ -571,3 +571,60 @@ class TestCapabilityTogglingStory55:
         assert "workspace_edit" in names
         assert "workspace_multi_edit" in names
         assert "workspace_patch" in names
+
+
+# ---------------------------------------------------------------------------
+# Story 5.6: Filesystem.mkdir()
+# ---------------------------------------------------------------------------
+
+
+class TestFilesystemMkdir:
+    def test_mkdir_creates_nested_dirs(self, tmp_path: Path) -> None:
+        tool, fs = make_wired_tool(tmp_path)
+        fs.mkdir("src/utils/helpers")
+        assert (fs._root / "src" / "utils" / "helpers").is_dir()
+
+    def test_mkdir_is_idempotent(self, tmp_path: Path) -> None:
+        tool, fs = make_wired_tool(tmp_path)
+        (fs._root / "existing").mkdir()
+        fs.mkdir("existing")  # must not raise
+        assert (fs._root / "existing").is_dir()
+
+    def test_mkdir_traversal_raises(self, tmp_path: Path) -> None:
+        tool, fs = make_wired_tool(tmp_path)
+        with pytest.raises(PermissionError):
+            fs.mkdir("../../escape")
+
+
+# ---------------------------------------------------------------------------
+# Story 5.6: workspace_mkdir tool
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceMkdir:
+    def test_mkdir_creates_dir_and_returns_confirmation(self, tmp_path: Path) -> None:
+        tool, fs = make_wired_tool(tmp_path)
+        mkdir_fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_mkdir")
+        result = mkdir_fn("src/utils")
+        assert result == "Created: src/utils"
+        assert (fs._root / "src" / "utils").is_dir()
+
+    def test_mkdir_traversal_raises(self, tmp_path: Path) -> None:
+        tool, fs = make_wired_tool(tmp_path)
+        mkdir_fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_mkdir")
+        with pytest.raises(PermissionError):
+            mkdir_fn("../../escape")
+
+    def test_mkdir_disabled_not_in_get_tools(self, tmp_path: Path) -> None:
+        observer, fs = make_observer(tmp_path)
+        with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
+            tool = WorkspaceTool(workspace_mkdir=False)
+            tool.observer(observer)
+        names = [t.__name__ for t in tool.get_tools()]
+        assert "workspace_mkdir" not in names
+        assert len(tool.get_tools()) == 9
+
+    def test_default_count_is_ten(self, tmp_path: Path) -> None:
+        """By default get_tools() returns 10: 4 read + write + delete + edit + multi_edit + patch + mkdir."""
+        tool, _ = make_wired_tool(tmp_path)
+        assert len(tool.get_tools()) == 10

--- a/tests/workspace/test_workspace_tool.py
+++ b/tests/workspace/test_workspace_tool.py
@@ -73,7 +73,7 @@ class TestObserverDelegation:
 
 
 class TestGetToolsDefault:
-    def test_default_count_is_nine(self, tmp_path: Path) -> None:
+    def test_default_count_is_ten(self, tmp_path: Path) -> None:
         """By default get_tools() returns 10: 4 read + write + delete + edit + multi_edit + patch + mkdir."""
         tool, _ = make_wired_tool(tmp_path)
         tools = tool.get_tools()
@@ -208,7 +208,7 @@ class TestWorkspaceDelete:
 
 
 class TestCapabilityToggling:
-    def test_workspace_delete_disabled_returns_eight_tools(self, tmp_path: Path) -> None:
+    def test_workspace_delete_disabled_returns_nine_tools(self, tmp_path: Path) -> None:
         """WorkspaceTool(workspace_delete=False) exposes 9 tools."""
         observer, fs = make_observer(tmp_path)
         with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
@@ -220,7 +220,7 @@ class TestCapabilityToggling:
         assert "workspace_write" in names
         assert len(tools) == 9
 
-    def test_workspace_write_disabled_returns_eight_tools(self, tmp_path: Path) -> None:
+    def test_workspace_write_disabled_returns_nine_tools(self, tmp_path: Path) -> None:
         """WorkspaceTool(workspace_write=False) exposes 9 tools."""
         observer, fs = make_observer(tmp_path)
         with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
@@ -232,7 +232,7 @@ class TestCapabilityToggling:
         assert "workspace_delete" in names
         assert len(tools) == 9
 
-    def test_both_write_and_delete_disabled_returns_seven_tools(
+    def test_both_write_and_delete_disabled_returns_eight_tools(
         self, tmp_path: Path
     ) -> None:
         """WorkspaceTool(workspace_write=False, workspace_delete=False) returns 8 tools."""
@@ -535,12 +535,12 @@ class TestWorkspacePatch:
 
 
 class TestCapabilityTogglingStory55:
-    def test_default_count_is_nine(self, tmp_path: Path) -> None:
+    def test_default_count_is_ten(self, tmp_path: Path) -> None:
         """By default get_tools() returns 10: 4 read + write + delete + edit + multi_edit + patch + mkdir."""
         tool, _ = make_wired_tool(tmp_path)
         assert len(tool.get_tools()) == 10
 
-    def test_edit_disabled_count_is_eight(self, tmp_path: Path) -> None:
+    def test_edit_disabled_count_is_nine(self, tmp_path: Path) -> None:
         """WorkspaceTool(workspace_edit=False) returns 9 tools."""
         observer, fs = make_observer(tmp_path)
         with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
@@ -548,7 +548,7 @@ class TestCapabilityTogglingStory55:
             tool.observer(observer)
         assert len(tool.get_tools()) == 9
 
-    def test_multi_edit_disabled_count_is_eight(self, tmp_path: Path) -> None:
+    def test_multi_edit_disabled_count_is_nine(self, tmp_path: Path) -> None:
         """WorkspaceTool(workspace_multi_edit=False) returns 9 tools."""
         observer, fs = make_observer(tmp_path)
         with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
@@ -556,7 +556,7 @@ class TestCapabilityTogglingStory55:
             tool.observer(observer)
         assert len(tool.get_tools()) == 9
 
-    def test_patch_disabled_count_is_eight(self, tmp_path: Path) -> None:
+    def test_patch_disabled_count_is_nine(self, tmp_path: Path) -> None:
         """WorkspaceTool(workspace_patch=False) returns 9 tools."""
         observer, fs = make_observer(tmp_path)
         with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):


### PR DESCRIPTION
## Summary

- Add `Filesystem.mkdir()` to `workspace.py` with `_validate_path()` guard, idempotent semantics (`parents=True, exist_ok=True`), and `PermissionError` on traversal
- Add `mkdir()` to the `Workspace` Protocol so runtime-checkable `isinstance` checks remain valid
- Add `WorkspaceMkdir` param class and `workspace_mkdir: WorkspaceMkdir | bool = True` field to `WorkspaceTool`; `_mkdir_factory` returns `"Created: <path>"` confirmation
- Extend `WorkspaceTool.get_tools()` with mkdir resolution block — default tool count increases from 9 to 10
- Add `max_depth: int = 1` to `WorkspaceList` and implement module-level `_build_tree()` helper with dirs-first sorting and `├──`/`└──`/`│   ` connectors
- Replace `_list_factory` with depth-aware version: `depth=1` flat list (`name/`, `name (N bytes)`), `depth=0`/`depth>1` ASCII tree via `_build_tree()`
- Export `WorkspaceMkdir` from `workspace/__init__.py`
- Add `TestFilesystemMkdir`, `TestWorkspaceMkdir`, `TestWorkspaceListDepth` test classes; update all tool-count assertions (+1 for mkdir)
- Code review fixes: remove unused `ws_root` parameter from `_build_tree()`; rename stale test methods to match actual post-mkdir counts; update `get_tools()` docstring to mention `workspace_mkdir`

183 tests pass, 97% branch coverage, ruff + mypy strict zero errors.

Closes #53