### PR TITLE
feat: DockerSandboxActor — persistent container execution (Story 6.3)

### DIFF
--- a/src/akgentic/tool/sandbox/__init__.py
+++ b/src/akgentic/tool/sandbox/__init__.py
@@ -1,0 +1,3 @@
+"""Sandbox submodule — placeholder exports (full exports added in Story 6.4)."""
+
+from __future__ import annotations

--- a/src/akgentic/tool/sandbox/actor.py
+++ b/src/akgentic/tool/sandbox/actor.py
@@ -1,0 +1,215 @@
+"""SandboxActor — abstract base class for sandbox execution backends.
+
+Defines models, the command allowlist, module constants, and the lifecycle/exec
+contract. Concrete subclasses (LocalSandboxActor, DockerSandboxActor) provide
+the execution backend by implementing _start_sandbox, _stop_sandbox, and _exec.
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from pathlib import Path
+
+from pydantic import BaseModel
+
+from akgentic.core.agent import Akgent, BaseConfig, BaseState
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Module-level constants
+# ---------------------------------------------------------------------------
+
+SANDBOX_ACTOR_NAME: str = "#SandboxActor"
+SANDBOX_ACTOR_ROLE: str = "ToolActor"
+
+ALLOWED_COMMANDS: frozenset[str] = frozenset(
+    {
+        "python",
+        "python3",
+        "pytest",
+        "ruff",
+        "mypy",
+        "git",
+        "uv",
+        "pip",
+        "cat",
+        "ls",
+        "find",
+        "grep",
+        "mkdir",
+        "cp",
+        "mv",
+        "rm",
+        "echo",
+        "touch",
+        "curl",
+        "wget",
+        "make",
+        "bash",
+        "sh",
+        "node",
+        "npm",
+        "npx",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Data models
+# ---------------------------------------------------------------------------
+
+
+class SandboxConfig(BaseConfig):
+    """Configuration for a SandboxActor.
+
+    Attributes:
+        team_id: Identifier of the team that owns this sandbox.
+    """
+
+    team_id: str
+
+
+class SandboxState(BaseState):
+    """Runtime state for a SandboxActor.
+
+    Attributes:
+        workspace_path: Path to the workspace directory on the host, or None if
+            the sandbox has not been started yet.
+        container_name: Name of the Docker container, or None if not applicable.
+    """
+
+    workspace_path: Path | None = None
+    container_name: str | None = None
+
+
+class ExecResult(BaseModel):
+    """Result of a sandbox command execution.
+
+    Attributes:
+        stdout: Captured standard output from the command.
+        stderr: Captured standard error from the command.
+        exit_code: Process exit code (0 indicates success).
+    """
+
+    stdout: str
+    stderr: str
+    exit_code: int
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class CommandNotAllowedError(Exception):
+    """Raised when exec() is called with a command binary not in ALLOWED_COMMANDS.
+
+    Only the first token (binary name) of the command string is checked.
+    Argument-level filtering is out of scope for the base class.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Abstract actor
+# ---------------------------------------------------------------------------
+
+
+class SandboxActor(Akgent[SandboxConfig, SandboxState], ABC):
+    """Abstract sandbox actor. Concrete subclasses provide the execution backend.
+
+    Responsibilities of this base class:
+    - Initialize and manage SandboxState via on_start / on_stop lifecycle hooks.
+    - Enforce the command allowlist before delegating to _exec.
+    - Define the abstract interface (_start_sandbox, _stop_sandbox, _exec) that
+      subclasses must implement.
+    """
+
+    def on_start(self) -> None:
+        """Initialize SandboxState and start the sandbox backend.
+
+        Registers the actor as a state observer (required for Pykka telemetry),
+        then delegates to _start_sandbox() for backend-specific setup.
+        """
+        self.state = SandboxState()
+        self.state.observer(self)
+        self._start_sandbox()
+
+    def on_stop(self) -> None:
+        """Stop the sandbox backend, swallowing any exceptions.
+
+        Calls _stop_sandbox() inside a try/except so that any backend error
+        does not prevent super().on_stop() from running. Leaving Pykka actors
+        in a broken state by raising in on_stop() is a critical failure mode
+        that this pattern prevents.
+        """
+        try:
+            self._stop_sandbox()
+        except Exception:
+            logger.warning(
+                "SandboxActor._stop_sandbox() raised during on_stop — swallowing",
+                exc_info=True,
+            )
+        super().on_stop()
+
+    def exec(self, cmd: str, cwd: str = "") -> ExecResult:
+        """Execute a command inside the sandbox after allowlist validation.
+
+        Only the first whitespace-delimited token (the binary name) is checked
+        against ALLOWED_COMMANDS. Argument-level filtering is out of scope.
+
+        Args:
+            cmd: Full command string to execute (e.g. "python main.py").
+            cwd: Working directory inside the sandbox. Defaults to "".
+
+        Returns:
+            ExecResult with stdout, stderr, and exit_code from the backend.
+
+        Raises:
+            CommandNotAllowedError: If the command binary is not in ALLOWED_COMMANDS.
+        """
+        binary = cmd.split()[0]
+        if binary not in ALLOWED_COMMANDS:
+            raise CommandNotAllowedError(
+                f"Command '{binary}' is not in the allowed commands list. "
+                f"Allowed: {sorted(ALLOWED_COMMANDS)}"
+            )
+        return self._exec(cmd, cwd)
+
+    # ------------------------------------------------------------------
+    # Abstract methods — must be implemented by concrete subclasses
+    # ------------------------------------------------------------------
+
+    @abstractmethod
+    def _start_sandbox(self) -> None:
+        """Start the sandbox execution environment.
+
+        Called from on_start() after SandboxState is initialized. Subclasses
+        should provision any resources needed (e.g., create a temp directory,
+        start a Docker container).
+        """
+
+    @abstractmethod
+    def _stop_sandbox(self) -> None:
+        """Stop and clean up the sandbox execution environment.
+
+        Called from on_stop() inside a try/except. Subclasses should release
+        resources (e.g., remove temp directory, stop a Docker container).
+        May raise — the caller swallows all exceptions.
+        """
+
+    @abstractmethod
+    def _exec(self, cmd: str, cwd: str) -> ExecResult:
+        """Execute a pre-validated command inside the sandbox.
+
+        Called by exec() after the allowlist check passes. Subclasses handle
+        the actual process execution (subprocess, Docker exec API, etc.).
+
+        Args:
+            cmd: Full command string (already validated by exec()).
+            cwd: Working directory inside the sandbox.
+
+        Returns:
+            ExecResult with captured stdout, stderr, and exit code.
+        """

--- a/src/akgentic/tool/sandbox/actor.py
+++ b/src/akgentic/tool/sandbox/actor.py
@@ -169,7 +169,12 @@ class SandboxActor(Akgent[SandboxConfig, SandboxState], ABC):
         Raises:
             CommandNotAllowedError: If the command binary is not in ALLOWED_COMMANDS.
         """
-        binary = cmd.split()[0]
+        tokens = cmd.split()
+        if not tokens:
+            raise CommandNotAllowedError(
+                "Command string is empty — no binary to validate against the allowlist."
+            )
+        binary = tokens[0]
         if binary not in ALLOWED_COMMANDS:
             raise CommandNotAllowedError(
                 f"Command '{binary}' is not in the allowed commands list. "

--- a/src/akgentic/tool/sandbox/docker.py
+++ b/src/akgentic/tool/sandbox/docker.py
@@ -1,0 +1,103 @@
+"""DockerSandboxActor — persistent Docker container per team."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+
+from akgentic.tool.sandbox.actor import ExecResult, SandboxActor
+
+SANDBOX_IMAGE: str = "akgentic-sandbox:latest"
+DOCKER_EXEC_TIMEOUT: int = 60
+
+
+class DockerSandboxActor(SandboxActor):
+    """Persistent Docker container sandbox per team.
+
+    Manages a single Docker container named sandbox-{team_id}.
+    Container is started (or reused) on on_start(), stopped (not removed)
+    on on_stop(). Used when SANDBOX_MODE=docker.
+    """
+
+    def _start_sandbox(self) -> None:
+        container_name = f"sandbox-{self.config.team_id}"
+        if shutil.which("docker") is None:
+            raise RuntimeError(
+                "docker CLI not found on PATH — cannot start DockerSandboxActor"
+            )
+        # Check if container already exists (any state)
+        check = subprocess.run(
+            [
+                "docker",
+                "ps",
+                "-a",
+                "--filter",
+                f"name={container_name}",
+                "--format",
+                "{{.Names}}",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if container_name in check.stdout:
+            subprocess.run(
+                ["docker", "start", container_name],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+        else:
+            subprocess.run(
+                [
+                    "docker",
+                    "run",
+                    "-d",
+                    "--name",
+                    container_name,
+                    "--network",
+                    "none",
+                    "-v",
+                    f"workspaces/{self.config.team_id}:/workspace",
+                    "-w",
+                    "/workspace",
+                    SANDBOX_IMAGE,
+                    "sleep",
+                    "infinity",
+                ],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+        self.state.container_name = container_name
+        self.state.notify_state_change()
+
+    def _stop_sandbox(self) -> None:
+        assert self.state.container_name is not None
+        subprocess.run(
+            ["docker", "stop", self.state.container_name],
+            capture_output=True,
+            text=True,
+        )
+        # Do NOT run docker rm — container filesystem preserved between restarts
+
+    def _exec(self, cmd: str, cwd: str) -> ExecResult:
+        assert self.state.container_name is not None
+        effective_workdir = f"/workspace/{cwd}" if cwd else "/workspace"
+        docker_cmd = [
+            "docker",
+            "exec",
+            "-w",
+            effective_workdir,
+            self.state.container_name,
+        ] + cmd.split()
+        result = subprocess.run(
+            docker_cmd,
+            capture_output=True,
+            text=True,
+            timeout=DOCKER_EXEC_TIMEOUT,
+        )
+        return ExecResult(
+            stdout=result.stdout,
+            stderr=result.stderr,
+            exit_code=result.returncode,
+        )

--- a/src/akgentic/tool/sandbox/docker.py
+++ b/src/akgentic/tool/sandbox/docker.py
@@ -39,7 +39,7 @@ class DockerSandboxActor(SandboxActor):
             capture_output=True,
             text=True,
         )
-        if container_name in check.stdout:
+        if container_name in check.stdout.splitlines():
             subprocess.run(
                 ["docker", "start", container_name],
                 capture_output=True,

--- a/src/akgentic/tool/sandbox/local.py
+++ b/src/akgentic/tool/sandbox/local.py
@@ -1,0 +1,41 @@
+"""LocalSandboxActor — subprocess-based sandbox for local filesystem execution."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from akgentic.tool.sandbox.actor import ExecResult, SandboxActor
+
+
+class LocalSandboxActor(SandboxActor):
+    """Subprocess-based sandbox actor for local filesystem execution.
+
+    Creates and manages a workspace directory under ./workspaces/{team_id}/.
+    No Docker daemon required. Used when SANDBOX_MODE=local (default).
+    """
+
+    def _start_sandbox(self) -> None:
+        workspace_path = Path(f"./workspaces/{self.config.team_id}")
+        workspace_path.mkdir(parents=True, exist_ok=True)
+        self.state.workspace_path = workspace_path.resolve()
+        self.state.notify_state_change()
+
+    def _stop_sandbox(self) -> None:
+        pass  # no persistent resource to tear down
+
+    def _exec(self, cmd: str, cwd: str) -> ExecResult:
+        assert self.state.workspace_path is not None
+        effective_cwd = self.state.workspace_path / cwd if cwd else self.state.workspace_path
+        result = subprocess.run(
+            cmd.split(),
+            cwd=str(effective_cwd),
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        return ExecResult(
+            stdout=result.stdout,
+            stderr=result.stderr,
+            exit_code=result.returncode,
+        )

--- a/tests/sandbox/test_docker_sandbox.py
+++ b/tests/sandbox/test_docker_sandbox.py
@@ -1,0 +1,426 @@
+"""Tests for DockerSandboxActor — persistent Docker container execution.
+
+Covers AC1 through AC11 for Story 6.3:
+- AC1: _start_sandbox() runs docker run when container does not exist
+- AC2: _start_sandbox() runs docker start when container already exists
+- AC3: _start_sandbox() raises RuntimeError when docker CLI not on PATH
+- AC4: _stop_sandbox() runs docker stop and does NOT run docker rm
+- AC5: Exceptions from _stop_sandbox() swallowed by SandboxActor.on_stop() (base class)
+- AC6: _exec("pytest tests/", cwd="src") builds docker exec -w /workspace/src
+- AC7: _exec("pytest tests/", cwd="") builds docker exec -w /workspace
+- AC8: state.container_name is set after _start_sandbox() (volume sharing by convention)
+- AC9: SANDBOX_IMAGE == "akgentic-sandbox:latest"
+- AC10: DOCKER_EXEC_TIMEOUT == 60
+- AC11: 80%+ branch coverage
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from akgentic.tool.sandbox.actor import (
+    ExecResult,
+    SandboxConfig,
+    SandboxState,
+)
+from akgentic.tool.sandbox.docker import (
+    DOCKER_EXEC_TIMEOUT,
+    SANDBOX_IMAGE,
+    DockerSandboxActor,
+)
+
+# ---------------------------------------------------------------------------
+# Helper factory
+# ---------------------------------------------------------------------------
+
+
+def make_actor(team_id: str = "team-test") -> DockerSandboxActor:
+    """Create a DockerSandboxActor with config and state pre-initialized (no Pykka runtime)."""
+    actor = DockerSandboxActor()
+    actor.config = SandboxConfig(name="sandbox", role="ToolActor", team_id=team_id)
+    actor.state = SandboxState()
+    actor.state.observer(actor)
+    return actor
+
+
+# ---------------------------------------------------------------------------
+# AC9: SANDBOX_IMAGE constant
+# ---------------------------------------------------------------------------
+
+
+def test_sandbox_image_constant() -> None:
+    """AC9: SANDBOX_IMAGE equals 'akgentic-sandbox:latest'."""
+    assert SANDBOX_IMAGE == "akgentic-sandbox:latest"
+
+
+# ---------------------------------------------------------------------------
+# AC10: DOCKER_EXEC_TIMEOUT constant
+# ---------------------------------------------------------------------------
+
+
+def test_docker_exec_timeout_constant() -> None:
+    """AC10: DOCKER_EXEC_TIMEOUT equals 60."""
+    assert DOCKER_EXEC_TIMEOUT == 60
+
+
+# ---------------------------------------------------------------------------
+# AC1: _start_sandbox() runs docker run when container does not exist
+# ---------------------------------------------------------------------------
+
+
+@patch("akgentic.tool.sandbox.docker.shutil.which", return_value="/usr/bin/docker")
+@patch("akgentic.tool.sandbox.docker.subprocess.run")
+def test_start_sandbox_creates_container_when_absent(
+    mock_run: MagicMock, mock_which: MagicMock
+) -> None:
+    """AC1: _start_sandbox() runs docker run -d when container does not exist."""
+    # First call: docker ps -a → returns empty stdout (container not found)
+    # Second call: docker run -d → returns success
+    mock_run.side_effect = [
+        MagicMock(stdout="", returncode=0),  # docker ps -a
+        MagicMock(stdout="abc123", returncode=0),  # docker run
+    ]
+    actor = make_actor(team_id="team-1")
+    actor._start_sandbox()
+
+    assert actor.state.container_name == "sandbox-team-1"
+    # Verify docker run was called (second call), not docker start
+    second_call_args = mock_run.call_args_list[1][0][0]
+    assert second_call_args[1] == "run"
+
+
+@patch("akgentic.tool.sandbox.docker.shutil.which", return_value="/usr/bin/docker")
+@patch("akgentic.tool.sandbox.docker.subprocess.run")
+def test_start_sandbox_docker_run_uses_correct_flags(
+    mock_run: MagicMock, mock_which: MagicMock
+) -> None:
+    """AC1: docker run uses -d, --name, --network none, -v, -w, sleep infinity."""
+    mock_run.side_effect = [
+        MagicMock(stdout="", returncode=0),  # docker ps -a
+        MagicMock(stdout="abc123", returncode=0),  # docker run
+    ]
+    actor = make_actor(team_id="team-1")
+    actor._start_sandbox()
+
+    run_call_args = mock_run.call_args_list[1][0][0]
+    assert run_call_args == [
+        "docker",
+        "run",
+        "-d",
+        "--name",
+        "sandbox-team-1",
+        "--network",
+        "none",
+        "-v",
+        "workspaces/team-1:/workspace",
+        "-w",
+        "/workspace",
+        SANDBOX_IMAGE,
+        "sleep",
+        "infinity",
+    ]
+
+
+@patch("akgentic.tool.sandbox.docker.shutil.which", return_value="/usr/bin/docker")
+@patch("akgentic.tool.sandbox.docker.subprocess.run")
+def test_start_sandbox_sets_container_name_in_state(
+    mock_run: MagicMock, mock_which: MagicMock
+) -> None:
+    """AC1/AC8: After _start_sandbox(), state.container_name is set to 'sandbox-{team_id}'."""
+    mock_run.side_effect = [
+        MagicMock(stdout="", returncode=0),  # docker ps -a
+        MagicMock(stdout="abc123", returncode=0),  # docker run
+    ]
+    actor = make_actor(team_id="team-1")
+    actor._start_sandbox()
+
+    assert actor.state.container_name == "sandbox-team-1"
+
+
+# ---------------------------------------------------------------------------
+# AC2: _start_sandbox() runs docker start when container already exists
+# ---------------------------------------------------------------------------
+
+
+@patch("akgentic.tool.sandbox.docker.shutil.which", return_value="/usr/bin/docker")
+@patch("akgentic.tool.sandbox.docker.subprocess.run")
+def test_start_sandbox_reuses_existing_container(
+    mock_run: MagicMock, mock_which: MagicMock
+) -> None:
+    """AC2: _start_sandbox() runs docker start when container already exists (any state)."""
+    # First call: docker ps -a → container name in stdout
+    # Second call: docker start → returns success
+    mock_run.side_effect = [
+        MagicMock(stdout="sandbox-team-1\n", returncode=0),  # docker ps -a
+        MagicMock(stdout="sandbox-team-1", returncode=0),  # docker start
+    ]
+    actor = make_actor(team_id="team-1")
+    actor._start_sandbox()
+
+    second_call_args = mock_run.call_args_list[1][0][0]
+    assert second_call_args[1] == "start"
+    assert actor.state.container_name == "sandbox-team-1"
+
+
+@patch("akgentic.tool.sandbox.docker.shutil.which", return_value="/usr/bin/docker")
+@patch("akgentic.tool.sandbox.docker.subprocess.run")
+def test_start_sandbox_docker_start_uses_correct_args(
+    mock_run: MagicMock, mock_which: MagicMock
+) -> None:
+    """AC2: docker start is called with the correct container name."""
+    mock_run.side_effect = [
+        MagicMock(stdout="sandbox-team-1\n", returncode=0),  # docker ps -a
+        MagicMock(stdout="sandbox-team-1", returncode=0),  # docker start
+    ]
+    actor = make_actor(team_id="team-1")
+    actor._start_sandbox()
+
+    start_call_args = mock_run.call_args_list[1][0][0]
+    assert start_call_args == ["docker", "start", "sandbox-team-1"]
+
+
+# ---------------------------------------------------------------------------
+# AC3: _start_sandbox() raises RuntimeError when docker not on PATH
+# ---------------------------------------------------------------------------
+
+
+@patch("akgentic.tool.sandbox.docker.shutil.which", return_value=None)
+def test_start_sandbox_raises_when_docker_not_on_path(mock_which: MagicMock) -> None:
+    """AC3: _start_sandbox() raises RuntimeError when shutil.which('docker') returns None."""
+    actor = make_actor()
+    with pytest.raises(RuntimeError, match="docker"):
+        actor._start_sandbox()
+
+
+@patch("akgentic.tool.sandbox.docker.shutil.which", return_value=None)
+def test_start_sandbox_runtime_error_message(mock_which: MagicMock) -> None:
+    """AC3: RuntimeError message mentions docker CLI."""
+    actor = make_actor()
+    with pytest.raises(RuntimeError, match="docker CLI not found on PATH"):
+        actor._start_sandbox()
+
+
+# ---------------------------------------------------------------------------
+# AC4: _stop_sandbox() runs docker stop and does NOT run docker rm
+# ---------------------------------------------------------------------------
+
+
+@patch("akgentic.tool.sandbox.docker.subprocess.run")
+def test_stop_sandbox_runs_docker_stop(mock_run: MagicMock) -> None:
+    """AC4: _stop_sandbox() calls docker stop with the container name."""
+    actor = make_actor(team_id="team-1")
+    actor.state.container_name = "sandbox-team-1"
+    mock_run.return_value = MagicMock(returncode=0)
+
+    actor._stop_sandbox()
+
+    assert mock_run.call_args_list[0][0][0] == ["docker", "stop", "sandbox-team-1"]
+
+
+@patch("akgentic.tool.sandbox.docker.subprocess.run")
+def test_stop_sandbox_does_not_rm_container(mock_run: MagicMock) -> None:
+    """AC4: _stop_sandbox() does NOT run docker rm — container preserved between restarts."""
+    actor = make_actor(team_id="team-1")
+    actor.state.container_name = "sandbox-team-1"
+    mock_run.return_value = MagicMock(returncode=0)
+
+    actor._stop_sandbox()
+
+    # Verify docker rm was NOT called in any subprocess.run call
+    for call_item in mock_run.call_args_list:
+        assert "rm" not in call_item[0][0]
+
+
+@patch("akgentic.tool.sandbox.docker.subprocess.run")
+def test_stop_sandbox_only_one_subprocess_call(mock_run: MagicMock) -> None:
+    """AC4: _stop_sandbox() makes exactly one subprocess.run call (docker stop only)."""
+    actor = make_actor(team_id="team-1")
+    actor.state.container_name = "sandbox-team-1"
+    mock_run.return_value = MagicMock(returncode=0)
+
+    actor._stop_sandbox()
+
+    assert mock_run.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# AC5: on_stop() swallows _stop_sandbox() exceptions (inherited behavior)
+# ---------------------------------------------------------------------------
+
+
+@patch("akgentic.tool.sandbox.docker.shutil.which", return_value="/usr/bin/docker")
+@patch("akgentic.tool.sandbox.docker.subprocess.run")
+def test_on_stop_swallows_stop_sandbox_exception(
+    mock_run: MagicMock, mock_which: MagicMock
+) -> None:
+    """AC5: on_stop() swallows exceptions raised by _stop_sandbox() — base class behavior."""
+    # Start sandbox first to set container_name
+    mock_run.side_effect = [
+        MagicMock(stdout="", returncode=0),  # docker ps -a
+        MagicMock(stdout="abc123", returncode=0),  # docker run
+        subprocess.CalledProcessError(1, "docker stop"),  # docker stop raises
+    ]
+    actor = make_actor(team_id="team-1")
+    actor._start_sandbox()
+
+    # on_stop() should not raise even though docker stop fails
+    actor.on_stop()  # Must not raise
+
+
+# ---------------------------------------------------------------------------
+# AC6: _exec() with cwd builds docker exec -w /workspace/src
+# ---------------------------------------------------------------------------
+
+
+@patch("akgentic.tool.sandbox.docker.subprocess.run")
+def test_exec_with_cwd_builds_correct_docker_command(mock_run: MagicMock) -> None:
+    """AC6: _exec('pytest tests/', cwd='src') builds docker exec -w /workspace/src."""
+    actor = make_actor(team_id="team-1")
+    actor.state.container_name = "sandbox-team-1"
+    mock_run.return_value = MagicMock(stdout="", stderr="", returncode=0)
+
+    actor._exec("pytest tests/", "src")
+
+    expected_cmd = [
+        "docker",
+        "exec",
+        "-w",
+        "/workspace/src",
+        "sandbox-team-1",
+        "pytest",
+        "tests/",
+    ]
+    mock_run.assert_called_once_with(
+        expected_cmd,
+        capture_output=True,
+        text=True,
+        timeout=DOCKER_EXEC_TIMEOUT,
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC7: _exec() with empty cwd builds docker exec -w /workspace
+# ---------------------------------------------------------------------------
+
+
+@patch("akgentic.tool.sandbox.docker.subprocess.run")
+def test_exec_without_cwd_uses_workspace_root(mock_run: MagicMock) -> None:
+    """AC7: _exec('pytest tests/', cwd='') builds docker exec -w /workspace (no trailing slash)."""
+    actor = make_actor(team_id="team-1")
+    actor.state.container_name = "sandbox-team-1"
+    mock_run.return_value = MagicMock(stdout="", stderr="", returncode=0)
+
+    actor._exec("pytest tests/", "")
+
+    expected_cmd = [
+        "docker",
+        "exec",
+        "-w",
+        "/workspace",
+        "sandbox-team-1",
+        "pytest",
+        "tests/",
+    ]
+    mock_run.assert_called_once_with(
+        expected_cmd,
+        capture_output=True,
+        text=True,
+        timeout=DOCKER_EXEC_TIMEOUT,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _exec() returns ExecResult with correct fields
+# ---------------------------------------------------------------------------
+
+
+@patch("akgentic.tool.sandbox.docker.subprocess.run")
+def test_exec_returns_exec_result_with_correct_fields(mock_run: MagicMock) -> None:
+    """_exec() returns ExecResult with stdout, stderr, exit_code from mocked subprocess."""
+    actor = make_actor(team_id="team-1")
+    actor.state.container_name = "sandbox-team-1"
+    mock_run.return_value = MagicMock(stdout="test passed", stderr="warning", returncode=0)
+
+    result = actor._exec("pytest tests/", "")
+
+    assert isinstance(result, ExecResult)
+    assert result.stdout == "test passed"
+    assert result.stderr == "warning"
+    assert result.exit_code == 0
+
+
+@patch("akgentic.tool.sandbox.docker.subprocess.run")
+def test_exec_captures_non_zero_exit_code(mock_run: MagicMock) -> None:
+    """_exec() correctly captures non-zero exit codes."""
+    actor = make_actor(team_id="team-1")
+    actor.state.container_name = "sandbox-team-1"
+    mock_run.return_value = MagicMock(stdout="", stderr="test failed", returncode=1)
+
+    result = actor._exec("pytest tests/", "")
+
+    assert result.exit_code == 1
+    assert result.stderr == "test failed"
+
+
+# ---------------------------------------------------------------------------
+# _exec() timeout propagates
+# ---------------------------------------------------------------------------
+
+
+@patch("akgentic.tool.sandbox.docker.subprocess.run")
+def test_exec_timeout_propagates(mock_run: MagicMock) -> None:
+    """_exec() propagates subprocess.TimeoutExpired — not swallowed."""
+    actor = make_actor(team_id="team-1")
+    actor.state.container_name = "sandbox-team-1"
+    mock_run.side_effect = subprocess.TimeoutExpired(cmd=["docker", "exec"], timeout=60)
+
+    with pytest.raises(subprocess.TimeoutExpired):
+        actor._exec("pytest tests/", "")
+
+
+# ---------------------------------------------------------------------------
+# AC8: Integration assertion — state.container_name set after _start_sandbox()
+# ---------------------------------------------------------------------------
+
+
+@patch("akgentic.tool.sandbox.docker.shutil.which", return_value="/usr/bin/docker")
+@patch("akgentic.tool.sandbox.docker.subprocess.run")
+def test_integration_container_name_set_after_start(
+    mock_run: MagicMock, mock_which: MagicMock
+) -> None:
+    """AC8: After _start_sandbox(), state.container_name is set — volume mount ensures file sharing."""
+    mock_run.side_effect = [
+        MagicMock(stdout="", returncode=0),  # docker ps -a
+        MagicMock(stdout="abc123", returncode=0),  # docker run
+    ]
+    actor = make_actor(team_id="team-1")
+    actor._start_sandbox()
+
+    # Volume sharing is by design convention (-v workspaces/team-1:/workspace)
+    # assert container_name is set (and thus the mount is active)
+    assert actor.state.container_name == "sandbox-team-1"
+
+
+# ---------------------------------------------------------------------------
+# notify_state_change is called after _start_sandbox()
+# ---------------------------------------------------------------------------
+
+
+@patch("akgentic.tool.sandbox.docker.shutil.which", return_value="/usr/bin/docker")
+@patch("akgentic.tool.sandbox.docker.subprocess.run")
+def test_start_sandbox_calls_notify_state_change(
+    mock_run: MagicMock, mock_which: MagicMock
+) -> None:
+    """_start_sandbox() calls state.notify_state_change() after setting container_name."""
+    mock_run.side_effect = [
+        MagicMock(stdout="", returncode=0),  # docker ps -a
+        MagicMock(stdout="abc123", returncode=0),  # docker run
+    ]
+    actor = make_actor(team_id="team-1")
+
+    with patch("akgentic.tool.sandbox.actor.SandboxState.notify_state_change") as mock_notify:
+        actor._start_sandbox()
+        mock_notify.assert_called_once()

--- a/tests/sandbox/test_docker_sandbox.py
+++ b/tests/sandbox/test_docker_sandbox.py
@@ -17,7 +17,7 @@ Covers AC1 through AC11 for Story 6.3:
 from __future__ import annotations
 
 import subprocess
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -180,6 +180,30 @@ def test_start_sandbox_docker_start_uses_correct_args(
 
     start_call_args = mock_run.call_args_list[1][0][0]
     assert start_call_args == ["docker", "start", "sandbox-team-1"]
+
+
+@patch("akgentic.tool.sandbox.docker.shutil.which", return_value="/usr/bin/docker")
+@patch("akgentic.tool.sandbox.docker.subprocess.run")
+def test_start_sandbox_no_false_positive_on_prefix_container_name(
+    mock_run: MagicMock, mock_which: MagicMock
+) -> None:
+    """AC1: container name prefix in stdout does not trigger false reuse.
+
+    If 'sandbox-team-10' appears in stdout, checking for 'sandbox-team-1'
+    must NOT match — exact line matching is required.
+    """
+    # docker ps -a stdout contains a prefix-matching name, not exact match
+    mock_run.side_effect = [
+        MagicMock(stdout="sandbox-team-10\n", returncode=0),  # docker ps -a
+        MagicMock(stdout="abc123", returncode=0),  # docker run (not docker start)
+    ]
+    actor = make_actor(team_id="team-1")
+    actor._start_sandbox()
+
+    # Must run docker run, NOT docker start
+    second_call_args = mock_run.call_args_list[1][0][0]
+    assert second_call_args[1] == "run"
+    assert actor.state.container_name == "sandbox-team-1"
 
 
 # ---------------------------------------------------------------------------
@@ -391,7 +415,7 @@ def test_exec_timeout_propagates(mock_run: MagicMock) -> None:
 def test_integration_container_name_set_after_start(
     mock_run: MagicMock, mock_which: MagicMock
 ) -> None:
-    """AC8: After _start_sandbox(), state.container_name is set — volume mount ensures file sharing."""
+    """AC8: After _start_sandbox(), state.container_name is set — volume mount ensures sharing."""
     mock_run.side_effect = [
         MagicMock(stdout="", returncode=0),  # docker ps -a
         MagicMock(stdout="abc123", returncode=0),  # docker run

--- a/tests/sandbox/test_local_sandbox.py
+++ b/tests/sandbox/test_local_sandbox.py
@@ -1,0 +1,249 @@
+"""Tests for LocalSandboxActor — subprocess-based sandbox execution.
+
+Covers AC1 through AC7 for Story 6.2:
+- _start_sandbox() creates workspace directory and stores absolute path
+- _start_sandbox() is idempotent (calling twice does not raise)
+- _stop_sandbox() is a no-op
+- _exec() with empty cwd uses state.workspace_path directly
+- _exec() with non-empty cwd uses state.workspace_path / cwd
+- _exec() returns ExecResult with correct stdout, stderr, exit_code
+- subprocess.TimeoutExpired propagates from _exec()
+- exec() public method works end-to-end through _exec()
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from akgentic.tool.sandbox.actor import ExecResult, SandboxConfig, SandboxState
+from akgentic.tool.sandbox.local import LocalSandboxActor
+
+
+# ---------------------------------------------------------------------------
+# Helper factory
+# ---------------------------------------------------------------------------
+
+
+def make_actor(team_id: str = "team-test") -> LocalSandboxActor:
+    """Create a LocalSandboxActor with config and state pre-initialized (no Pykka runtime)."""
+    actor = LocalSandboxActor()
+    actor.config = SandboxConfig(name="sandbox", role="ToolActor", team_id=team_id)
+    actor.state = SandboxState()
+    actor.state.observer(actor)
+    return actor
+
+
+# ---------------------------------------------------------------------------
+# AC1: _start_sandbox() creates workspace and stores absolute path
+# ---------------------------------------------------------------------------
+
+
+def test_start_sandbox_creates_workspace_directory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """AC1: _start_sandbox() creates ./workspaces/team-1/ relative to CWD."""
+    monkeypatch.chdir(tmp_path)
+    actor = make_actor(team_id="team-1")
+
+    actor._start_sandbox()
+
+    expected = tmp_path / "workspaces" / "team-1"
+    assert expected.exists()
+    assert expected.is_dir()
+
+
+def test_start_sandbox_stores_absolute_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """AC1: _start_sandbox() stores resolved absolute path in state.workspace_path."""
+    monkeypatch.chdir(tmp_path)
+    actor = make_actor(team_id="team-1")
+
+    actor._start_sandbox()
+
+    assert actor.state.workspace_path is not None
+    assert actor.state.workspace_path.is_absolute()
+    assert actor.state.workspace_path == (tmp_path / "workspaces" / "team-1").resolve()
+
+
+def test_start_sandbox_calls_notify_state_change(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """AC1: _start_sandbox() calls state.notify_state_change() — verified via class-level patch."""
+    monkeypatch.chdir(tmp_path)
+    actor = make_actor(team_id="team-1")
+
+    with patch("akgentic.tool.sandbox.actor.SandboxState.notify_state_change") as mock_notify:
+        actor._start_sandbox()
+        mock_notify.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# AC2: _start_sandbox() is idempotent
+# ---------------------------------------------------------------------------
+
+
+def test_start_sandbox_is_idempotent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """AC2: Calling _start_sandbox() twice does not raise."""
+    monkeypatch.chdir(tmp_path)
+    actor = make_actor(team_id="team-1")
+
+    actor._start_sandbox()
+    actor._start_sandbox()  # Must not raise
+
+    expected = tmp_path / "workspaces" / "team-1"
+    assert expected.exists()
+
+
+# ---------------------------------------------------------------------------
+# AC3: _stop_sandbox() is a no-op
+# ---------------------------------------------------------------------------
+
+
+def test_stop_sandbox_is_noop(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """AC3: _stop_sandbox() returns None and has no side effects."""
+    monkeypatch.chdir(tmp_path)
+    actor = make_actor(team_id="team-1")
+    actor._start_sandbox()
+
+    result = actor._stop_sandbox()
+
+    assert result is None
+
+
+def test_stop_sandbox_does_not_remove_workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """AC3: _stop_sandbox() leaves the workspace directory intact."""
+    monkeypatch.chdir(tmp_path)
+    actor = make_actor(team_id="team-1")
+    actor._start_sandbox()
+
+    actor._stop_sandbox()
+
+    expected = tmp_path / "workspaces" / "team-1"
+    assert expected.exists()
+
+
+# ---------------------------------------------------------------------------
+# AC4: _exec() with empty cwd uses state.workspace_path
+# ---------------------------------------------------------------------------
+
+
+@patch("akgentic.tool.sandbox.local.subprocess.run")
+def test_exec_no_cwd_uses_workspace_path(mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """AC4: _exec(cmd, cwd='') passes state.workspace_path as cwd to subprocess.run."""
+    monkeypatch.chdir(tmp_path)
+    actor = make_actor(team_id="team-1")
+    actor._start_sandbox()
+
+    mock_run.return_value = MagicMock(stdout="output", stderr="", returncode=0)
+
+    actor._exec("pytest tests/", "")
+
+    mock_run.assert_called_once_with(
+        ["pytest", "tests/"],
+        cwd=str(actor.state.workspace_path),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC5: _exec() with non-empty cwd uses state.workspace_path / cwd
+# ---------------------------------------------------------------------------
+
+
+@patch("akgentic.tool.sandbox.local.subprocess.run")
+def test_exec_with_cwd_appends_to_workspace_path(mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """AC5: _exec(cmd, cwd='src') passes state.workspace_path / 'src' as cwd."""
+    monkeypatch.chdir(tmp_path)
+    actor = make_actor(team_id="team-1")
+    actor._start_sandbox()
+
+    mock_run.return_value = MagicMock(stdout="output", stderr="", returncode=0)
+
+    actor._exec("pytest tests/", "src")
+
+    expected_cwd = str(actor.state.workspace_path / "src")
+    mock_run.assert_called_once_with(
+        ["pytest", "tests/"],
+        cwd=expected_cwd,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC4 / AC5: _exec() returns ExecResult with correct fields
+# ---------------------------------------------------------------------------
+
+
+@patch("akgentic.tool.sandbox.local.subprocess.run")
+def test_exec_returns_exec_result(mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """_exec() returns ExecResult with stdout, stderr, exit_code from subprocess.run."""
+    monkeypatch.chdir(tmp_path)
+    actor = make_actor(team_id="team-1")
+    actor._start_sandbox()
+
+    mock_run.return_value = MagicMock(stdout="test passed", stderr="warning", returncode=0)
+
+    result = actor._exec("pytest tests/", "")
+
+    assert isinstance(result, ExecResult)
+    assert result.stdout == "test passed"
+    assert result.stderr == "warning"
+    assert result.exit_code == 0
+
+
+@patch("akgentic.tool.sandbox.local.subprocess.run")
+def test_exec_captures_non_zero_exit_code(mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """_exec() correctly captures non-zero exit codes from subprocess.run."""
+    monkeypatch.chdir(tmp_path)
+    actor = make_actor(team_id="team-1")
+    actor._start_sandbox()
+
+    mock_run.return_value = MagicMock(stdout="", stderr="test failed", returncode=1)
+
+    result = actor._exec("pytest tests/", "")
+
+    assert result.exit_code == 1
+    assert result.stderr == "test failed"
+
+
+# ---------------------------------------------------------------------------
+# AC6: subprocess.TimeoutExpired propagates
+# ---------------------------------------------------------------------------
+
+
+@patch("akgentic.tool.sandbox.local.subprocess.run")
+def test_exec_timeout_propagates(mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """AC6: subprocess.TimeoutExpired from subprocess.run propagates out of _exec()."""
+    monkeypatch.chdir(tmp_path)
+    actor = make_actor(team_id="team-1")
+    actor._start_sandbox()
+
+    mock_run.side_effect = subprocess.TimeoutExpired(cmd=["sleep", "999"], timeout=30)
+
+    with pytest.raises(subprocess.TimeoutExpired):
+        actor._exec("sleep 999", "")
+
+
+# ---------------------------------------------------------------------------
+# AC7: exec() public method works end-to-end
+# ---------------------------------------------------------------------------
+
+
+@patch("akgentic.tool.sandbox.local.subprocess.run")
+def test_public_exec_method_end_to_end(mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """AC7: actor.exec() through inherited SandboxActor.exec() delegates to _exec()."""
+    monkeypatch.chdir(tmp_path)
+    actor = make_actor(team_id="team-1")
+    actor.on_start()  # Use the full lifecycle (sets state via SandboxActor.on_start)
+
+    mock_run.return_value = MagicMock(stdout="passed", stderr="", returncode=0)
+
+    result = actor.exec("pytest tests/")
+
+    assert isinstance(result, ExecResult)
+    assert result.stdout == "passed"
+    assert result.exit_code == 0
+    mock_run.assert_called_once()

--- a/tests/sandbox/test_local_sandbox.py
+++ b/tests/sandbox/test_local_sandbox.py
@@ -19,9 +19,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from akgentic.tool.sandbox.actor import ExecResult, SandboxConfig, SandboxState
+from akgentic.tool.sandbox.actor import (
+    ExecResult,
+    SandboxConfig,
+    SandboxState,
+)
 from akgentic.tool.sandbox.local import LocalSandboxActor
-
 
 # ---------------------------------------------------------------------------
 # Helper factory
@@ -42,7 +45,9 @@ def make_actor(team_id: str = "team-test") -> LocalSandboxActor:
 # ---------------------------------------------------------------------------
 
 
-def test_start_sandbox_creates_workspace_directory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_start_sandbox_creates_workspace_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """AC1: _start_sandbox() creates ./workspaces/team-1/ relative to CWD."""
     monkeypatch.chdir(tmp_path)
     actor = make_actor(team_id="team-1")
@@ -54,7 +59,9 @@ def test_start_sandbox_creates_workspace_directory(tmp_path: Path, monkeypatch: 
     assert expected.is_dir()
 
 
-def test_start_sandbox_stores_absolute_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_start_sandbox_stores_absolute_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """AC1: _start_sandbox() stores resolved absolute path in state.workspace_path."""
     monkeypatch.chdir(tmp_path)
     actor = make_actor(team_id="team-1")
@@ -66,7 +73,9 @@ def test_start_sandbox_stores_absolute_path(tmp_path: Path, monkeypatch: pytest.
     assert actor.state.workspace_path == (tmp_path / "workspaces" / "team-1").resolve()
 
 
-def test_start_sandbox_calls_notify_state_change(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_start_sandbox_calls_notify_state_change(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """AC1: _start_sandbox() calls state.notify_state_change() — verified via class-level patch."""
     monkeypatch.chdir(tmp_path)
     actor = make_actor(team_id="team-1")
@@ -109,7 +118,9 @@ def test_stop_sandbox_is_noop(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -
     assert result is None
 
 
-def test_stop_sandbox_does_not_remove_workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_stop_sandbox_does_not_remove_workspace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """AC3: _stop_sandbox() leaves the workspace directory intact."""
     monkeypatch.chdir(tmp_path)
     actor = make_actor(team_id="team-1")
@@ -127,7 +138,9 @@ def test_stop_sandbox_does_not_remove_workspace(tmp_path: Path, monkeypatch: pyt
 
 
 @patch("akgentic.tool.sandbox.local.subprocess.run")
-def test_exec_no_cwd_uses_workspace_path(mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_exec_no_cwd_uses_workspace_path(
+    mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """AC4: _exec(cmd, cwd='') passes state.workspace_path as cwd to subprocess.run."""
     monkeypatch.chdir(tmp_path)
     actor = make_actor(team_id="team-1")
@@ -152,7 +165,9 @@ def test_exec_no_cwd_uses_workspace_path(mock_run: MagicMock, tmp_path: Path, mo
 
 
 @patch("akgentic.tool.sandbox.local.subprocess.run")
-def test_exec_with_cwd_appends_to_workspace_path(mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_exec_with_cwd_appends_to_workspace_path(
+    mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """AC5: _exec(cmd, cwd='src') passes state.workspace_path / 'src' as cwd."""
     monkeypatch.chdir(tmp_path)
     actor = make_actor(team_id="team-1")
@@ -178,7 +193,9 @@ def test_exec_with_cwd_appends_to_workspace_path(mock_run: MagicMock, tmp_path: 
 
 
 @patch("akgentic.tool.sandbox.local.subprocess.run")
-def test_exec_returns_exec_result(mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_exec_returns_exec_result(
+    mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """_exec() returns ExecResult with stdout, stderr, exit_code from subprocess.run."""
     monkeypatch.chdir(tmp_path)
     actor = make_actor(team_id="team-1")
@@ -195,7 +212,9 @@ def test_exec_returns_exec_result(mock_run: MagicMock, tmp_path: Path, monkeypat
 
 
 @patch("akgentic.tool.sandbox.local.subprocess.run")
-def test_exec_captures_non_zero_exit_code(mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_exec_captures_non_zero_exit_code(
+    mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """_exec() correctly captures non-zero exit codes from subprocess.run."""
     monkeypatch.chdir(tmp_path)
     actor = make_actor(team_id="team-1")
@@ -215,7 +234,9 @@ def test_exec_captures_non_zero_exit_code(mock_run: MagicMock, tmp_path: Path, m
 
 
 @patch("akgentic.tool.sandbox.local.subprocess.run")
-def test_exec_timeout_propagates(mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_exec_timeout_propagates(
+    mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """AC6: subprocess.TimeoutExpired from subprocess.run propagates out of _exec()."""
     monkeypatch.chdir(tmp_path)
     actor = make_actor(team_id="team-1")
@@ -233,7 +254,9 @@ def test_exec_timeout_propagates(mock_run: MagicMock, tmp_path: Path, monkeypatc
 
 
 @patch("akgentic.tool.sandbox.local.subprocess.run")
-def test_public_exec_method_end_to_end(mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_public_exec_method_end_to_end(
+    mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """AC7: actor.exec() through inherited SandboxActor.exec() delegates to _exec()."""
     monkeypatch.chdir(tmp_path)
     actor = make_actor(team_id="team-1")

--- a/tests/sandbox/test_sandbox_actor.py
+++ b/tests/sandbox/test_sandbox_actor.py
@@ -9,9 +9,9 @@ Covers AC1 through AC9 for Story 6.1:
 
 from __future__ import annotations
 
-import pytest
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+
+import pytest
 
 from akgentic.tool.sandbox.actor import (
     ALLOWED_COMMANDS,
@@ -23,7 +23,6 @@ from akgentic.tool.sandbox.actor import (
     SandboxConfig,
     SandboxState,
 )
-
 
 # ---------------------------------------------------------------------------
 # Minimal concrete stub — required because SandboxActor is abstract
@@ -238,6 +237,15 @@ def test_exec_disallowed_command_error_message_contains_binary() -> None:
         actor.exec("malware --install")
 
 
+def test_exec_empty_command_raises_error() -> None:
+    """exec('') raises CommandNotAllowedError — empty string has no binary token."""
+    actor = ConcreteSandboxActor()
+    actor.on_start()
+
+    with pytest.raises(CommandNotAllowedError, match="empty"):
+        actor.exec("")
+
+
 # ---------------------------------------------------------------------------
 # exec() allowlist edge case (AC6)
 # ---------------------------------------------------------------------------
@@ -320,13 +328,8 @@ def test_on_stop_calls_super_on_stop() -> None:
     actor = FailingStopSandboxActor()
     actor.on_start()
 
-    super_called = False
-
-    import akgentic.tool.sandbox.actor as actor_module
-    original_super = super
-
-    # Patch super() inside on_stop to track the call
-    # Instead, we verify indirectly: on_stop() must not raise
-    # and state observer is still intact (super().on_stop() is a Pykka hook, no-op in unit tests)
+    # Verify indirectly: on_stop() must not raise.
+    # super().on_stop() is a Pykka hook (no-op in unit tests without a running actor system).
+    # If we reach the end of this call without exception, super().on_stop() was not blocked
+    # by the _stop_sandbox() failure.
     actor.on_stop()  # Should not raise
-    # If we reach here, super().on_stop() was not blocked by _stop_sandbox exception

--- a/tests/sandbox/test_sandbox_actor.py
+++ b/tests/sandbox/test_sandbox_actor.py
@@ -1,0 +1,332 @@
+"""Tests for SandboxActor base class — models, allowlist, and lifecycle.
+
+Covers AC1 through AC9 for Story 6.1:
+- SandboxConfig, SandboxState, ExecResult model validation
+- ALLOWED_COMMANDS allowlist pass/fail/edge cases
+- CommandNotAllowedError raised on disallowed binary
+- on_start() / on_stop() lifecycle via a minimal concrete stub
+"""
+
+from __future__ import annotations
+
+import pytest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from akgentic.tool.sandbox.actor import (
+    ALLOWED_COMMANDS,
+    SANDBOX_ACTOR_NAME,
+    SANDBOX_ACTOR_ROLE,
+    CommandNotAllowedError,
+    ExecResult,
+    SandboxActor,
+    SandboxConfig,
+    SandboxState,
+)
+
+
+# ---------------------------------------------------------------------------
+# Minimal concrete stub — required because SandboxActor is abstract
+# ---------------------------------------------------------------------------
+
+
+class ConcreteSandboxActor(SandboxActor):
+    """Minimal non-abstract subclass for unit testing."""
+
+    def _start_sandbox(self) -> None:
+        pass  # no-op for testing
+
+    def _stop_sandbox(self) -> None:
+        pass  # no-op for testing
+
+    def _exec(self, cmd: str, cwd: str) -> ExecResult:
+        return ExecResult(stdout="ok", stderr="", exit_code=0)
+
+
+class FailingStopSandboxActor(ConcreteSandboxActor):
+    """Subclass whose _stop_sandbox always raises, for on_stop() swallow test."""
+
+    def _stop_sandbox(self) -> None:
+        raise RuntimeError("Sandbox stop failed")
+
+
+# ---------------------------------------------------------------------------
+# Module constants
+# ---------------------------------------------------------------------------
+
+
+def test_sandbox_actor_name_constant() -> None:
+    """AC3: SANDBOX_ACTOR_NAME is the expected string."""
+    assert SANDBOX_ACTOR_NAME == "#SandboxActor"
+
+
+def test_sandbox_actor_role_constant() -> None:
+    """AC3: SANDBOX_ACTOR_ROLE is the expected string."""
+    assert SANDBOX_ACTOR_ROLE == "ToolActor"
+
+
+# ---------------------------------------------------------------------------
+# SandboxConfig model validation (AC1)
+# ---------------------------------------------------------------------------
+
+
+def test_sandbox_config_requires_team_id() -> None:
+    """SandboxConfig raises ValidationError when team_id is missing."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        SandboxConfig(name="test", role="ToolActor")  # type: ignore[call-arg]
+
+
+def test_sandbox_config_valid() -> None:
+    """SandboxConfig accepts name, role, and team_id."""
+    config = SandboxConfig(name="sandbox", role="ToolActor", team_id="team-42")
+    assert config.team_id == "team-42"
+    assert config.name == "sandbox"
+    assert config.role == "ToolActor"
+
+
+# ---------------------------------------------------------------------------
+# SandboxState model validation (AC1)
+# ---------------------------------------------------------------------------
+
+
+def test_sandbox_state_defaults() -> None:
+    """SandboxState has workspace_path=None and container_name=None by default."""
+    state = SandboxState()
+    assert state.workspace_path is None
+    assert state.container_name is None
+
+
+def test_sandbox_state_with_values() -> None:
+    """SandboxState accepts Path and string values."""
+    state = SandboxState(workspace_path=Path("/tmp/ws"), container_name="my-container")
+    assert state.workspace_path == Path("/tmp/ws")
+    assert state.container_name == "my-container"
+
+
+# ---------------------------------------------------------------------------
+# ExecResult model validation (AC1)
+# ---------------------------------------------------------------------------
+
+
+def test_exec_result_valid() -> None:
+    """ExecResult accepts stdout, stderr, exit_code."""
+    result = ExecResult(stdout="hello", stderr="", exit_code=0)
+    assert result.stdout == "hello"
+    assert result.stderr == ""
+    assert result.exit_code == 0
+
+
+def test_exec_result_requires_all_fields() -> None:
+    """ExecResult raises ValidationError when required fields are missing."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        ExecResult(stdout="hello", stderr="")  # type: ignore[call-arg]
+
+
+def test_exec_result_non_zero_exit_code() -> None:
+    """ExecResult stores non-zero exit codes."""
+    result = ExecResult(stdout="", stderr="error output", exit_code=1)
+    assert result.exit_code == 1
+    assert result.stderr == "error output"
+
+
+# ---------------------------------------------------------------------------
+# ALLOWED_COMMANDS (AC2)
+# ---------------------------------------------------------------------------
+
+
+def test_allowed_commands_is_frozenset() -> None:
+    """ALLOWED_COMMANDS is a frozenset."""
+    assert isinstance(ALLOWED_COMMANDS, frozenset)
+
+
+def test_allowed_commands_exact_set() -> None:
+    """AC2: ALLOWED_COMMANDS contains exactly the FR-SB-5 binaries."""
+    expected = frozenset(
+        {
+            "python",
+            "python3",
+            "pytest",
+            "ruff",
+            "mypy",
+            "git",
+            "uv",
+            "pip",
+            "cat",
+            "ls",
+            "find",
+            "grep",
+            "mkdir",
+            "cp",
+            "mv",
+            "rm",
+            "echo",
+            "touch",
+            "curl",
+            "wget",
+            "make",
+            "bash",
+            "sh",
+            "node",
+            "npm",
+            "npx",
+        }
+    )
+    assert ALLOWED_COMMANDS == expected
+
+
+# ---------------------------------------------------------------------------
+# exec() allowlist pass (AC4)
+# ---------------------------------------------------------------------------
+
+
+def test_exec_allowed_command_delegates_to_exec_impl() -> None:
+    """AC4: exec('python main.py') delegates to _exec and returns its ExecResult."""
+    actor = ConcreteSandboxActor()
+    actor.on_start()
+
+    result = actor.exec("python main.py")
+
+    assert isinstance(result, ExecResult)
+    assert result.stdout == "ok"
+    assert result.exit_code == 0
+
+
+def test_exec_allowed_command_passes_cmd_and_cwd() -> None:
+    """exec() passes cmd and cwd to _exec unmodified."""
+    actor = ConcreteSandboxActor()
+    actor.on_start()
+
+    received: list[tuple[str, str]] = []
+
+    original_exec = actor._exec
+
+    def capturing_exec(cmd: str, cwd: str) -> ExecResult:
+        received.append((cmd, cwd))
+        return original_exec(cmd, cwd)
+
+    actor._exec = capturing_exec  # type: ignore[method-assign]
+
+    actor.exec("python main.py", "/workspace")
+
+    assert received == [("python main.py", "/workspace")]
+
+
+# ---------------------------------------------------------------------------
+# exec() allowlist fail (AC5)
+# ---------------------------------------------------------------------------
+
+
+def test_exec_disallowed_command_raises_error() -> None:
+    """AC5: exec('malware --install') raises CommandNotAllowedError."""
+    actor = ConcreteSandboxActor()
+    actor.on_start()
+
+    with pytest.raises(CommandNotAllowedError):
+        actor.exec("malware --install")
+
+
+def test_exec_disallowed_command_error_message_contains_binary() -> None:
+    """CommandNotAllowedError message names the disallowed binary."""
+    actor = ConcreteSandboxActor()
+    actor.on_start()
+
+    with pytest.raises(CommandNotAllowedError, match="malware"):
+        actor.exec("malware --install")
+
+
+# ---------------------------------------------------------------------------
+# exec() allowlist edge case (AC6)
+# ---------------------------------------------------------------------------
+
+
+def test_exec_rm_rf_passes_allowlist() -> None:
+    """AC6: exec('rm -rf /') passes — only 'rm' binary is checked, not args."""
+    actor = ConcreteSandboxActor()
+    actor.on_start()
+
+    # Should NOT raise — 'rm' is in ALLOWED_COMMANDS
+    result = actor.exec("rm -rf /")
+    assert isinstance(result, ExecResult)
+
+
+# ---------------------------------------------------------------------------
+# on_start() lifecycle (AC7)
+# ---------------------------------------------------------------------------
+
+
+def test_on_start_initializes_state() -> None:
+    """AC7: on_start() creates a SandboxState instance."""
+    actor = ConcreteSandboxActor()
+    actor.on_start()
+
+    assert isinstance(actor.state, SandboxState)
+
+
+def test_on_start_calls_start_sandbox() -> None:
+    """AC7: on_start() calls _start_sandbox()."""
+    actor = ConcreteSandboxActor()
+    call_count = 0
+
+    original = actor._start_sandbox
+
+    def tracking_start() -> None:
+        nonlocal call_count
+        call_count += 1
+        original()
+
+    actor._start_sandbox = tracking_start  # type: ignore[method-assign]
+    actor.on_start()
+
+    assert call_count == 1
+
+
+def test_on_start_registers_state_observer() -> None:
+    """on_start() registers the actor as a state observer."""
+    actor = ConcreteSandboxActor()
+    actor.on_start()
+
+    # The state's _observer should be the actor itself
+    assert actor.state._observer is actor
+
+
+# ---------------------------------------------------------------------------
+# on_stop() exception swallowing (AC8)
+# ---------------------------------------------------------------------------
+
+
+def test_on_stop_swallows_stop_sandbox_exception() -> None:
+    """AC8: on_stop() swallows exceptions from _stop_sandbox() — does not propagate."""
+    actor = FailingStopSandboxActor()
+    actor.on_start()
+
+    # Must not raise even though _stop_sandbox() raises RuntimeError
+    actor.on_stop()  # Should complete without exception
+
+
+def test_on_stop_no_exception_completes_normally() -> None:
+    """on_stop() completes normally when _stop_sandbox() does not raise."""
+    actor = ConcreteSandboxActor()
+    actor.on_start()
+
+    actor.on_stop()  # Should complete without exception
+
+
+def test_on_stop_calls_super_on_stop() -> None:
+    """AC8: on_stop() calls super().on_stop() even when _stop_sandbox() raises."""
+    actor = FailingStopSandboxActor()
+    actor.on_start()
+
+    super_called = False
+
+    import akgentic.tool.sandbox.actor as actor_module
+    original_super = super
+
+    # Patch super() inside on_stop to track the call
+    # Instead, we verify indirectly: on_stop() must not raise
+    # and state observer is still intact (super().on_stop() is a Pykka hook, no-op in unit tests)
+    actor.on_stop()  # Should not raise
+    # If we reach here, super().on_stop() was not blocked by _stop_sandbox exception


### PR DESCRIPTION
## Summary

- Implements `DockerSandboxActor` in `sandbox/docker.py` as a persistent Docker container sandbox per team
- Container reuse: `docker start` if named container exists (any state), `docker run -d` if absent — no `docker rm` on stop (NFR-SB-5 preserved)
- Network isolation: `--network none` enforced on all sandbox containers (NFR-SB-3)
- Volume mount: `workspaces/{team_id}:/workspace` — zero-sync file sharing with `WorkspaceTool`
- Constants: `DOCKER_EXEC_TIMEOUT=60`, `SANDBOX_IMAGE="akgentic-sandbox:latest"`
- 21 unit tests, 100% branch coverage — all subprocess calls mocked, no real Docker required

## Review fixes applied

- **Bug fix**: Container existence check changed from substring (`in check.stdout`) to exact line match (`in check.stdout.splitlines()`) — prevents false-positive container reuse when team IDs share a prefix (e.g. `team-1` matching `sandbox-team-10` output from `docker ps`)
- **Ruff F401**: Removed unused `call` import from `unittest.mock` in test file
- **Ruff E501**: Shortened overlong docstring line (103 → 100 chars) in test file
- **New test**: `test_start_sandbox_no_false_positive_on_prefix_container_name` explicitly validates exact-line matching behavior

Closes #61