### PR TITLE
feat: workspace_id parity with WorkspaceTool (story 6.6)

### DIFF
--- a/src/akgentic/tool/__init__.py
+++ b/src/akgentic/tool/__init__.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 # Submodules with their own __init__ files
-from . import mcp, planning, search, team, workspace  # noqa: F401
+from . import mcp, planning, sandbox, search, team, workspace  # noqa: F401
+from .sandbox.tool import ExecTool  # noqa: F401
 from .workspace.tool import WorkspaceReadTool, WorkspaceTool  # noqa: F401
 from .core import (  # noqa: F401
     COMMAND,
@@ -49,9 +50,11 @@ __all__ = [
     # Submodules
     "mcp",
     "planning",
+    "sandbox",
     "search",
     "team",
     "workspace",
+    "ExecTool",
     "WorkspaceReadTool",
     "WorkspaceTool",
 ]

--- a/src/akgentic/tool/__init__.py
+++ b/src/akgentic/tool/__init__.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 # Submodules with their own __init__ files
 from . import mcp, planning, sandbox, search, team, workspace  # noqa: F401
-from .sandbox.tool import ExecTool  # noqa: F401
-from .workspace.tool import WorkspaceReadTool, WorkspaceTool  # noqa: F401
 from .core import (  # noqa: F401
     COMMAND,
     SYSTEM_PROMPT,
@@ -22,6 +20,8 @@ from .event import (  # noqa: F401
     ToolCallEvent,
     ToolObserver,
 )
+from .sandbox.tool import ExecTool  # noqa: F401
+from .workspace.tool import WorkspaceReadTool, WorkspaceTool  # noqa: F401
 
 try:
     from .vector import EmbeddingService, VectorEntry, VectorIndex  # noqa: F401

--- a/src/akgentic/tool/core.py
+++ b/src/akgentic/tool/core.py
@@ -11,8 +11,7 @@ from abc import ABC, abstractmethod
 from enum import StrEnum
 from typing import Any, Callable, TypeVar
 
-from pydantic import BaseModel
-
+from akgentic.core.utils import SerializableBaseModel
 from akgentic.tool.errors import RetriableError
 from akgentic.tool.event import ToolObserver
 
@@ -56,7 +55,7 @@ TOOL_CALL = Channels.TOOL_CALL
 COMMAND = Channels.COMMAND
 
 
-class BaseToolParam(BaseModel):
+class BaseToolParam(SerializableBaseModel):
     """Base for capability parameter models.
 
     Provides common fields that control how a capability is exposed
@@ -100,7 +99,7 @@ class BaseToolParam(BaseModel):
         return f"{base_doc}\n\nAdditional Instructions:\n{self.instructions}"
 
 
-class ToolCard(BaseModel, ABC):
+class ToolCard(SerializableBaseModel, ABC):
     """Abstract base: tool configuration + callable factory in one class.
 
     Subclasses define typed fields for their capabilities and implement

--- a/src/akgentic/tool/sandbox/__init__.py
+++ b/src/akgentic/tool/sandbox/__init__.py
@@ -1,3 +1,29 @@
-"""Sandbox submodule — placeholder exports (full exports added in Story 6.4)."""
+"""Sandbox submodule — sandboxed shell execution for SWE agents."""
 
 from __future__ import annotations
+
+from .actor import (
+    ALLOWED_COMMANDS,
+    SANDBOX_ACTOR_NAME,
+    CommandNotAllowedError,
+    ExecResult,
+    SandboxActor,
+    SandboxConfig,
+    SandboxState,
+)
+from .docker import DockerSandboxActor
+from .local import LocalSandboxActor
+from .tool import ExecTool
+
+__all__ = [
+    "ALLOWED_COMMANDS",
+    "CommandNotAllowedError",
+    "DockerSandboxActor",
+    "ExecResult",
+    "ExecTool",
+    "LocalSandboxActor",
+    "SANDBOX_ACTOR_NAME",
+    "SandboxActor",
+    "SandboxConfig",
+    "SandboxState",
+]

--- a/src/akgentic/tool/sandbox/__init__.py
+++ b/src/akgentic/tool/sandbox/__init__.py
@@ -1,0 +1,3 @@
+"""Sandbox submodule — placeholder exports (full exports added in Story 6.4)."""
+
+from __future__ import annotations

--- a/src/akgentic/tool/sandbox/actor.py
+++ b/src/akgentic/tool/sandbox/actor.py
@@ -67,11 +67,16 @@ class SandboxConfig(BaseConfig):
 
     Attributes:
         team_id: Identifier of the team that owns this sandbox.
+        workspace_id: Optional workspace directory name override.  When ``None``
+            (default), the workspace directory is named after ``team_id``.  When
+            set, the named directory is used instead.  Docker container name
+            always uses ``team_id`` — containers are per-team, not per-workspace.
         mode: Execution backend — ``"local"`` (subprocess) or ``"docker"``
             (persistent container).  Defaults to ``"local"``.
     """
 
     team_id: str
+    workspace_id: str | None = None
     mode: Literal["local", "docker"] = "local"
 
 

--- a/src/akgentic/tool/sandbox/actor.py
+++ b/src/akgentic/tool/sandbox/actor.py
@@ -1,0 +1,215 @@
+"""SandboxActor — abstract base class for sandbox execution backends.
+
+Defines models, the command allowlist, module constants, and the lifecycle/exec
+contract. Concrete subclasses (LocalSandboxActor, DockerSandboxActor) provide
+the execution backend by implementing _start_sandbox, _stop_sandbox, and _exec.
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from pathlib import Path
+
+from pydantic import BaseModel
+
+from akgentic.core.agent import Akgent, BaseConfig, BaseState
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Module-level constants
+# ---------------------------------------------------------------------------
+
+SANDBOX_ACTOR_NAME: str = "#SandboxActor"
+SANDBOX_ACTOR_ROLE: str = "ToolActor"
+
+ALLOWED_COMMANDS: frozenset[str] = frozenset(
+    {
+        "python",
+        "python3",
+        "pytest",
+        "ruff",
+        "mypy",
+        "git",
+        "uv",
+        "pip",
+        "cat",
+        "ls",
+        "find",
+        "grep",
+        "mkdir",
+        "cp",
+        "mv",
+        "rm",
+        "echo",
+        "touch",
+        "curl",
+        "wget",
+        "make",
+        "bash",
+        "sh",
+        "node",
+        "npm",
+        "npx",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Data models
+# ---------------------------------------------------------------------------
+
+
+class SandboxConfig(BaseConfig):
+    """Configuration for a SandboxActor.
+
+    Attributes:
+        team_id: Identifier of the team that owns this sandbox.
+    """
+
+    team_id: str
+
+
+class SandboxState(BaseState):
+    """Runtime state for a SandboxActor.
+
+    Attributes:
+        workspace_path: Path to the workspace directory on the host, or None if
+            the sandbox has not been started yet.
+        container_name: Name of the Docker container, or None if not applicable.
+    """
+
+    workspace_path: Path | None = None
+    container_name: str | None = None
+
+
+class ExecResult(BaseModel):
+    """Result of a sandbox command execution.
+
+    Attributes:
+        stdout: Captured standard output from the command.
+        stderr: Captured standard error from the command.
+        exit_code: Process exit code (0 indicates success).
+    """
+
+    stdout: str
+    stderr: str
+    exit_code: int
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class CommandNotAllowedError(Exception):
+    """Raised when exec() is called with a command binary not in ALLOWED_COMMANDS.
+
+    Only the first token (binary name) of the command string is checked.
+    Argument-level filtering is out of scope for the base class.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Abstract actor
+# ---------------------------------------------------------------------------
+
+
+class SandboxActor(Akgent[SandboxConfig, SandboxState], ABC):
+    """Abstract sandbox actor. Concrete subclasses provide the execution backend.
+
+    Responsibilities of this base class:
+    - Initialize and manage SandboxState via on_start / on_stop lifecycle hooks.
+    - Enforce the command allowlist before delegating to _exec.
+    - Define the abstract interface (_start_sandbox, _stop_sandbox, _exec) that
+      subclasses must implement.
+    """
+
+    def on_start(self) -> None:
+        """Initialize SandboxState and start the sandbox backend.
+
+        Registers the actor as a state observer (required for Pykka telemetry),
+        then delegates to _start_sandbox() for backend-specific setup.
+        """
+        self.state = SandboxState()
+        self.state.observer(self)
+        self._start_sandbox()
+
+    def on_stop(self) -> None:
+        """Stop the sandbox backend, swallowing any exceptions.
+
+        Calls _stop_sandbox() inside a try/except so that any backend error
+        does not prevent super().on_stop() from running. Leaving Pykka actors
+        in a broken state by raising in on_stop() is a critical failure mode
+        that this pattern prevents.
+        """
+        try:
+            self._stop_sandbox()
+        except Exception:
+            logger.warning(
+                "SandboxActor._stop_sandbox() raised during on_stop — swallowing",
+                exc_info=True,
+            )
+        super().on_stop()
+
+    def exec(self, cmd: str, cwd: str = "") -> ExecResult:
+        """Execute a command inside the sandbox after allowlist validation.
+
+        Only the first whitespace-delimited token (the binary name) is checked
+        against ALLOWED_COMMANDS. Argument-level filtering is out of scope.
+
+        Args:
+            cmd: Full command string to execute (e.g. "python main.py").
+            cwd: Working directory inside the sandbox. Defaults to "".
+
+        Returns:
+            ExecResult with stdout, stderr, and exit_code from the backend.
+
+        Raises:
+            CommandNotAllowedError: If the command binary is not in ALLOWED_COMMANDS.
+        """
+        binary = cmd.split()[0]
+        if binary not in ALLOWED_COMMANDS:
+            raise CommandNotAllowedError(
+                f"Command '{binary}' is not in the allowed commands list. "
+                f"Allowed: {sorted(ALLOWED_COMMANDS)}"
+            )
+        return self._exec(cmd, cwd)
+
+    # ------------------------------------------------------------------
+    # Abstract methods — must be implemented by concrete subclasses
+    # ------------------------------------------------------------------
+
+    @abstractmethod
+    def _start_sandbox(self) -> None:
+        """Start the sandbox execution environment.
+
+        Called from on_start() after SandboxState is initialized. Subclasses
+        should provision any resources needed (e.g., create a temp directory,
+        start a Docker container).
+        """
+
+    @abstractmethod
+    def _stop_sandbox(self) -> None:
+        """Stop and clean up the sandbox execution environment.
+
+        Called from on_stop() inside a try/except. Subclasses should release
+        resources (e.g., remove temp directory, stop a Docker container).
+        May raise — the caller swallows all exceptions.
+        """
+
+    @abstractmethod
+    def _exec(self, cmd: str, cwd: str) -> ExecResult:
+        """Execute a pre-validated command inside the sandbox.
+
+        Called by exec() after the allowlist check passes. Subclasses handle
+        the actual process execution (subprocess, Docker exec API, etc.).
+
+        Args:
+            cmd: Full command string (already validated by exec()).
+            cwd: Working directory inside the sandbox.
+
+        Returns:
+            ExecResult with captured stdout, stderr, and exit code.
+        """

--- a/src/akgentic/tool/sandbox/actor.py
+++ b/src/akgentic/tool/sandbox/actor.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import logging
 from abc import ABC, abstractmethod
 from pathlib import Path
+from typing import Literal
 
 from pydantic import BaseModel
 
@@ -66,9 +67,12 @@ class SandboxConfig(BaseConfig):
 
     Attributes:
         team_id: Identifier of the team that owns this sandbox.
+        mode: Execution backend — ``"local"`` (subprocess) or ``"docker"``
+            (persistent container).  Defaults to ``"local"``.
     """
 
     team_id: str
+    mode: Literal["local", "docker"] = "local"
 
 
 class SandboxState(BaseState):

--- a/src/akgentic/tool/sandbox/actor.py
+++ b/src/akgentic/tool/sandbox/actor.py
@@ -169,7 +169,12 @@ class SandboxActor(Akgent[SandboxConfig, SandboxState], ABC):
         Raises:
             CommandNotAllowedError: If the command binary is not in ALLOWED_COMMANDS.
         """
-        binary = cmd.split()[0]
+        tokens = cmd.split()
+        if not tokens:
+            raise CommandNotAllowedError(
+                "Command string is empty — no binary to validate against the allowlist."
+            )
+        binary = tokens[0]
         if binary not in ALLOWED_COMMANDS:
             raise CommandNotAllowedError(
                 f"Command '{binary}' is not in the allowed commands list. "

--- a/src/akgentic/tool/sandbox/docker.py
+++ b/src/akgentic/tool/sandbox/docker.py
@@ -29,7 +29,8 @@ class DockerSandboxActor(SandboxActor):
                 "docker CLI not found on PATH — cannot start DockerSandboxActor"
             )
         base = os.environ.get("AKGENTIC_WORKSPACES_ROOT", "./workspaces")
-        volume = f"{Path(base) / self.config.team_id}:/workspace"
+        ws_name = self.config.workspace_id or self.config.team_id
+        volume = f"{Path(base) / ws_name}:/workspace"
         # Check if container already exists (any state)
         check = subprocess.run(
             [

--- a/src/akgentic/tool/sandbox/docker.py
+++ b/src/akgentic/tool/sandbox/docker.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 
@@ -16,7 +17,8 @@ class DockerSandboxActor(SandboxActor):
 
     Manages a single Docker container named sandbox-{team_id}.
     Container is started (or reused) on on_start(), stopped (not removed)
-    on on_stop(). Used when SANDBOX_MODE=docker.
+    on on_stop(). The host-side volume mount root is derived from the
+    ``AKGENTIC_WORKSPACES_ROOT`` environment variable (default: ``./workspaces``).
     """
 
     def _start_sandbox(self) -> None:
@@ -25,6 +27,8 @@ class DockerSandboxActor(SandboxActor):
             raise RuntimeError(
                 "docker CLI not found on PATH — cannot start DockerSandboxActor"
             )
+        base = os.environ.get("AKGENTIC_WORKSPACES_ROOT", "./workspaces")
+        volume = f"{base}/{self.config.team_id}:/workspace"
         # Check if container already exists (any state)
         check = subprocess.run(
             [
@@ -57,7 +61,7 @@ class DockerSandboxActor(SandboxActor):
                     "--network",
                     "none",
                     "-v",
-                    f"workspaces/{self.config.team_id}:/workspace",
+                    volume,
                     "-w",
                     "/workspace",
                     SANDBOX_IMAGE,

--- a/src/akgentic/tool/sandbox/docker.py
+++ b/src/akgentic/tool/sandbox/docker.py
@@ -1,0 +1,103 @@
+"""DockerSandboxActor — persistent Docker container per team."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+
+from akgentic.tool.sandbox.actor import ExecResult, SandboxActor
+
+SANDBOX_IMAGE: str = "akgentic-sandbox:latest"
+DOCKER_EXEC_TIMEOUT: int = 60
+
+
+class DockerSandboxActor(SandboxActor):
+    """Persistent Docker container sandbox per team.
+
+    Manages a single Docker container named sandbox-{team_id}.
+    Container is started (or reused) on on_start(), stopped (not removed)
+    on on_stop(). Used when SANDBOX_MODE=docker.
+    """
+
+    def _start_sandbox(self) -> None:
+        container_name = f"sandbox-{self.config.team_id}"
+        if shutil.which("docker") is None:
+            raise RuntimeError(
+                "docker CLI not found on PATH — cannot start DockerSandboxActor"
+            )
+        # Check if container already exists (any state)
+        check = subprocess.run(
+            [
+                "docker",
+                "ps",
+                "-a",
+                "--filter",
+                f"name={container_name}",
+                "--format",
+                "{{.Names}}",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if container_name in check.stdout:
+            subprocess.run(
+                ["docker", "start", container_name],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+        else:
+            subprocess.run(
+                [
+                    "docker",
+                    "run",
+                    "-d",
+                    "--name",
+                    container_name,
+                    "--network",
+                    "none",
+                    "-v",
+                    f"workspaces/{self.config.team_id}:/workspace",
+                    "-w",
+                    "/workspace",
+                    SANDBOX_IMAGE,
+                    "sleep",
+                    "infinity",
+                ],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+        self.state.container_name = container_name
+        self.state.notify_state_change()
+
+    def _stop_sandbox(self) -> None:
+        assert self.state.container_name is not None
+        subprocess.run(
+            ["docker", "stop", self.state.container_name],
+            capture_output=True,
+            text=True,
+        )
+        # Do NOT run docker rm — container filesystem preserved between restarts
+
+    def _exec(self, cmd: str, cwd: str) -> ExecResult:
+        assert self.state.container_name is not None
+        effective_workdir = f"/workspace/{cwd}" if cwd else "/workspace"
+        docker_cmd = [
+            "docker",
+            "exec",
+            "-w",
+            effective_workdir,
+            self.state.container_name,
+        ] + cmd.split()
+        result = subprocess.run(
+            docker_cmd,
+            capture_output=True,
+            text=True,
+            timeout=DOCKER_EXEC_TIMEOUT,
+        )
+        return ExecResult(
+            stdout=result.stdout,
+            stderr=result.stderr,
+            exit_code=result.returncode,
+        )

--- a/src/akgentic/tool/sandbox/docker.py
+++ b/src/akgentic/tool/sandbox/docker.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+from pathlib import Path
 
 from akgentic.tool.sandbox.actor import ExecResult, SandboxActor
 
@@ -28,7 +29,7 @@ class DockerSandboxActor(SandboxActor):
                 "docker CLI not found on PATH — cannot start DockerSandboxActor"
             )
         base = os.environ.get("AKGENTIC_WORKSPACES_ROOT", "./workspaces")
-        volume = f"{base}/{self.config.team_id}:/workspace"
+        volume = f"{Path(base) / self.config.team_id}:/workspace"
         # Check if container already exists (any state)
         check = subprocess.run(
             [

--- a/src/akgentic/tool/sandbox/docker.py
+++ b/src/akgentic/tool/sandbox/docker.py
@@ -39,7 +39,7 @@ class DockerSandboxActor(SandboxActor):
             capture_output=True,
             text=True,
         )
-        if container_name in check.stdout:
+        if container_name in check.stdout.splitlines():
             subprocess.run(
                 ["docker", "start", container_name],
                 capture_output=True,

--- a/src/akgentic/tool/sandbox/docker.py
+++ b/src/akgentic/tool/sandbox/docker.py
@@ -16,10 +16,13 @@ DOCKER_EXEC_TIMEOUT: int = 60
 class DockerSandboxActor(SandboxActor):
     """Persistent Docker container sandbox per team.
 
-    Manages a single Docker container named sandbox-{team_id}.
+    Manages a single Docker container named ``sandbox-{team_id}``.
     Container is started (or reused) on on_start(), stopped (not removed)
-    on on_stop(). The host-side volume mount root is derived from the
-    ``AKGENTIC_WORKSPACES_ROOT`` environment variable (default: ``./workspaces``).
+    on on_stop(). The host-side volume mount path uses
+    ``{AKGENTIC_WORKSPACES_ROOT}/{workspace_id or team_id}`` so that when
+    ``SandboxConfig.workspace_id`` is set, the mounted directory matches the
+    one used by ``WorkspaceTool(workspace_id=...)``. The container name always
+    uses ``team_id`` — containers are per-team execution resources.
     """
 
     def _start_sandbox(self) -> None:

--- a/src/akgentic/tool/sandbox/local.py
+++ b/src/akgentic/tool/sandbox/local.py
@@ -13,8 +13,10 @@ class LocalSandboxActor(SandboxActor):
     """Subprocess-based sandbox actor for local filesystem execution.
 
     Creates and manages a workspace directory under
-    ``<AKGENTIC_WORKSPACES_ROOT>/{team_id}/`` (default root: ``./workspaces``).
-    No Docker daemon required.
+    ``<AKGENTIC_WORKSPACES_ROOT>/{workspace_id or team_id}/`` (default root:
+    ``./workspaces``). When ``SandboxConfig.workspace_id`` is set, that value is
+    used as the directory name instead of ``team_id``, enabling directory sharing
+    with ``WorkspaceTool(workspace_id=...)``. No Docker daemon required.
     """
 
     def _start_sandbox(self) -> None:

--- a/src/akgentic/tool/sandbox/local.py
+++ b/src/akgentic/tool/sandbox/local.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 from pathlib import Path
 
@@ -11,12 +12,14 @@ from akgentic.tool.sandbox.actor import ExecResult, SandboxActor
 class LocalSandboxActor(SandboxActor):
     """Subprocess-based sandbox actor for local filesystem execution.
 
-    Creates and manages a workspace directory under ./workspaces/{team_id}/.
-    No Docker daemon required. Used when SANDBOX_MODE=local (default).
+    Creates and manages a workspace directory under
+    ``<AKGENTIC_WORKSPACES_ROOT>/{team_id}/`` (default root: ``./workspaces``).
+    No Docker daemon required.
     """
 
     def _start_sandbox(self) -> None:
-        workspace_path = Path(f"./workspaces/{self.config.team_id}")
+        base = os.environ.get("AKGENTIC_WORKSPACES_ROOT", "./workspaces")
+        workspace_path = Path(base) / self.config.team_id
         workspace_path.mkdir(parents=True, exist_ok=True)
         self.state.workspace_path = workspace_path.resolve()
         self.state.notify_state_change()

--- a/src/akgentic/tool/sandbox/local.py
+++ b/src/akgentic/tool/sandbox/local.py
@@ -1,0 +1,41 @@
+"""LocalSandboxActor — subprocess-based sandbox for local filesystem execution."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from akgentic.tool.sandbox.actor import ExecResult, SandboxActor
+
+
+class LocalSandboxActor(SandboxActor):
+    """Subprocess-based sandbox actor for local filesystem execution.
+
+    Creates and manages a workspace directory under ./workspaces/{team_id}/.
+    No Docker daemon required. Used when SANDBOX_MODE=local (default).
+    """
+
+    def _start_sandbox(self) -> None:
+        workspace_path = Path(f"./workspaces/{self.config.team_id}")
+        workspace_path.mkdir(parents=True, exist_ok=True)
+        self.state.workspace_path = workspace_path.resolve()
+        self.state.notify_state_change()
+
+    def _stop_sandbox(self) -> None:
+        pass  # no persistent resource to tear down
+
+    def _exec(self, cmd: str, cwd: str) -> ExecResult:
+        assert self.state.workspace_path is not None
+        effective_cwd = self.state.workspace_path / cwd if cwd else self.state.workspace_path
+        result = subprocess.run(
+            cmd.split(),
+            cwd=str(effective_cwd),
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        return ExecResult(
+            stdout=result.stdout,
+            stderr=result.stderr,
+            exit_code=result.returncode,
+        )

--- a/src/akgentic/tool/sandbox/local.py
+++ b/src/akgentic/tool/sandbox/local.py
@@ -19,7 +19,8 @@ class LocalSandboxActor(SandboxActor):
 
     def _start_sandbox(self) -> None:
         base = os.environ.get("AKGENTIC_WORKSPACES_ROOT", "./workspaces")
-        workspace_path = Path(base) / self.config.team_id
+        ws_name = self.config.workspace_id or self.config.team_id
+        workspace_path = Path(base) / ws_name
         workspace_path.mkdir(parents=True, exist_ok=True)
         self.state.workspace_path = workspace_path.resolve()
         self.state.notify_state_change()

--- a/src/akgentic/tool/sandbox/tool.py
+++ b/src/akgentic/tool/sandbox/tool.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-import os
-from typing import Any, Callable
+from typing import Any, Callable, Literal
 
 from pydantic import PrivateAttr
 
@@ -53,13 +52,14 @@ class ExecTool(ToolCard):
     name: str = "Exec"
     description: str = "Execute sandboxed shell commands in the team workspace"
     exec_command: ExecCommand | bool = True
+    mode: Literal["local", "docker"] = "local"
 
     _sandbox_proxy: SandboxActor | None = PrivateAttr(default=None)
 
     def observer(self, observer: ActorToolObserver) -> "ExecTool":  # type: ignore[override]
         """Attach observer and set up the sandbox actor proxy.
 
-        Resolves SANDBOX_ACTOR_CLASSES[SANDBOX_MODE] at call time (not import
+        Resolves ``SANDBOX_ACTOR_CLASSES[self.mode]`` at call time (not import
         time) so that akgentic-infra can inject additional actor classes before
         any ExecTool is constructed (NFR-SB-7).
 
@@ -71,7 +71,7 @@ class ExecTool(ToolCard):
 
         Raises:
             ValueError: If observer.orchestrator is None.
-            KeyError: If SANDBOX_MODE env var names an unregistered backend.
+            KeyError: If ``self.mode`` names an unregistered backend.
         """
         self._observer = observer
         if observer.orchestrator is None:
@@ -81,15 +81,15 @@ class ExecTool(ToolCard):
         sandbox_addr = orchestrator_proxy.get_team_member(SANDBOX_ACTOR_NAME)
 
         if sandbox_addr is None:
-            sandbox_mode = os.environ.get("SANDBOX_MODE", "local")
             # KeyError on unknown mode — intentional (fail-fast, NFR-SB-7)
-            actor_class = SANDBOX_ACTOR_CLASSES[sandbox_mode]
+            actor_class = SANDBOX_ACTOR_CLASSES[self.mode]
             sandbox_addr = orchestrator_proxy.createActor(
                 actor_class,
                 config=SandboxConfig(
                     name=SANDBOX_ACTOR_NAME,
                     role="ToolActor",
                     team_id=str(observer._team_id),  # type: ignore[attr-defined]
+                    mode=self.mode,
                 ),
             )
 

--- a/src/akgentic/tool/sandbox/tool.py
+++ b/src/akgentic/tool/sandbox/tool.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Callable, Literal
 
 from pydantic import PrivateAttr
@@ -18,6 +19,9 @@ from akgentic.tool.sandbox.actor import (
 )
 from akgentic.tool.sandbox.docker import DockerSandboxActor
 from akgentic.tool.sandbox.local import LocalSandboxActor
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 # ---------------------------------------------------------------------------
 # SANDBOX_ACTOR_CLASSES — mutable injection window for runtime registration
@@ -53,6 +57,7 @@ class ExecTool(ToolCard):
     description: str = "Execute sandboxed shell commands in the team workspace"
     exec_command: ExecCommand | bool = True
     mode: Literal["local", "docker"] = "local"
+    workspace_id: str | None = None
 
     _sandbox_proxy: SandboxActor | None = PrivateAttr(default=None)
 
@@ -61,7 +66,9 @@ class ExecTool(ToolCard):
 
         Resolves ``SANDBOX_ACTOR_CLASSES[self.mode]`` at call time (not import
         time) so that akgentic-infra can inject additional actor classes before
-        any ExecTool is constructed (NFR-SB-7).
+        any ExecTool is constructed (NFR-SB-7).  ``self.workspace_id`` is
+        forwarded to ``SandboxConfig`` so the sandbox backend uses the same
+        workspace directory as ``WorkspaceTool(workspace_id=...)``.
 
         Args:
             observer: Actor-aware observer providing orchestrator access.
@@ -81,6 +88,7 @@ class ExecTool(ToolCard):
         sandbox_addr = orchestrator_proxy.get_team_member(SANDBOX_ACTOR_NAME)
 
         if sandbox_addr is None:
+            logger.info(f"ExecTool: create {SANDBOX_ACTOR_NAME}.")
             # KeyError on unknown mode — intentional (fail-fast, NFR-SB-7)
             actor_class = SANDBOX_ACTOR_CLASSES[self.mode]
             sandbox_addr = orchestrator_proxy.createActor(
@@ -89,6 +97,7 @@ class ExecTool(ToolCard):
                     name=SANDBOX_ACTOR_NAME,
                     role="ToolActor",
                     team_id=str(observer._team_id),  # type: ignore[attr-defined]
+                    workspace_id=self.workspace_id,
                     mode=self.mode,
                 ),
             )

--- a/src/akgentic/tool/sandbox/tool.py
+++ b/src/akgentic/tool/sandbox/tool.py
@@ -1,0 +1,133 @@
+"""ExecTool — ToolCard proxy for SandboxActor execution backend."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Callable
+
+from pydantic import PrivateAttr
+
+from akgentic.core.orchestrator import Orchestrator
+from akgentic.tool.core import TOOL_CALL, BaseToolParam, Channels, ToolCard, _resolve
+from akgentic.tool.event import ActorToolObserver
+from akgentic.tool.sandbox.actor import (
+    ALLOWED_COMMANDS,
+    SANDBOX_ACTOR_NAME,
+    CommandNotAllowedError,
+    SandboxActor,
+    SandboxConfig,
+)
+from akgentic.tool.sandbox.docker import DockerSandboxActor
+from akgentic.tool.sandbox.local import LocalSandboxActor
+
+# ---------------------------------------------------------------------------
+# SANDBOX_ACTOR_CLASSES — mutable injection window for runtime registration
+# ---------------------------------------------------------------------------
+
+SANDBOX_ACTOR_CLASSES: dict[str, type[SandboxActor]] = {
+    "local": LocalSandboxActor,
+    "docker": DockerSandboxActor,
+    # "e2b": E2BSandboxActor  ← injected by akgentic-infra at runtime
+}
+
+
+# ---------------------------------------------------------------------------
+# Capability parameter model
+# ---------------------------------------------------------------------------
+
+
+class ExecCommand(BaseToolParam):
+    """Execute a sandboxed shell command in the team workspace."""
+
+    expose: set[Channels] = {TOOL_CALL}
+
+
+# ---------------------------------------------------------------------------
+# ExecTool ToolCard
+# ---------------------------------------------------------------------------
+
+
+class ExecTool(ToolCard):
+    """ToolCard proxy that routes shell commands to the team's SandboxActor."""
+
+    name: str = "Exec"
+    description: str = "Execute sandboxed shell commands in the team workspace"
+    exec_command: ExecCommand | bool = True
+
+    _sandbox_proxy: SandboxActor | None = PrivateAttr(default=None)
+
+    def observer(self, observer: ActorToolObserver) -> "ExecTool":  # type: ignore[override]
+        """Attach observer and set up the sandbox actor proxy.
+
+        Resolves SANDBOX_ACTOR_CLASSES[SANDBOX_MODE] at call time (not import
+        time) so that akgentic-infra can inject additional actor classes before
+        any ExecTool is constructed (NFR-SB-7).
+
+        Args:
+            observer: Actor-aware observer providing orchestrator access.
+
+        Returns:
+            Self, for method chaining.
+
+        Raises:
+            ValueError: If observer.orchestrator is None.
+            KeyError: If SANDBOX_MODE env var names an unregistered backend.
+        """
+        self._observer = observer
+        if observer.orchestrator is None:
+            raise ValueError("ExecTool requires access to the orchestrator.")
+
+        orchestrator_proxy = observer.proxy_ask(observer.orchestrator, Orchestrator)
+        sandbox_addr = orchestrator_proxy.get_team_member(SANDBOX_ACTOR_NAME)
+
+        if sandbox_addr is None:
+            sandbox_mode = os.environ.get("SANDBOX_MODE", "local")
+            # KeyError on unknown mode — intentional (fail-fast, NFR-SB-7)
+            actor_class = SANDBOX_ACTOR_CLASSES[sandbox_mode]
+            sandbox_addr = orchestrator_proxy.createActor(
+                actor_class,
+                config=SandboxConfig(
+                    name=SANDBOX_ACTOR_NAME,
+                    role="ToolActor",
+                    team_id=str(observer._team_id),  # type: ignore[attr-defined]
+                ),
+            )
+
+        self._sandbox_proxy = observer.proxy_ask(sandbox_addr, SandboxActor)
+        return self
+
+    def get_tools(self) -> list[Callable[..., Any]]:
+        """Return the exec_command tool callable when enabled."""
+        tools: list[Callable[..., Any]] = []
+        ec = _resolve(self.exec_command, ExecCommand)
+        if ec is not None and TOOL_CALL in ec.expose:
+            tools.append(self._exec_command_factory(ec))
+        return tools
+
+    def _exec_command_factory(self, params: ExecCommand) -> Callable[..., Any]:
+        """Build the exec_command callable bound to the sandbox proxy."""
+        assert self._sandbox_proxy is not None, "_sandbox_proxy must be set before get_tools()"
+        sandbox_proxy = self._sandbox_proxy
+
+        def exec_command(cmd: str, cwd: str = "") -> str:
+            """Execute a sandboxed shell command in the team workspace.
+
+            Args:
+                cmd: Full command string. The binary (first token) must be in the allow-list.
+                cwd: Subdirectory relative to workspace root. Defaults to workspace root.
+
+            Returns:
+                Combined stdout, stderr, and exit code summary as a string.
+                On disallowed command: error string listing allowed commands.
+            """
+            try:
+                result = sandbox_proxy.exec(cmd, cwd)
+                return (
+                    f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+                    f"\nexit_code: {result.exit_code}"
+                )
+            except CommandNotAllowedError as e:
+                return f"CommandNotAllowedError: {e}. Allowed commands: {sorted(ALLOWED_COMMANDS)}"
+
+        exec_command.__doc__ = params.format_docstring(exec_command.__doc__)
+        return exec_command

--- a/src/akgentic/tool/workspace/workspace.py
+++ b/src/akgentic/tool/workspace/workspace.py
@@ -4,7 +4,8 @@ Provides a secure, team-scoped filesystem backend for workspace tools.
 All path operations validate that the resolved path stays within the workspace root
 to prevent directory traversal attacks.
 
-Unknown WORKSPACE_MODE values raise KeyError intentionally (fail-fast behaviour).
+The workspace root is derived from the ``AKGENTIC_WORKSPACES_ROOT`` environment
+variable (default: ``./workspaces``).
 """
 
 from __future__ import annotations
@@ -134,19 +135,16 @@ class Filesystem:
 
 
 def get_workspace(workspace_name: str) -> Filesystem:
-    """Return a :class:`Filesystem` for *workspace_name* using the current mode.
+    """Return a :class:`Filesystem` for *workspace_name* rooted at the configured base.
 
-    The base path is selected from ``WORKSPACE_MODE`` environment variable:
+    The base path is read from the ``AKGENTIC_WORKSPACES_ROOT`` environment
+    variable.  When the variable is unset the default ``./workspaces`` is used.
 
-    - ``local`` (default, or unset): ``./workspaces``
-    - ``docker``: ``/workspaces``
+    Args:
+        workspace_name: Team-scoped workspace directory name (e.g. ``"team-1"``).
 
-    Raises:
-        KeyError: if ``WORKSPACE_MODE`` is set to an unknown value (fail-fast).
+    Returns:
+        A :class:`Filesystem` anchored at ``<AKGENTIC_WORKSPACES_ROOT>/<workspace_name>``.
     """
-    mode = os.environ.get("WORKSPACE_MODE", "local")
-    base_path = {
-        "local": "./workspaces",
-        "docker": "/workspaces",
-    }[mode]
+    base_path = os.environ.get("AKGENTIC_WORKSPACES_ROOT", "./workspaces")
     return Filesystem(base_path=base_path, workspace_name=workspace_name)

--- a/tests/sandbox/test_docker_sandbox.py
+++ b/tests/sandbox/test_docker_sandbox.py
@@ -1,6 +1,6 @@
 """Tests for DockerSandboxActor — persistent Docker container execution.
 
-Covers AC1 through AC11 for Story 6.3:
+Covers AC1 through AC11 for Story 6.3 (updated for Story 6.5):
 - AC1: _start_sandbox() runs docker run when container does not exist
 - AC2: _start_sandbox() runs docker start when container already exists
 - AC3: _start_sandbox() raises RuntimeError when docker CLI not on PATH
@@ -12,6 +12,7 @@ Covers AC1 through AC11 for Story 6.3:
 - AC9: SANDBOX_IMAGE == "akgentic-sandbox:latest"
 - AC10: DOCKER_EXEC_TIMEOUT == 60
 - AC11: 80%+ branch coverage
+- Story 6.5: volume mount host path derived from AKGENTIC_WORKSPACES_ROOT
 """
 
 from __future__ import annotations
@@ -95,9 +96,10 @@ def test_start_sandbox_creates_container_when_absent(
 @patch("akgentic.tool.sandbox.docker.shutil.which", return_value="/usr/bin/docker")
 @patch("akgentic.tool.sandbox.docker.subprocess.run")
 def test_start_sandbox_docker_run_uses_correct_flags(
-    mock_run: MagicMock, mock_which: MagicMock
+    mock_run: MagicMock, mock_which: MagicMock, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """AC1: docker run uses -d, --name, --network none, -v, -w, sleep infinity."""
+    """AC1: docker run uses -d, --name, --network none, -v, -w, sleep infinity (default root)."""
+    monkeypatch.delenv("AKGENTIC_WORKSPACES_ROOT", raising=False)
     mock_run.side_effect = [
         MagicMock(stdout="", returncode=0),  # docker ps -a
         MagicMock(stdout="abc123", returncode=0),  # docker run
@@ -115,13 +117,32 @@ def test_start_sandbox_docker_run_uses_correct_flags(
         "--network",
         "none",
         "-v",
-        "workspaces/team-1:/workspace",
+        "./workspaces/team-1:/workspace",
         "-w",
         "/workspace",
         SANDBOX_IMAGE,
         "sleep",
         "infinity",
     ]
+
+
+@patch("akgentic.tool.sandbox.docker.shutil.which", return_value="/usr/bin/docker")
+@patch("akgentic.tool.sandbox.docker.subprocess.run")
+def test_start_sandbox_docker_run_uses_custom_workspaces_root(
+    mock_run: MagicMock, mock_which: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Story 6.5: docker run -v uses AKGENTIC_WORKSPACES_ROOT when set."""
+    monkeypatch.setenv("AKGENTIC_WORKSPACES_ROOT", "/workspaces")
+    mock_run.side_effect = [
+        MagicMock(stdout="", returncode=0),  # docker ps -a
+        MagicMock(stdout="abc123", returncode=0),  # docker run
+    ]
+    actor = make_actor(team_id="team-1")
+    actor._start_sandbox()
+
+    run_call_args = mock_run.call_args_list[1][0][0]
+    volume_arg_idx = run_call_args.index("-v") + 1
+    assert run_call_args[volume_arg_idx] == "/workspaces/team-1:/workspace"
 
 
 @patch("akgentic.tool.sandbox.docker.shutil.which", return_value="/usr/bin/docker")

--- a/tests/sandbox/test_docker_sandbox.py
+++ b/tests/sandbox/test_docker_sandbox.py
@@ -1,0 +1,426 @@
+"""Tests for DockerSandboxActor — persistent Docker container execution.
+
+Covers AC1 through AC11 for Story 6.3:
+- AC1: _start_sandbox() runs docker run when container does not exist
+- AC2: _start_sandbox() runs docker start when container already exists
+- AC3: _start_sandbox() raises RuntimeError when docker CLI not on PATH
+- AC4: _stop_sandbox() runs docker stop and does NOT run docker rm
+- AC5: Exceptions from _stop_sandbox() swallowed by SandboxActor.on_stop() (base class)
+- AC6: _exec("pytest tests/", cwd="src") builds docker exec -w /workspace/src
+- AC7: _exec("pytest tests/", cwd="") builds docker exec -w /workspace
+- AC8: state.container_name is set after _start_sandbox() (volume sharing by convention)
+- AC9: SANDBOX_IMAGE == "akgentic-sandbox:latest"
+- AC10: DOCKER_EXEC_TIMEOUT == 60
+- AC11: 80%+ branch coverage
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from akgentic.tool.sandbox.actor import (
+    ExecResult,
+    SandboxConfig,
+    SandboxState,
+)
+from akgentic.tool.sandbox.docker import (
+    DOCKER_EXEC_TIMEOUT,
+    SANDBOX_IMAGE,
+    DockerSandboxActor,
+)
+
+# ---------------------------------------------------------------------------
+# Helper factory
+# ---------------------------------------------------------------------------
+
+
+def make_actor(team_id: str = "team-test") -> DockerSandboxActor:
+    """Create a DockerSandboxActor with config and state pre-initialized (no Pykka runtime)."""
+    actor = DockerSandboxActor()
+    actor.config = SandboxConfig(name="sandbox", role="ToolActor", team_id=team_id)
+    actor.state = SandboxState()
+    actor.state.observer(actor)
+    return actor
+
+
+# ---------------------------------------------------------------------------
+# AC9: SANDBOX_IMAGE constant
+# ---------------------------------------------------------------------------
+
+
+def test_sandbox_image_constant() -> None:
+    """AC9: SANDBOX_IMAGE equals 'akgentic-sandbox:latest'."""
+    assert SANDBOX_IMAGE == "akgentic-sandbox:latest"
+
+
+# ---------------------------------------------------------------------------
+# AC10: DOCKER_EXEC_TIMEOUT constant
+# ---------------------------------------------------------------------------
+
+
+def test_docker_exec_timeout_constant() -> None:
+    """AC10: DOCKER_EXEC_TIMEOUT equals 60."""
+    assert DOCKER_EXEC_TIMEOUT == 60
+
+
+# ---------------------------------------------------------------------------
+# AC1: _start_sandbox() runs docker run when container does not exist
+# ---------------------------------------------------------------------------
+
+
+@patch("akgentic.tool.sandbox.docker.shutil.which", return_value="/usr/bin/docker")
+@patch("akgentic.tool.sandbox.docker.subprocess.run")
+def test_start_sandbox_creates_container_when_absent(
+    mock_run: MagicMock, mock_which: MagicMock
+) -> None:
+    """AC1: _start_sandbox() runs docker run -d when container does not exist."""
+    # First call: docker ps -a → returns empty stdout (container not found)
+    # Second call: docker run -d → returns success
+    mock_run.side_effect = [
+        MagicMock(stdout="", returncode=0),  # docker ps -a
+        MagicMock(stdout="abc123", returncode=0),  # docker run
+    ]
+    actor = make_actor(team_id="team-1")
+    actor._start_sandbox()
+
+    assert actor.state.container_name == "sandbox-team-1"
+    # Verify docker run was called (second call), not docker start
+    second_call_args = mock_run.call_args_list[1][0][0]
+    assert second_call_args[1] == "run"
+
+
+@patch("akgentic.tool.sandbox.docker.shutil.which", return_value="/usr/bin/docker")
+@patch("akgentic.tool.sandbox.docker.subprocess.run")
+def test_start_sandbox_docker_run_uses_correct_flags(
+    mock_run: MagicMock, mock_which: MagicMock
+) -> None:
+    """AC1: docker run uses -d, --name, --network none, -v, -w, sleep infinity."""
+    mock_run.side_effect = [
+        MagicMock(stdout="", returncode=0),  # docker ps -a
+        MagicMock(stdout="abc123", returncode=0),  # docker run
+    ]
+    actor = make_actor(team_id="team-1")
+    actor._start_sandbox()
+
+    run_call_args = mock_run.call_args_list[1][0][0]
+    assert run_call_args == [
+        "docker",
+        "run",
+        "-d",
+        "--name",
+        "sandbox-team-1",
+        "--network",
+        "none",
+        "-v",
+        "workspaces/team-1:/workspace",
+        "-w",
+        "/workspace",
+        SANDBOX_IMAGE,
+        "sleep",
+        "infinity",
+    ]
+
+
+@patch("akgentic.tool.sandbox.docker.shutil.which", return_value="/usr/bin/docker")
+@patch("akgentic.tool.sandbox.docker.subprocess.run")
+def test_start_sandbox_sets_container_name_in_state(
+    mock_run: MagicMock, mock_which: MagicMock
+) -> None:
+    """AC1/AC8: After _start_sandbox(), state.container_name is set to 'sandbox-{team_id}'."""
+    mock_run.side_effect = [
+        MagicMock(stdout="", returncode=0),  # docker ps -a
+        MagicMock(stdout="abc123", returncode=0),  # docker run
+    ]
+    actor = make_actor(team_id="team-1")
+    actor._start_sandbox()
+
+    assert actor.state.container_name == "sandbox-team-1"
+
+
+# ---------------------------------------------------------------------------
+# AC2: _start_sandbox() runs docker start when container already exists
+# ---------------------------------------------------------------------------
+
+
+@patch("akgentic.tool.sandbox.docker.shutil.which", return_value="/usr/bin/docker")
+@patch("akgentic.tool.sandbox.docker.subprocess.run")
+def test_start_sandbox_reuses_existing_container(
+    mock_run: MagicMock, mock_which: MagicMock
+) -> None:
+    """AC2: _start_sandbox() runs docker start when container already exists (any state)."""
+    # First call: docker ps -a → container name in stdout
+    # Second call: docker start → returns success
+    mock_run.side_effect = [
+        MagicMock(stdout="sandbox-team-1\n", returncode=0),  # docker ps -a
+        MagicMock(stdout="sandbox-team-1", returncode=0),  # docker start
+    ]
+    actor = make_actor(team_id="team-1")
+    actor._start_sandbox()
+
+    second_call_args = mock_run.call_args_list[1][0][0]
+    assert second_call_args[1] == "start"
+    assert actor.state.container_name == "sandbox-team-1"
+
+
+@patch("akgentic.tool.sandbox.docker.shutil.which", return_value="/usr/bin/docker")
+@patch("akgentic.tool.sandbox.docker.subprocess.run")
+def test_start_sandbox_docker_start_uses_correct_args(
+    mock_run: MagicMock, mock_which: MagicMock
+) -> None:
+    """AC2: docker start is called with the correct container name."""
+    mock_run.side_effect = [
+        MagicMock(stdout="sandbox-team-1\n", returncode=0),  # docker ps -a
+        MagicMock(stdout="sandbox-team-1", returncode=0),  # docker start
+    ]
+    actor = make_actor(team_id="team-1")
+    actor._start_sandbox()
+
+    start_call_args = mock_run.call_args_list[1][0][0]
+    assert start_call_args == ["docker", "start", "sandbox-team-1"]
+
+
+# ---------------------------------------------------------------------------
+# AC3: _start_sandbox() raises RuntimeError when docker not on PATH
+# ---------------------------------------------------------------------------
+
+
+@patch("akgentic.tool.sandbox.docker.shutil.which", return_value=None)
+def test_start_sandbox_raises_when_docker_not_on_path(mock_which: MagicMock) -> None:
+    """AC3: _start_sandbox() raises RuntimeError when shutil.which('docker') returns None."""
+    actor = make_actor()
+    with pytest.raises(RuntimeError, match="docker"):
+        actor._start_sandbox()
+
+
+@patch("akgentic.tool.sandbox.docker.shutil.which", return_value=None)
+def test_start_sandbox_runtime_error_message(mock_which: MagicMock) -> None:
+    """AC3: RuntimeError message mentions docker CLI."""
+    actor = make_actor()
+    with pytest.raises(RuntimeError, match="docker CLI not found on PATH"):
+        actor._start_sandbox()
+
+
+# ---------------------------------------------------------------------------
+# AC4: _stop_sandbox() runs docker stop and does NOT run docker rm
+# ---------------------------------------------------------------------------
+
+
+@patch("akgentic.tool.sandbox.docker.subprocess.run")
+def test_stop_sandbox_runs_docker_stop(mock_run: MagicMock) -> None:
+    """AC4: _stop_sandbox() calls docker stop with the container name."""
+    actor = make_actor(team_id="team-1")
+    actor.state.container_name = "sandbox-team-1"
+    mock_run.return_value = MagicMock(returncode=0)
+
+    actor._stop_sandbox()
+
+    assert mock_run.call_args_list[0][0][0] == ["docker", "stop", "sandbox-team-1"]
+
+
+@patch("akgentic.tool.sandbox.docker.subprocess.run")
+def test_stop_sandbox_does_not_rm_container(mock_run: MagicMock) -> None:
+    """AC4: _stop_sandbox() does NOT run docker rm — container preserved between restarts."""
+    actor = make_actor(team_id="team-1")
+    actor.state.container_name = "sandbox-team-1"
+    mock_run.return_value = MagicMock(returncode=0)
+
+    actor._stop_sandbox()
+
+    # Verify docker rm was NOT called in any subprocess.run call
+    for call_item in mock_run.call_args_list:
+        assert "rm" not in call_item[0][0]
+
+
+@patch("akgentic.tool.sandbox.docker.subprocess.run")
+def test_stop_sandbox_only_one_subprocess_call(mock_run: MagicMock) -> None:
+    """AC4: _stop_sandbox() makes exactly one subprocess.run call (docker stop only)."""
+    actor = make_actor(team_id="team-1")
+    actor.state.container_name = "sandbox-team-1"
+    mock_run.return_value = MagicMock(returncode=0)
+
+    actor._stop_sandbox()
+
+    assert mock_run.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# AC5: on_stop() swallows _stop_sandbox() exceptions (inherited behavior)
+# ---------------------------------------------------------------------------
+
+
+@patch("akgentic.tool.sandbox.docker.shutil.which", return_value="/usr/bin/docker")
+@patch("akgentic.tool.sandbox.docker.subprocess.run")
+def test_on_stop_swallows_stop_sandbox_exception(
+    mock_run: MagicMock, mock_which: MagicMock
+) -> None:
+    """AC5: on_stop() swallows exceptions raised by _stop_sandbox() — base class behavior."""
+    # Start sandbox first to set container_name
+    mock_run.side_effect = [
+        MagicMock(stdout="", returncode=0),  # docker ps -a
+        MagicMock(stdout="abc123", returncode=0),  # docker run
+        subprocess.CalledProcessError(1, "docker stop"),  # docker stop raises
+    ]
+    actor = make_actor(team_id="team-1")
+    actor._start_sandbox()
+
+    # on_stop() should not raise even though docker stop fails
+    actor.on_stop()  # Must not raise
+
+
+# ---------------------------------------------------------------------------
+# AC6: _exec() with cwd builds docker exec -w /workspace/src
+# ---------------------------------------------------------------------------
+
+
+@patch("akgentic.tool.sandbox.docker.subprocess.run")
+def test_exec_with_cwd_builds_correct_docker_command(mock_run: MagicMock) -> None:
+    """AC6: _exec('pytest tests/', cwd='src') builds docker exec -w /workspace/src."""
+    actor = make_actor(team_id="team-1")
+    actor.state.container_name = "sandbox-team-1"
+    mock_run.return_value = MagicMock(stdout="", stderr="", returncode=0)
+
+    actor._exec("pytest tests/", "src")
+
+    expected_cmd = [
+        "docker",
+        "exec",
+        "-w",
+        "/workspace/src",
+        "sandbox-team-1",
+        "pytest",
+        "tests/",
+    ]
+    mock_run.assert_called_once_with(
+        expected_cmd,
+        capture_output=True,
+        text=True,
+        timeout=DOCKER_EXEC_TIMEOUT,
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC7: _exec() with empty cwd builds docker exec -w /workspace
+# ---------------------------------------------------------------------------
+
+
+@patch("akgentic.tool.sandbox.docker.subprocess.run")
+def test_exec_without_cwd_uses_workspace_root(mock_run: MagicMock) -> None:
+    """AC7: _exec('pytest tests/', cwd='') builds docker exec -w /workspace (no trailing slash)."""
+    actor = make_actor(team_id="team-1")
+    actor.state.container_name = "sandbox-team-1"
+    mock_run.return_value = MagicMock(stdout="", stderr="", returncode=0)
+
+    actor._exec("pytest tests/", "")
+
+    expected_cmd = [
+        "docker",
+        "exec",
+        "-w",
+        "/workspace",
+        "sandbox-team-1",
+        "pytest",
+        "tests/",
+    ]
+    mock_run.assert_called_once_with(
+        expected_cmd,
+        capture_output=True,
+        text=True,
+        timeout=DOCKER_EXEC_TIMEOUT,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _exec() returns ExecResult with correct fields
+# ---------------------------------------------------------------------------
+
+
+@patch("akgentic.tool.sandbox.docker.subprocess.run")
+def test_exec_returns_exec_result_with_correct_fields(mock_run: MagicMock) -> None:
+    """_exec() returns ExecResult with stdout, stderr, exit_code from mocked subprocess."""
+    actor = make_actor(team_id="team-1")
+    actor.state.container_name = "sandbox-team-1"
+    mock_run.return_value = MagicMock(stdout="test passed", stderr="warning", returncode=0)
+
+    result = actor._exec("pytest tests/", "")
+
+    assert isinstance(result, ExecResult)
+    assert result.stdout == "test passed"
+    assert result.stderr == "warning"
+    assert result.exit_code == 0
+
+
+@patch("akgentic.tool.sandbox.docker.subprocess.run")
+def test_exec_captures_non_zero_exit_code(mock_run: MagicMock) -> None:
+    """_exec() correctly captures non-zero exit codes."""
+    actor = make_actor(team_id="team-1")
+    actor.state.container_name = "sandbox-team-1"
+    mock_run.return_value = MagicMock(stdout="", stderr="test failed", returncode=1)
+
+    result = actor._exec("pytest tests/", "")
+
+    assert result.exit_code == 1
+    assert result.stderr == "test failed"
+
+
+# ---------------------------------------------------------------------------
+# _exec() timeout propagates
+# ---------------------------------------------------------------------------
+
+
+@patch("akgentic.tool.sandbox.docker.subprocess.run")
+def test_exec_timeout_propagates(mock_run: MagicMock) -> None:
+    """_exec() propagates subprocess.TimeoutExpired — not swallowed."""
+    actor = make_actor(team_id="team-1")
+    actor.state.container_name = "sandbox-team-1"
+    mock_run.side_effect = subprocess.TimeoutExpired(cmd=["docker", "exec"], timeout=60)
+
+    with pytest.raises(subprocess.TimeoutExpired):
+        actor._exec("pytest tests/", "")
+
+
+# ---------------------------------------------------------------------------
+# AC8: Integration assertion — state.container_name set after _start_sandbox()
+# ---------------------------------------------------------------------------
+
+
+@patch("akgentic.tool.sandbox.docker.shutil.which", return_value="/usr/bin/docker")
+@patch("akgentic.tool.sandbox.docker.subprocess.run")
+def test_integration_container_name_set_after_start(
+    mock_run: MagicMock, mock_which: MagicMock
+) -> None:
+    """AC8: After _start_sandbox(), state.container_name is set — volume mount ensures file sharing."""
+    mock_run.side_effect = [
+        MagicMock(stdout="", returncode=0),  # docker ps -a
+        MagicMock(stdout="abc123", returncode=0),  # docker run
+    ]
+    actor = make_actor(team_id="team-1")
+    actor._start_sandbox()
+
+    # Volume sharing is by design convention (-v workspaces/team-1:/workspace)
+    # assert container_name is set (and thus the mount is active)
+    assert actor.state.container_name == "sandbox-team-1"
+
+
+# ---------------------------------------------------------------------------
+# notify_state_change is called after _start_sandbox()
+# ---------------------------------------------------------------------------
+
+
+@patch("akgentic.tool.sandbox.docker.shutil.which", return_value="/usr/bin/docker")
+@patch("akgentic.tool.sandbox.docker.subprocess.run")
+def test_start_sandbox_calls_notify_state_change(
+    mock_run: MagicMock, mock_which: MagicMock
+) -> None:
+    """_start_sandbox() calls state.notify_state_change() after setting container_name."""
+    mock_run.side_effect = [
+        MagicMock(stdout="", returncode=0),  # docker ps -a
+        MagicMock(stdout="abc123", returncode=0),  # docker run
+    ]
+    actor = make_actor(team_id="team-1")
+
+    with patch("akgentic.tool.sandbox.actor.SandboxState.notify_state_change") as mock_notify:
+        actor._start_sandbox()
+        mock_notify.assert_called_once()

--- a/tests/sandbox/test_docker_sandbox.py
+++ b/tests/sandbox/test_docker_sandbox.py
@@ -38,10 +38,14 @@ from akgentic.tool.sandbox.docker import (
 # ---------------------------------------------------------------------------
 
 
-def make_actor(team_id: str = "team-test") -> DockerSandboxActor:
+def make_actor(
+    team_id: str = "team-test", workspace_id: str | None = None
+) -> DockerSandboxActor:
     """Create a DockerSandboxActor with config and state pre-initialized (no Pykka runtime)."""
     actor = DockerSandboxActor()
-    actor.config = SandboxConfig(name="sandbox", role="ToolActor", team_id=team_id)
+    actor.config = SandboxConfig(
+        name="sandbox", role="ToolActor", team_id=team_id, workspace_id=workspace_id
+    )
     actor.state = SandboxState()
     actor.state.observer(actor)
     return actor
@@ -495,3 +499,66 @@ def test_start_sandbox_calls_notify_state_change(
     with patch("akgentic.tool.sandbox.actor.SandboxState.notify_state_change") as mock_notify:
         actor._start_sandbox()
         mock_notify.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Story 6.6: workspace_id overrides team_id for volume mount; container name unchanged
+# ---------------------------------------------------------------------------
+
+
+@patch("akgentic.tool.sandbox.docker.shutil.which", return_value="/usr/bin/docker")
+@patch("akgentic.tool.sandbox.docker.subprocess.run")
+def test_start_sandbox_workspace_id_overrides_volume_mount(
+    mock_run: MagicMock, mock_which: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """FR-SB-34: workspace_id='test' makes volume mount use 'test', not team_id."""
+    monkeypatch.delenv("AKGENTIC_WORKSPACES_ROOT", raising=False)
+    mock_run.side_effect = [
+        MagicMock(stdout="", returncode=0),  # docker ps -a
+        MagicMock(stdout="abc123", returncode=0),  # docker run
+    ]
+    actor = make_actor(team_id="t1", workspace_id="test")
+    actor._start_sandbox()
+
+    run_call_args = mock_run.call_args_list[1][0][0]
+    volume_arg_idx = run_call_args.index("-v") + 1
+    assert run_call_args[volume_arg_idx] == "workspaces/test:/workspace"
+
+
+@patch("akgentic.tool.sandbox.docker.shutil.which", return_value="/usr/bin/docker")
+@patch("akgentic.tool.sandbox.docker.subprocess.run")
+def test_start_sandbox_container_name_uses_team_id_not_workspace_id(
+    mock_run: MagicMock, mock_which: MagicMock
+) -> None:
+    """FR-SB-34: container name is sandbox-{team_id}, NOT sandbox-{workspace_id}."""
+    mock_run.side_effect = [
+        MagicMock(stdout="", returncode=0),  # docker ps -a
+        MagicMock(stdout="abc123", returncode=0),  # docker run
+    ]
+    actor = make_actor(team_id="t1", workspace_id="test")
+    actor._start_sandbox()
+
+    # Container name must be based on team_id, not workspace_id
+    assert actor.state.container_name == "sandbox-t1"
+    run_call_args = mock_run.call_args_list[1][0][0]
+    name_idx = run_call_args.index("--name") + 1
+    assert run_call_args[name_idx] == "sandbox-t1"
+
+
+@patch("akgentic.tool.sandbox.docker.shutil.which", return_value="/usr/bin/docker")
+@patch("akgentic.tool.sandbox.docker.subprocess.run")
+def test_start_sandbox_workspace_id_none_uses_team_id_for_volume(
+    mock_run: MagicMock, mock_which: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """FR-SB-34: workspace_id=None falls back to team_id for volume mount (unchanged default)."""
+    monkeypatch.delenv("AKGENTIC_WORKSPACES_ROOT", raising=False)
+    mock_run.side_effect = [
+        MagicMock(stdout="", returncode=0),  # docker ps -a
+        MagicMock(stdout="abc123", returncode=0),  # docker run
+    ]
+    actor = make_actor(team_id="team-1", workspace_id=None)
+    actor._start_sandbox()
+
+    run_call_args = mock_run.call_args_list[1][0][0]
+    volume_arg_idx = run_call_args.index("-v") + 1
+    assert run_call_args[volume_arg_idx] == "workspaces/team-1:/workspace"

--- a/tests/sandbox/test_docker_sandbox.py
+++ b/tests/sandbox/test_docker_sandbox.py
@@ -17,7 +17,7 @@ Covers AC1 through AC11 for Story 6.3:
 from __future__ import annotations
 
 import subprocess
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -180,6 +180,30 @@ def test_start_sandbox_docker_start_uses_correct_args(
 
     start_call_args = mock_run.call_args_list[1][0][0]
     assert start_call_args == ["docker", "start", "sandbox-team-1"]
+
+
+@patch("akgentic.tool.sandbox.docker.shutil.which", return_value="/usr/bin/docker")
+@patch("akgentic.tool.sandbox.docker.subprocess.run")
+def test_start_sandbox_no_false_positive_on_prefix_container_name(
+    mock_run: MagicMock, mock_which: MagicMock
+) -> None:
+    """AC1: container name prefix in stdout does not trigger false reuse.
+
+    If 'sandbox-team-10' appears in stdout, checking for 'sandbox-team-1'
+    must NOT match — exact line matching is required.
+    """
+    # docker ps -a stdout contains a prefix-matching name, not exact match
+    mock_run.side_effect = [
+        MagicMock(stdout="sandbox-team-10\n", returncode=0),  # docker ps -a
+        MagicMock(stdout="abc123", returncode=0),  # docker run (not docker start)
+    ]
+    actor = make_actor(team_id="team-1")
+    actor._start_sandbox()
+
+    # Must run docker run, NOT docker start
+    second_call_args = mock_run.call_args_list[1][0][0]
+    assert second_call_args[1] == "run"
+    assert actor.state.container_name == "sandbox-team-1"
 
 
 # ---------------------------------------------------------------------------
@@ -391,7 +415,7 @@ def test_exec_timeout_propagates(mock_run: MagicMock) -> None:
 def test_integration_container_name_set_after_start(
     mock_run: MagicMock, mock_which: MagicMock
 ) -> None:
-    """AC8: After _start_sandbox(), state.container_name is set — volume mount ensures file sharing."""
+    """AC8: After _start_sandbox(), state.container_name is set — volume mount ensures sharing."""
     mock_run.side_effect = [
         MagicMock(stdout="", returncode=0),  # docker ps -a
         MagicMock(stdout="abc123", returncode=0),  # docker run

--- a/tests/sandbox/test_docker_sandbox.py
+++ b/tests/sandbox/test_docker_sandbox.py
@@ -117,7 +117,7 @@ def test_start_sandbox_docker_run_uses_correct_flags(
         "--network",
         "none",
         "-v",
-        "./workspaces/team-1:/workspace",
+        "workspaces/team-1:/workspace",
         "-w",
         "/workspace",
         SANDBOX_IMAGE,
@@ -143,6 +143,32 @@ def test_start_sandbox_docker_run_uses_custom_workspaces_root(
     run_call_args = mock_run.call_args_list[1][0][0]
     volume_arg_idx = run_call_args.index("-v") + 1
     assert run_call_args[volume_arg_idx] == "/workspaces/team-1:/workspace"
+
+
+@patch("akgentic.tool.sandbox.docker.shutil.which", return_value="/usr/bin/docker")
+@patch("akgentic.tool.sandbox.docker.subprocess.run")
+def test_start_sandbox_docker_run_normalizes_trailing_slash_in_root(
+    mock_run: MagicMock, mock_which: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Story 6.5: AKGENTIC_WORKSPACES_ROOT with trailing slash must NOT produce double-slash volume.
+
+    e.g. '/workspaces/' must yield '/workspaces/team-1:/workspace', not '/workspaces//team-1:/workspace'.
+    Path() normalizes this automatically.
+    """
+    monkeypatch.setenv("AKGENTIC_WORKSPACES_ROOT", "/workspaces/")
+    mock_run.side_effect = [
+        MagicMock(stdout="", returncode=0),  # docker ps -a
+        MagicMock(stdout="abc123", returncode=0),  # docker run
+    ]
+    actor = make_actor(team_id="team-1")
+    actor._start_sandbox()
+
+    run_call_args = mock_run.call_args_list[1][0][0]
+    volume_arg_idx = run_call_args.index("-v") + 1
+    volume = run_call_args[volume_arg_idx]
+    assert volume == "/workspaces/team-1:/workspace", (
+        f"Volume mount must not contain double slash: got '{volume}'"
+    )
 
 
 @patch("akgentic.tool.sandbox.docker.shutil.which", return_value="/usr/bin/docker")

--- a/tests/sandbox/test_exec_tool.py
+++ b/tests/sandbox/test_exec_tool.py
@@ -1,0 +1,379 @@
+"""Tests for ExecTool — observer wiring, SANDBOX_MODE resolution, tool behaviour.
+
+Covers AC1–AC13 for Story 6.4:
+- SANDBOX_ACTOR_CLASSES dict (AC1)
+- ExecTool fields (AC2)
+- observer() raises ValueError when orchestrator is None (AC3)
+- observer() creates LocalSandboxActor with SANDBOX_MODE=local (AC4)
+- observer() creates DockerSandboxActor with SANDBOX_MODE=docker (AC5)
+- observer() reuses existing actor — no second createActor call (AC6)
+- observer() raises KeyError on unknown SANDBOX_MODE (AC7)
+- exec_command returns formatted stdout/stderr/exit_code (AC8)
+- exec_command catches CommandNotAllowedError → error string (AC9)
+- get_tools() returns [] when exec_command=False (AC10)
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from akgentic.core.actor_address import ActorAddress
+from akgentic.tool.sandbox.actor import (
+    ALLOWED_COMMANDS,
+    SANDBOX_ACTOR_NAME,
+    CommandNotAllowedError,
+    ExecResult,
+    SandboxActor,
+    SandboxConfig,
+)
+from akgentic.tool.sandbox.docker import DockerSandboxActor
+from akgentic.tool.sandbox.local import LocalSandboxActor
+from akgentic.tool.sandbox.tool import SANDBOX_ACTOR_CLASSES, ExecTool
+
+
+# ---------------------------------------------------------------------------
+# Mock observer infrastructure
+# ---------------------------------------------------------------------------
+
+
+class MockObserver:
+    """Minimal ActorToolObserver stub for ExecTool unit tests."""
+
+    def __init__(
+        self,
+        has_orchestrator: bool = True,
+        existing_actor: ActorAddress | None = None,
+    ) -> None:
+        self._team_id = "team-test"
+        self.myAddress = MagicMock(spec=ActorAddress)
+        self.orchestrator = MagicMock(spec=ActorAddress) if has_orchestrator else None
+
+        # Set up orchestrator proxy mock
+        self._orch_proxy = MagicMock()
+        self._orch_proxy.get_team_member.return_value = existing_actor  # None = not found
+        new_addr = MagicMock(spec=ActorAddress)
+        self._orch_proxy.createActor.return_value = new_addr
+        self._new_actor_addr = new_addr
+
+    def proxy_ask(
+        self,
+        actor: ActorAddress,
+        actor_type: object = None,
+        timeout: int | None = None,
+    ) -> object:
+        if actor is self.orchestrator:
+            return self._orch_proxy
+        return MagicMock()  # sandbox proxy
+
+    def notify_event(self, event: object) -> None:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# AC1 — SANDBOX_ACTOR_CLASSES registry
+# ---------------------------------------------------------------------------
+
+
+def test_sandbox_actor_classes_has_local_key() -> None:
+    """AC1: SANDBOX_ACTOR_CLASSES['local'] maps to LocalSandboxActor."""
+    assert "local" in SANDBOX_ACTOR_CLASSES
+    assert SANDBOX_ACTOR_CLASSES["local"] is LocalSandboxActor
+
+
+def test_sandbox_actor_classes_has_docker_key() -> None:
+    """AC1: SANDBOX_ACTOR_CLASSES['docker'] maps to DockerSandboxActor."""
+    assert "docker" in SANDBOX_ACTOR_CLASSES
+    assert SANDBOX_ACTOR_CLASSES["docker"] is DockerSandboxActor
+
+
+def test_sandbox_actor_classes_is_mutable_dict() -> None:
+    """AC1: SANDBOX_ACTOR_CLASSES is a regular dict (mutable — injection window)."""
+    assert isinstance(SANDBOX_ACTOR_CLASSES, dict)
+
+
+# ---------------------------------------------------------------------------
+# AC2 — ExecTool field defaults
+# ---------------------------------------------------------------------------
+
+
+def test_exec_tool_name_default() -> None:
+    """AC2: ExecTool.name defaults to 'Exec'."""
+    tool = ExecTool()
+    assert tool.name == "Exec"
+
+
+def test_exec_tool_description_default() -> None:
+    """AC2: ExecTool.description is the expected string."""
+    tool = ExecTool()
+    assert tool.description == "Execute sandboxed shell commands in the team workspace"
+
+
+def test_exec_tool_exec_command_default_is_true() -> None:
+    """AC2: ExecTool.exec_command defaults to True."""
+    tool = ExecTool()
+    assert tool.exec_command is True
+
+
+# ---------------------------------------------------------------------------
+# AC3 — observer() raises ValueError when orchestrator is None
+# ---------------------------------------------------------------------------
+
+
+def test_observer_raises_value_error_when_orchestrator_is_none() -> None:
+    """AC3: observer() raises ValueError when observer.orchestrator is None."""
+    tool = ExecTool()
+    observer = MockObserver(has_orchestrator=False)
+
+    with pytest.raises(ValueError, match="orchestrator"):
+        tool.observer(observer)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# AC4 — observer() creates LocalSandboxActor when SANDBOX_MODE=local
+# ---------------------------------------------------------------------------
+
+
+def test_observer_creates_local_sandbox_actor(monkeypatch: pytest.MonkeyPatch) -> None:
+    """AC4: observer() with SANDBOX_MODE=local creates LocalSandboxActor."""
+    monkeypatch.setenv("SANDBOX_MODE", "local")
+    observer = MockObserver(existing_actor=None)
+    tool = ExecTool()
+
+    tool.observer(observer)  # type: ignore[arg-type]
+
+    observer._orch_proxy.createActor.assert_called_once()
+    call_args = observer._orch_proxy.createActor.call_args
+    assert call_args[0][0] is LocalSandboxActor
+
+
+def test_observer_creates_actor_with_correct_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """AC4: SandboxConfig passed to createActor has name, role, and team_id."""
+    monkeypatch.setenv("SANDBOX_MODE", "local")
+    observer = MockObserver(existing_actor=None)
+    tool = ExecTool()
+
+    tool.observer(observer)  # type: ignore[arg-type]
+
+    call_kwargs = observer._orch_proxy.createActor.call_args[1]
+    config: SandboxConfig = call_kwargs["config"]
+    assert config.name == SANDBOX_ACTOR_NAME
+    assert config.role == "ToolActor"
+    assert config.team_id == "team-test"
+
+
+def test_observer_stores_sandbox_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
+    """AC4: observer() stores a non-None _sandbox_proxy after wiring."""
+    monkeypatch.setenv("SANDBOX_MODE", "local")
+    observer = MockObserver(existing_actor=None)
+    tool = ExecTool()
+
+    tool.observer(observer)  # type: ignore[arg-type]
+
+    assert tool._sandbox_proxy is not None
+
+
+# ---------------------------------------------------------------------------
+# AC5 — observer() creates DockerSandboxActor when SANDBOX_MODE=docker
+# ---------------------------------------------------------------------------
+
+
+def test_observer_creates_docker_sandbox_actor(monkeypatch: pytest.MonkeyPatch) -> None:
+    """AC5: observer() with SANDBOX_MODE=docker creates DockerSandboxActor."""
+    monkeypatch.setenv("SANDBOX_MODE", "docker")
+    observer = MockObserver(existing_actor=None)
+    tool = ExecTool()
+
+    tool.observer(observer)  # type: ignore[arg-type]
+
+    observer._orch_proxy.createActor.assert_called_once()
+    call_args = observer._orch_proxy.createActor.call_args
+    assert call_args[0][0] is DockerSandboxActor
+
+
+# ---------------------------------------------------------------------------
+# AC6 — observer() reuses existing actor — does NOT call createActor again
+# ---------------------------------------------------------------------------
+
+
+def test_observer_reuses_existing_actor(monkeypatch: pytest.MonkeyPatch) -> None:
+    """AC6: when #SandboxActor already exists, createActor is NOT called."""
+    monkeypatch.setenv("SANDBOX_MODE", "local")
+    existing_addr = MagicMock(spec=ActorAddress)
+    observer = MockObserver(existing_actor=existing_addr)
+    tool = ExecTool()
+
+    tool.observer(observer)  # type: ignore[arg-type]
+
+    observer._orch_proxy.createActor.assert_not_called()
+
+
+def test_observer_second_call_reuses_actor(monkeypatch: pytest.MonkeyPatch) -> None:
+    """AC6: calling observer() a second time (actor already exists) does not create a new one."""
+    monkeypatch.setenv("SANDBOX_MODE", "local")
+
+    # First call: no existing actor → creates one
+    observer1 = MockObserver(existing_actor=None)
+    tool = ExecTool()
+    tool.observer(observer1)  # type: ignore[arg-type]
+    assert observer1._orch_proxy.createActor.call_count == 1
+
+    # Second call: actor now exists
+    existing_addr = MagicMock(spec=ActorAddress)
+    observer2 = MockObserver(existing_actor=existing_addr)
+    tool.observer(observer2)  # type: ignore[arg-type]
+
+    observer2._orch_proxy.createActor.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# AC7 — observer() raises KeyError on unknown SANDBOX_MODE
+# ---------------------------------------------------------------------------
+
+
+def test_observer_raises_key_error_on_unknown_sandbox_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC7: SANDBOX_MODE=unknown → KeyError (fail-fast, no error handling added)."""
+    monkeypatch.setenv("SANDBOX_MODE", "unknown-backend")
+    observer = MockObserver(existing_actor=None)
+    tool = ExecTool()
+
+    with pytest.raises(KeyError):
+        tool.observer(observer)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# AC8 — exec_command returns formatted stdout/stderr/exit_code
+# ---------------------------------------------------------------------------
+
+
+def test_exec_command_returns_formatted_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    """AC8: exec_command returns 'stdout:\\n...\\nstderr:\\n...\\nexit_code: 0'."""
+    monkeypatch.setenv("SANDBOX_MODE", "local")
+    observer = MockObserver(existing_actor=None)
+    tool = ExecTool()
+    tool.observer(observer)  # type: ignore[arg-type]
+
+    # Replace proxy with a controlled mock
+    mock_proxy = MagicMock(spec=SandboxActor)
+    mock_proxy.exec.return_value = ExecResult(
+        stdout="===== 5 passed =====", stderr="", exit_code=0
+    )
+    tool._sandbox_proxy = mock_proxy
+
+    tools = tool.get_tools()
+    assert len(tools) == 1
+    result = tools[0](cmd="pytest tests/ -v")
+
+    assert "exit_code: 0" in result
+    assert "5 passed" in result
+    assert "stdout:" in result
+    assert "stderr:" in result
+
+
+def test_exec_command_includes_stderr_in_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    """AC8: exec_command includes stderr in the returned string."""
+    monkeypatch.setenv("SANDBOX_MODE", "local")
+    observer = MockObserver(existing_actor=None)
+    tool = ExecTool()
+    tool.observer(observer)  # type: ignore[arg-type]
+
+    mock_proxy = MagicMock(spec=SandboxActor)
+    mock_proxy.exec.return_value = ExecResult(stdout="", stderr="SyntaxError", exit_code=1)
+    tool._sandbox_proxy = mock_proxy
+
+    tools = tool.get_tools()
+    result = tools[0](cmd="python bad.py")
+
+    assert "SyntaxError" in result
+    assert "exit_code: 1" in result
+
+
+# ---------------------------------------------------------------------------
+# AC9 — exec_command catches CommandNotAllowedError → error string
+# ---------------------------------------------------------------------------
+
+
+def test_exec_command_catches_command_not_allowed_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC9: CommandNotAllowedError is caught and returned as an error string — not raised."""
+    monkeypatch.setenv("SANDBOX_MODE", "local")
+    observer = MockObserver(existing_actor=None)
+    tool = ExecTool()
+    tool.observer(observer)  # type: ignore[arg-type]
+
+    mock_proxy = MagicMock(spec=SandboxActor)
+    mock_proxy.exec.side_effect = CommandNotAllowedError("malware not allowed")
+    tool._sandbox_proxy = mock_proxy
+
+    tools = tool.get_tools()
+    result = tools[0](cmd="malware --install")
+
+    assert "CommandNotAllowedError" in result
+    assert not result.startswith("Traceback")  # must not have raised
+
+
+def test_exec_command_error_string_lists_allowed_commands(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC9: error string contains the sorted list of ALLOWED_COMMANDS."""
+    monkeypatch.setenv("SANDBOX_MODE", "local")
+    observer = MockObserver(existing_actor=None)
+    tool = ExecTool()
+    tool.observer(observer)  # type: ignore[arg-type]
+
+    mock_proxy = MagicMock(spec=SandboxActor)
+    mock_proxy.exec.side_effect = CommandNotAllowedError("malware not in allowlist")
+    tool._sandbox_proxy = mock_proxy
+
+    tools = tool.get_tools()
+    result = tools[0](cmd="malware --install")
+
+    # Should list at least some allowed binaries
+    for binary in ["pytest", "python"]:
+        assert binary in result
+
+
+# ---------------------------------------------------------------------------
+# AC10 — get_tools() returns [] when exec_command=False
+# ---------------------------------------------------------------------------
+
+
+def test_get_tools_returns_empty_list_when_exec_command_disabled() -> None:
+    """AC10: ExecTool(exec_command=False).get_tools() returns []."""
+    tool = ExecTool(exec_command=False)
+    assert tool.get_tools() == []
+
+
+def test_get_tools_returns_one_callable_when_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """get_tools() returns exactly one callable when exec_command=True."""
+    monkeypatch.setenv("SANDBOX_MODE", "local")
+    observer = MockObserver(existing_actor=None)
+    tool = ExecTool()
+    tool.observer(observer)  # type: ignore[arg-type]
+
+    mock_proxy = MagicMock(spec=SandboxActor)
+    tool._sandbox_proxy = mock_proxy
+
+    tools = tool.get_tools()
+    assert len(tools) == 1
+    assert callable(tools[0])
+
+
+# ---------------------------------------------------------------------------
+# observer() return value — method chaining
+# ---------------------------------------------------------------------------
+
+
+def test_observer_returns_self(monkeypatch: pytest.MonkeyPatch) -> None:
+    """observer() returns the ExecTool instance for method chaining."""
+    monkeypatch.setenv("SANDBOX_MODE", "local")
+    observer = MockObserver(existing_actor=None)
+    tool = ExecTool()
+
+    result = tool.observer(observer)  # type: ignore[arg-type]
+
+    assert result is tool

--- a/tests/sandbox/test_exec_tool.py
+++ b/tests/sandbox/test_exec_tool.py
@@ -18,10 +18,9 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 import pytest
-
 from akgentic.core.actor_address import ActorAddress
+
 from akgentic.tool.sandbox.actor import (
-    ALLOWED_COMMANDS,
     SANDBOX_ACTOR_NAME,
     CommandNotAllowedError,
     ExecResult,
@@ -31,7 +30,6 @@ from akgentic.tool.sandbox.actor import (
 from akgentic.tool.sandbox.docker import DockerSandboxActor
 from akgentic.tool.sandbox.local import LocalSandboxActor
 from akgentic.tool.sandbox.tool import SANDBOX_ACTOR_CLASSES, ExecTool
-
 
 # ---------------------------------------------------------------------------
 # Mock observer infrastructure

--- a/tests/sandbox/test_exec_tool.py
+++ b/tests/sandbox/test_exec_tool.py
@@ -404,3 +404,58 @@ def test_exec_tool_mode_not_affected_by_sandbox_mode_env(
     call_args = observer._orch_proxy.createActor.call_args
     # Despite env var, LocalSandboxActor must be chosen (mode="local")
     assert call_args[0][0] is LocalSandboxActor
+
+
+# ---------------------------------------------------------------------------
+# Story 6.6: workspace_id field on ExecTool and pass-through to SandboxConfig
+# ---------------------------------------------------------------------------
+
+
+def test_exec_tool_workspace_id_defaults_to_none() -> None:
+    """FR-SB-32: ExecTool.workspace_id defaults to None."""
+    tool = ExecTool()
+    assert tool.workspace_id is None
+
+
+def test_exec_tool_workspace_id_can_be_set() -> None:
+    """FR-SB-32: ExecTool(workspace_id='test') stores workspace_id='test'."""
+    tool = ExecTool(workspace_id="test")
+    assert tool.workspace_id == "test"
+
+
+def test_observer_passes_workspace_id_to_sandbox_config() -> None:
+    """FR-SB-32: ExecTool.observer() passes workspace_id through to SandboxConfig."""
+    observer = MockObserver(existing_actor=None)
+    tool = ExecTool(workspace_id="test")
+
+    tool.observer(observer)  # type: ignore[arg-type]
+
+    call_kwargs = observer._orch_proxy.createActor.call_args[1]
+    config: SandboxConfig = call_kwargs["config"]
+    assert config.workspace_id == "test"
+
+
+def test_observer_passes_workspace_id_none_to_sandbox_config() -> None:
+    """FR-SB-32: ExecTool() (no workspace_id) passes workspace_id=None to SandboxConfig."""
+    observer = MockObserver(existing_actor=None)
+    tool = ExecTool()
+
+    tool.observer(observer)  # type: ignore[arg-type]
+
+    call_kwargs = observer._orch_proxy.createActor.call_args[1]
+    config: SandboxConfig = call_kwargs["config"]
+    assert config.workspace_id is None
+
+
+def test_observer_config_has_team_id_and_workspace_id_independently() -> None:
+    """FR-SB-32: SandboxConfig gets both team_id and workspace_id, independently set."""
+    observer = MockObserver(existing_actor=None)
+    observer._team_id = "t1"
+    tool = ExecTool(workspace_id="my-ws")
+
+    tool.observer(observer)  # type: ignore[arg-type]
+
+    call_kwargs = observer._orch_proxy.createActor.call_args[1]
+    config: SandboxConfig = call_kwargs["config"]
+    assert config.team_id == "t1"
+    assert config.workspace_id == "my-ws"

--- a/tests/sandbox/test_exec_tool.py
+++ b/tests/sandbox/test_exec_tool.py
@@ -1,16 +1,17 @@
-"""Tests for ExecTool — observer wiring, SANDBOX_MODE resolution, tool behaviour.
+"""Tests for ExecTool — observer wiring, mode field, tool behaviour.
 
-Covers AC1–AC13 for Story 6.4:
+Covers AC1–AC13 for Story 6.4 (updated for Story 6.5):
 - SANDBOX_ACTOR_CLASSES dict (AC1)
-- ExecTool fields (AC2)
+- ExecTool fields including mode (AC2)
 - observer() raises ValueError when orchestrator is None (AC3)
-- observer() creates LocalSandboxActor with SANDBOX_MODE=local (AC4)
-- observer() creates DockerSandboxActor with SANDBOX_MODE=docker (AC5)
+- observer() creates LocalSandboxActor with mode="local" (AC4)
+- observer() creates DockerSandboxActor with mode="docker" (AC5)
 - observer() reuses existing actor — no second createActor call (AC6)
-- observer() raises KeyError on unknown SANDBOX_MODE (AC7)
+- observer() raises KeyError on unknown mode (AC7)
 - exec_command returns formatted stdout/stderr/exit_code (AC8)
 - exec_command catches CommandNotAllowedError → error string (AC9)
 - get_tools() returns [] when exec_command=False (AC10)
+- Story 6.5: mode comes from ExecTool.mode field, not SANDBOX_MODE env var
 """
 
 from __future__ import annotations
@@ -92,7 +93,7 @@ def test_sandbox_actor_classes_is_mutable_dict() -> None:
 
 
 # ---------------------------------------------------------------------------
-# AC2 — ExecTool field defaults
+# AC2 — ExecTool field defaults (including mode)
 # ---------------------------------------------------------------------------
 
 
@@ -114,6 +115,18 @@ def test_exec_tool_exec_command_default_is_true() -> None:
     assert tool.exec_command is True
 
 
+def test_exec_tool_mode_defaults_to_local() -> None:
+    """Story 6.5: ExecTool.mode defaults to 'local'."""
+    tool = ExecTool()
+    assert tool.mode == "local"
+
+
+def test_exec_tool_mode_can_be_set_to_docker() -> None:
+    """Story 6.5: ExecTool(mode='docker') stores mode='docker'."""
+    tool = ExecTool(mode="docker")
+    assert tool.mode == "docker"
+
+
 # ---------------------------------------------------------------------------
 # AC3 — observer() raises ValueError when orchestrator is None
 # ---------------------------------------------------------------------------
@@ -129,15 +142,14 @@ def test_observer_raises_value_error_when_orchestrator_is_none() -> None:
 
 
 # ---------------------------------------------------------------------------
-# AC4 — observer() creates LocalSandboxActor when SANDBOX_MODE=local
+# AC4 — observer() creates LocalSandboxActor when mode="local"
 # ---------------------------------------------------------------------------
 
 
-def test_observer_creates_local_sandbox_actor(monkeypatch: pytest.MonkeyPatch) -> None:
-    """AC4: observer() with SANDBOX_MODE=local creates LocalSandboxActor."""
-    monkeypatch.setenv("SANDBOX_MODE", "local")
+def test_observer_creates_local_sandbox_actor() -> None:
+    """AC4: ExecTool(mode='local').observer() creates LocalSandboxActor."""
     observer = MockObserver(existing_actor=None)
-    tool = ExecTool()
+    tool = ExecTool(mode="local")
 
     tool.observer(observer)  # type: ignore[arg-type]
 
@@ -146,11 +158,10 @@ def test_observer_creates_local_sandbox_actor(monkeypatch: pytest.MonkeyPatch) -
     assert call_args[0][0] is LocalSandboxActor
 
 
-def test_observer_creates_actor_with_correct_config(monkeypatch: pytest.MonkeyPatch) -> None:
-    """AC4: SandboxConfig passed to createActor has name, role, and team_id."""
-    monkeypatch.setenv("SANDBOX_MODE", "local")
+def test_observer_creates_actor_with_correct_config() -> None:
+    """AC4: SandboxConfig passed to createActor has name, role, team_id, and mode."""
     observer = MockObserver(existing_actor=None)
-    tool = ExecTool()
+    tool = ExecTool(mode="local")
 
     tool.observer(observer)  # type: ignore[arg-type]
 
@@ -159,13 +170,13 @@ def test_observer_creates_actor_with_correct_config(monkeypatch: pytest.MonkeyPa
     assert config.name == SANDBOX_ACTOR_NAME
     assert config.role == "ToolActor"
     assert config.team_id == "team-test"
+    assert config.mode == "local"
 
 
-def test_observer_stores_sandbox_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_observer_stores_sandbox_proxy() -> None:
     """AC4: observer() stores a non-None _sandbox_proxy after wiring."""
-    monkeypatch.setenv("SANDBOX_MODE", "local")
     observer = MockObserver(existing_actor=None)
-    tool = ExecTool()
+    tool = ExecTool(mode="local")
 
     tool.observer(observer)  # type: ignore[arg-type]
 
@@ -173,15 +184,14 @@ def test_observer_stores_sandbox_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 # ---------------------------------------------------------------------------
-# AC5 — observer() creates DockerSandboxActor when SANDBOX_MODE=docker
+# AC5 — observer() creates DockerSandboxActor when mode="docker"
 # ---------------------------------------------------------------------------
 
 
-def test_observer_creates_docker_sandbox_actor(monkeypatch: pytest.MonkeyPatch) -> None:
-    """AC5: observer() with SANDBOX_MODE=docker creates DockerSandboxActor."""
-    monkeypatch.setenv("SANDBOX_MODE", "docker")
+def test_observer_creates_docker_sandbox_actor() -> None:
+    """AC5: ExecTool(mode='docker').observer() creates DockerSandboxActor."""
     observer = MockObserver(existing_actor=None)
-    tool = ExecTool()
+    tool = ExecTool(mode="docker")
 
     tool.observer(observer)  # type: ignore[arg-type]
 
@@ -190,14 +200,25 @@ def test_observer_creates_docker_sandbox_actor(monkeypatch: pytest.MonkeyPatch) 
     assert call_args[0][0] is DockerSandboxActor
 
 
+def test_observer_creates_docker_actor_config_has_mode_docker() -> None:
+    """Story 6.5: SandboxConfig for docker mode has mode='docker'."""
+    observer = MockObserver(existing_actor=None)
+    tool = ExecTool(mode="docker")
+
+    tool.observer(observer)  # type: ignore[arg-type]
+
+    call_kwargs = observer._orch_proxy.createActor.call_args[1]
+    config: SandboxConfig = call_kwargs["config"]
+    assert config.mode == "docker"
+
+
 # ---------------------------------------------------------------------------
 # AC6 — observer() reuses existing actor — does NOT call createActor again
 # ---------------------------------------------------------------------------
 
 
-def test_observer_reuses_existing_actor(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_observer_reuses_existing_actor() -> None:
     """AC6: when #SandboxActor already exists, createActor is NOT called."""
-    monkeypatch.setenv("SANDBOX_MODE", "local")
     existing_addr = MagicMock(spec=ActorAddress)
     observer = MockObserver(existing_actor=existing_addr)
     tool = ExecTool()
@@ -207,10 +228,8 @@ def test_observer_reuses_existing_actor(monkeypatch: pytest.MonkeyPatch) -> None
     observer._orch_proxy.createActor.assert_not_called()
 
 
-def test_observer_second_call_reuses_actor(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_observer_second_call_reuses_actor() -> None:
     """AC6: calling observer() a second time (actor already exists) does not create a new one."""
-    monkeypatch.setenv("SANDBOX_MODE", "local")
-
     # First call: no existing actor → creates one
     observer1 = MockObserver(existing_actor=None)
     tool = ExecTool()
@@ -226,17 +245,16 @@ def test_observer_second_call_reuses_actor(monkeypatch: pytest.MonkeyPatch) -> N
 
 
 # ---------------------------------------------------------------------------
-# AC7 — observer() raises KeyError on unknown SANDBOX_MODE
+# AC7 — observer() raises KeyError on unknown mode value
 # ---------------------------------------------------------------------------
 
 
-def test_observer_raises_key_error_on_unknown_sandbox_mode(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """AC7: SANDBOX_MODE=unknown → KeyError (fail-fast, no error handling added)."""
-    monkeypatch.setenv("SANDBOX_MODE", "unknown-backend")
+def test_observer_raises_key_error_on_unknown_mode() -> None:
+    """AC7: ExecTool(mode=...) with an unregistered mode → KeyError (fail-fast)."""
     observer = MockObserver(existing_actor=None)
+    # Bypass Literal validation by using object.__setattr__
     tool = ExecTool()
+    object.__setattr__(tool, "mode", "unknown-backend")
 
     with pytest.raises(KeyError):
         tool.observer(observer)  # type: ignore[arg-type]
@@ -247,11 +265,10 @@ def test_observer_raises_key_error_on_unknown_sandbox_mode(
 # ---------------------------------------------------------------------------
 
 
-def test_exec_command_returns_formatted_output(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_exec_command_returns_formatted_output() -> None:
     """AC8: exec_command returns 'stdout:\\n...\\nstderr:\\n...\\nexit_code: 0'."""
-    monkeypatch.setenv("SANDBOX_MODE", "local")
     observer = MockObserver(existing_actor=None)
-    tool = ExecTool()
+    tool = ExecTool(mode="local")
     tool.observer(observer)  # type: ignore[arg-type]
 
     # Replace proxy with a controlled mock
@@ -271,11 +288,10 @@ def test_exec_command_returns_formatted_output(monkeypatch: pytest.MonkeyPatch) 
     assert "stderr:" in result
 
 
-def test_exec_command_includes_stderr_in_output(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_exec_command_includes_stderr_in_output() -> None:
     """AC8: exec_command includes stderr in the returned string."""
-    monkeypatch.setenv("SANDBOX_MODE", "local")
     observer = MockObserver(existing_actor=None)
-    tool = ExecTool()
+    tool = ExecTool(mode="local")
     tool.observer(observer)  # type: ignore[arg-type]
 
     mock_proxy = MagicMock(spec=SandboxActor)
@@ -294,13 +310,10 @@ def test_exec_command_includes_stderr_in_output(monkeypatch: pytest.MonkeyPatch)
 # ---------------------------------------------------------------------------
 
 
-def test_exec_command_catches_command_not_allowed_error(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_exec_command_catches_command_not_allowed_error() -> None:
     """AC9: CommandNotAllowedError is caught and returned as an error string — not raised."""
-    monkeypatch.setenv("SANDBOX_MODE", "local")
     observer = MockObserver(existing_actor=None)
-    tool = ExecTool()
+    tool = ExecTool(mode="local")
     tool.observer(observer)  # type: ignore[arg-type]
 
     mock_proxy = MagicMock(spec=SandboxActor)
@@ -314,13 +327,10 @@ def test_exec_command_catches_command_not_allowed_error(
     assert not result.startswith("Traceback")  # must not have raised
 
 
-def test_exec_command_error_string_lists_allowed_commands(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_exec_command_error_string_lists_allowed_commands() -> None:
     """AC9: error string contains the sorted list of ALLOWED_COMMANDS."""
-    monkeypatch.setenv("SANDBOX_MODE", "local")
     observer = MockObserver(existing_actor=None)
-    tool = ExecTool()
+    tool = ExecTool(mode="local")
     tool.observer(observer)  # type: ignore[arg-type]
 
     mock_proxy = MagicMock(spec=SandboxActor)
@@ -346,11 +356,10 @@ def test_get_tools_returns_empty_list_when_exec_command_disabled() -> None:
     assert tool.get_tools() == []
 
 
-def test_get_tools_returns_one_callable_when_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_get_tools_returns_one_callable_when_enabled() -> None:
     """get_tools() returns exactly one callable when exec_command=True."""
-    monkeypatch.setenv("SANDBOX_MODE", "local")
     observer = MockObserver(existing_actor=None)
-    tool = ExecTool()
+    tool = ExecTool(mode="local")
     tool.observer(observer)  # type: ignore[arg-type]
 
     mock_proxy = MagicMock(spec=SandboxActor)
@@ -366,12 +375,32 @@ def test_get_tools_returns_one_callable_when_enabled(monkeypatch: pytest.MonkeyP
 # ---------------------------------------------------------------------------
 
 
-def test_observer_returns_self(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_observer_returns_self() -> None:
     """observer() returns the ExecTool instance for method chaining."""
-    monkeypatch.setenv("SANDBOX_MODE", "local")
     observer = MockObserver(existing_actor=None)
     tool = ExecTool()
 
     result = tool.observer(observer)  # type: ignore[arg-type]
 
     assert result is tool
+
+
+# ---------------------------------------------------------------------------
+# Story 6.5: no SANDBOX_MODE env var dependency
+# ---------------------------------------------------------------------------
+
+
+def test_exec_tool_mode_not_affected_by_sandbox_mode_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Story 6.5: SANDBOX_MODE env var has no effect — mode is read from ExecTool.mode."""
+    # Even if SANDBOX_MODE is set, ExecTool must use self.mode exclusively
+    monkeypatch.setenv("SANDBOX_MODE", "docker")
+    observer = MockObserver(existing_actor=None)
+    tool = ExecTool(mode="local")  # explicit local
+
+    tool.observer(observer)  # type: ignore[arg-type]
+
+    call_args = observer._orch_proxy.createActor.call_args
+    # Despite env var, LocalSandboxActor must be chosen (mode="local")
+    assert call_args[0][0] is LocalSandboxActor

--- a/tests/sandbox/test_local_sandbox.py
+++ b/tests/sandbox/test_local_sandbox.py
@@ -299,3 +299,64 @@ def test_public_exec_method_end_to_end(
     assert result.stdout == "passed"
     assert result.exit_code == 0
     mock_run.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Story 6.5: shared-filesystem invariant — WorkspaceTool and LocalSandboxActor
+# resolve to the same absolute path for the same team_id
+# ---------------------------------------------------------------------------
+
+
+def test_workspace_tool_and_local_sandbox_actor_resolve_same_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Story 6.5 AC: WorkspaceTool (via get_workspace) and LocalSandboxActor share the same
+    workspace root when AKGENTIC_WORKSPACES_ROOT is unset.
+
+    Both tools must resolve to the same absolute path for team-1 to guarantee
+    the shared-filesystem invariant (ADR-006).
+    """
+    from akgentic.tool.workspace.workspace import get_workspace
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("AKGENTIC_WORKSPACES_ROOT", raising=False)
+
+    # WorkspaceTool path (via get_workspace factory)
+    workspace = get_workspace("team-1")
+    workspace_tool_root = workspace._root.resolve()
+
+    # LocalSandboxActor path (via _start_sandbox())
+    actor = make_actor(team_id="team-1")
+    actor._start_sandbox()
+    sandbox_root = actor.state.workspace_path
+
+    assert sandbox_root is not None
+    assert workspace_tool_root == sandbox_root, (
+        f"WorkspaceTool root ({workspace_tool_root}) != "
+        f"LocalSandboxActor root ({sandbox_root})"
+    )
+
+
+def test_workspace_tool_and_local_sandbox_actor_resolve_same_path_custom_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Story 6.5 AC: Both tools use custom AKGENTIC_WORKSPACES_ROOT and resolve to same path."""
+    from akgentic.tool.workspace.workspace import get_workspace
+
+    custom_root = tmp_path / "shared-workspaces"
+    monkeypatch.setenv("AKGENTIC_WORKSPACES_ROOT", str(custom_root))
+
+    # WorkspaceTool path
+    workspace = get_workspace("team-1")
+    workspace_tool_root = workspace._root.resolve()
+
+    # LocalSandboxActor path
+    actor = make_actor(team_id="team-1")
+    actor._start_sandbox()
+    sandbox_root = actor.state.workspace_path
+
+    assert sandbox_root is not None
+    assert workspace_tool_root == sandbox_root, (
+        f"WorkspaceTool root ({workspace_tool_root}) != "
+        f"LocalSandboxActor root ({sandbox_root})"
+    )

--- a/tests/sandbox/test_local_sandbox.py
+++ b/tests/sandbox/test_local_sandbox.py
@@ -1,0 +1,249 @@
+"""Tests for LocalSandboxActor — subprocess-based sandbox execution.
+
+Covers AC1 through AC7 for Story 6.2:
+- _start_sandbox() creates workspace directory and stores absolute path
+- _start_sandbox() is idempotent (calling twice does not raise)
+- _stop_sandbox() is a no-op
+- _exec() with empty cwd uses state.workspace_path directly
+- _exec() with non-empty cwd uses state.workspace_path / cwd
+- _exec() returns ExecResult with correct stdout, stderr, exit_code
+- subprocess.TimeoutExpired propagates from _exec()
+- exec() public method works end-to-end through _exec()
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from akgentic.tool.sandbox.actor import ExecResult, SandboxConfig, SandboxState
+from akgentic.tool.sandbox.local import LocalSandboxActor
+
+
+# ---------------------------------------------------------------------------
+# Helper factory
+# ---------------------------------------------------------------------------
+
+
+def make_actor(team_id: str = "team-test") -> LocalSandboxActor:
+    """Create a LocalSandboxActor with config and state pre-initialized (no Pykka runtime)."""
+    actor = LocalSandboxActor()
+    actor.config = SandboxConfig(name="sandbox", role="ToolActor", team_id=team_id)
+    actor.state = SandboxState()
+    actor.state.observer(actor)
+    return actor
+
+
+# ---------------------------------------------------------------------------
+# AC1: _start_sandbox() creates workspace and stores absolute path
+# ---------------------------------------------------------------------------
+
+
+def test_start_sandbox_creates_workspace_directory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """AC1: _start_sandbox() creates ./workspaces/team-1/ relative to CWD."""
+    monkeypatch.chdir(tmp_path)
+    actor = make_actor(team_id="team-1")
+
+    actor._start_sandbox()
+
+    expected = tmp_path / "workspaces" / "team-1"
+    assert expected.exists()
+    assert expected.is_dir()
+
+
+def test_start_sandbox_stores_absolute_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """AC1: _start_sandbox() stores resolved absolute path in state.workspace_path."""
+    monkeypatch.chdir(tmp_path)
+    actor = make_actor(team_id="team-1")
+
+    actor._start_sandbox()
+
+    assert actor.state.workspace_path is not None
+    assert actor.state.workspace_path.is_absolute()
+    assert actor.state.workspace_path == (tmp_path / "workspaces" / "team-1").resolve()
+
+
+def test_start_sandbox_calls_notify_state_change(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """AC1: _start_sandbox() calls state.notify_state_change() — verified via class-level patch."""
+    monkeypatch.chdir(tmp_path)
+    actor = make_actor(team_id="team-1")
+
+    with patch("akgentic.tool.sandbox.actor.SandboxState.notify_state_change") as mock_notify:
+        actor._start_sandbox()
+        mock_notify.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# AC2: _start_sandbox() is idempotent
+# ---------------------------------------------------------------------------
+
+
+def test_start_sandbox_is_idempotent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """AC2: Calling _start_sandbox() twice does not raise."""
+    monkeypatch.chdir(tmp_path)
+    actor = make_actor(team_id="team-1")
+
+    actor._start_sandbox()
+    actor._start_sandbox()  # Must not raise
+
+    expected = tmp_path / "workspaces" / "team-1"
+    assert expected.exists()
+
+
+# ---------------------------------------------------------------------------
+# AC3: _stop_sandbox() is a no-op
+# ---------------------------------------------------------------------------
+
+
+def test_stop_sandbox_is_noop(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """AC3: _stop_sandbox() returns None and has no side effects."""
+    monkeypatch.chdir(tmp_path)
+    actor = make_actor(team_id="team-1")
+    actor._start_sandbox()
+
+    result = actor._stop_sandbox()
+
+    assert result is None
+
+
+def test_stop_sandbox_does_not_remove_workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """AC3: _stop_sandbox() leaves the workspace directory intact."""
+    monkeypatch.chdir(tmp_path)
+    actor = make_actor(team_id="team-1")
+    actor._start_sandbox()
+
+    actor._stop_sandbox()
+
+    expected = tmp_path / "workspaces" / "team-1"
+    assert expected.exists()
+
+
+# ---------------------------------------------------------------------------
+# AC4: _exec() with empty cwd uses state.workspace_path
+# ---------------------------------------------------------------------------
+
+
+@patch("akgentic.tool.sandbox.local.subprocess.run")
+def test_exec_no_cwd_uses_workspace_path(mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """AC4: _exec(cmd, cwd='') passes state.workspace_path as cwd to subprocess.run."""
+    monkeypatch.chdir(tmp_path)
+    actor = make_actor(team_id="team-1")
+    actor._start_sandbox()
+
+    mock_run.return_value = MagicMock(stdout="output", stderr="", returncode=0)
+
+    actor._exec("pytest tests/", "")
+
+    mock_run.assert_called_once_with(
+        ["pytest", "tests/"],
+        cwd=str(actor.state.workspace_path),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC5: _exec() with non-empty cwd uses state.workspace_path / cwd
+# ---------------------------------------------------------------------------
+
+
+@patch("akgentic.tool.sandbox.local.subprocess.run")
+def test_exec_with_cwd_appends_to_workspace_path(mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """AC5: _exec(cmd, cwd='src') passes state.workspace_path / 'src' as cwd."""
+    monkeypatch.chdir(tmp_path)
+    actor = make_actor(team_id="team-1")
+    actor._start_sandbox()
+
+    mock_run.return_value = MagicMock(stdout="output", stderr="", returncode=0)
+
+    actor._exec("pytest tests/", "src")
+
+    expected_cwd = str(actor.state.workspace_path / "src")
+    mock_run.assert_called_once_with(
+        ["pytest", "tests/"],
+        cwd=expected_cwd,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC4 / AC5: _exec() returns ExecResult with correct fields
+# ---------------------------------------------------------------------------
+
+
+@patch("akgentic.tool.sandbox.local.subprocess.run")
+def test_exec_returns_exec_result(mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """_exec() returns ExecResult with stdout, stderr, exit_code from subprocess.run."""
+    monkeypatch.chdir(tmp_path)
+    actor = make_actor(team_id="team-1")
+    actor._start_sandbox()
+
+    mock_run.return_value = MagicMock(stdout="test passed", stderr="warning", returncode=0)
+
+    result = actor._exec("pytest tests/", "")
+
+    assert isinstance(result, ExecResult)
+    assert result.stdout == "test passed"
+    assert result.stderr == "warning"
+    assert result.exit_code == 0
+
+
+@patch("akgentic.tool.sandbox.local.subprocess.run")
+def test_exec_captures_non_zero_exit_code(mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """_exec() correctly captures non-zero exit codes from subprocess.run."""
+    monkeypatch.chdir(tmp_path)
+    actor = make_actor(team_id="team-1")
+    actor._start_sandbox()
+
+    mock_run.return_value = MagicMock(stdout="", stderr="test failed", returncode=1)
+
+    result = actor._exec("pytest tests/", "")
+
+    assert result.exit_code == 1
+    assert result.stderr == "test failed"
+
+
+# ---------------------------------------------------------------------------
+# AC6: subprocess.TimeoutExpired propagates
+# ---------------------------------------------------------------------------
+
+
+@patch("akgentic.tool.sandbox.local.subprocess.run")
+def test_exec_timeout_propagates(mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """AC6: subprocess.TimeoutExpired from subprocess.run propagates out of _exec()."""
+    monkeypatch.chdir(tmp_path)
+    actor = make_actor(team_id="team-1")
+    actor._start_sandbox()
+
+    mock_run.side_effect = subprocess.TimeoutExpired(cmd=["sleep", "999"], timeout=30)
+
+    with pytest.raises(subprocess.TimeoutExpired):
+        actor._exec("sleep 999", "")
+
+
+# ---------------------------------------------------------------------------
+# AC7: exec() public method works end-to-end
+# ---------------------------------------------------------------------------
+
+
+@patch("akgentic.tool.sandbox.local.subprocess.run")
+def test_public_exec_method_end_to_end(mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """AC7: actor.exec() through inherited SandboxActor.exec() delegates to _exec()."""
+    monkeypatch.chdir(tmp_path)
+    actor = make_actor(team_id="team-1")
+    actor.on_start()  # Use the full lifecycle (sets state via SandboxActor.on_start)
+
+    mock_run.return_value = MagicMock(stdout="passed", stderr="", returncode=0)
+
+    result = actor.exec("pytest tests/")
+
+    assert isinstance(result, ExecResult)
+    assert result.stdout == "passed"
+    assert result.exit_code == 0
+    mock_run.assert_called_once()

--- a/tests/sandbox/test_local_sandbox.py
+++ b/tests/sandbox/test_local_sandbox.py
@@ -19,9 +19,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from akgentic.tool.sandbox.actor import ExecResult, SandboxConfig, SandboxState
+from akgentic.tool.sandbox.actor import (
+    ExecResult,
+    SandboxConfig,
+    SandboxState,
+)
 from akgentic.tool.sandbox.local import LocalSandboxActor
-
 
 # ---------------------------------------------------------------------------
 # Helper factory
@@ -42,7 +45,9 @@ def make_actor(team_id: str = "team-test") -> LocalSandboxActor:
 # ---------------------------------------------------------------------------
 
 
-def test_start_sandbox_creates_workspace_directory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_start_sandbox_creates_workspace_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """AC1: _start_sandbox() creates ./workspaces/team-1/ relative to CWD."""
     monkeypatch.chdir(tmp_path)
     actor = make_actor(team_id="team-1")
@@ -54,7 +59,9 @@ def test_start_sandbox_creates_workspace_directory(tmp_path: Path, monkeypatch: 
     assert expected.is_dir()
 
 
-def test_start_sandbox_stores_absolute_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_start_sandbox_stores_absolute_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """AC1: _start_sandbox() stores resolved absolute path in state.workspace_path."""
     monkeypatch.chdir(tmp_path)
     actor = make_actor(team_id="team-1")
@@ -66,7 +73,9 @@ def test_start_sandbox_stores_absolute_path(tmp_path: Path, monkeypatch: pytest.
     assert actor.state.workspace_path == (tmp_path / "workspaces" / "team-1").resolve()
 
 
-def test_start_sandbox_calls_notify_state_change(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_start_sandbox_calls_notify_state_change(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """AC1: _start_sandbox() calls state.notify_state_change() — verified via class-level patch."""
     monkeypatch.chdir(tmp_path)
     actor = make_actor(team_id="team-1")
@@ -109,7 +118,9 @@ def test_stop_sandbox_is_noop(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -
     assert result is None
 
 
-def test_stop_sandbox_does_not_remove_workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_stop_sandbox_does_not_remove_workspace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """AC3: _stop_sandbox() leaves the workspace directory intact."""
     monkeypatch.chdir(tmp_path)
     actor = make_actor(team_id="team-1")
@@ -127,7 +138,9 @@ def test_stop_sandbox_does_not_remove_workspace(tmp_path: Path, monkeypatch: pyt
 
 
 @patch("akgentic.tool.sandbox.local.subprocess.run")
-def test_exec_no_cwd_uses_workspace_path(mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_exec_no_cwd_uses_workspace_path(
+    mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """AC4: _exec(cmd, cwd='') passes state.workspace_path as cwd to subprocess.run."""
     monkeypatch.chdir(tmp_path)
     actor = make_actor(team_id="team-1")
@@ -152,7 +165,9 @@ def test_exec_no_cwd_uses_workspace_path(mock_run: MagicMock, tmp_path: Path, mo
 
 
 @patch("akgentic.tool.sandbox.local.subprocess.run")
-def test_exec_with_cwd_appends_to_workspace_path(mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_exec_with_cwd_appends_to_workspace_path(
+    mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """AC5: _exec(cmd, cwd='src') passes state.workspace_path / 'src' as cwd."""
     monkeypatch.chdir(tmp_path)
     actor = make_actor(team_id="team-1")
@@ -178,7 +193,9 @@ def test_exec_with_cwd_appends_to_workspace_path(mock_run: MagicMock, tmp_path: 
 
 
 @patch("akgentic.tool.sandbox.local.subprocess.run")
-def test_exec_returns_exec_result(mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_exec_returns_exec_result(
+    mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """_exec() returns ExecResult with stdout, stderr, exit_code from subprocess.run."""
     monkeypatch.chdir(tmp_path)
     actor = make_actor(team_id="team-1")
@@ -195,7 +212,9 @@ def test_exec_returns_exec_result(mock_run: MagicMock, tmp_path: Path, monkeypat
 
 
 @patch("akgentic.tool.sandbox.local.subprocess.run")
-def test_exec_captures_non_zero_exit_code(mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_exec_captures_non_zero_exit_code(
+    mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """_exec() correctly captures non-zero exit codes from subprocess.run."""
     monkeypatch.chdir(tmp_path)
     actor = make_actor(team_id="team-1")
@@ -215,7 +234,9 @@ def test_exec_captures_non_zero_exit_code(mock_run: MagicMock, tmp_path: Path, m
 
 
 @patch("akgentic.tool.sandbox.local.subprocess.run")
-def test_exec_timeout_propagates(mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_exec_timeout_propagates(
+    mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """AC6: subprocess.TimeoutExpired from subprocess.run propagates out of _exec()."""
     monkeypatch.chdir(tmp_path)
     actor = make_actor(team_id="team-1")
@@ -233,7 +254,9 @@ def test_exec_timeout_propagates(mock_run: MagicMock, tmp_path: Path, monkeypatc
 
 
 @patch("akgentic.tool.sandbox.local.subprocess.run")
-def test_public_exec_method_end_to_end(mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_public_exec_method_end_to_end(
+    mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """AC7: actor.exec() through inherited SandboxActor.exec() delegates to _exec()."""
     monkeypatch.chdir(tmp_path)
     actor = make_actor(team_id="team-1")

--- a/tests/sandbox/test_local_sandbox.py
+++ b/tests/sandbox/test_local_sandbox.py
@@ -1,7 +1,8 @@
 """Tests for LocalSandboxActor — subprocess-based sandbox execution.
 
-Covers AC1 through AC7 for Story 6.2:
+Covers AC1 through AC7 for Story 6.2 (updated for Story 6.5):
 - _start_sandbox() creates workspace directory and stores absolute path
+- _start_sandbox() uses AKGENTIC_WORKSPACES_ROOT (default ./workspaces)
 - _start_sandbox() is idempotent (calling twice does not raise)
 - _stop_sandbox() is a no-op
 - _exec() with empty cwd uses state.workspace_path directly
@@ -48,8 +49,9 @@ def make_actor(team_id: str = "team-test") -> LocalSandboxActor:
 def test_start_sandbox_creates_workspace_directory(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """AC1: _start_sandbox() creates ./workspaces/team-1/ relative to CWD."""
+    """AC1: _start_sandbox() creates ./workspaces/team-1/ relative to CWD (default root)."""
     monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("AKGENTIC_WORKSPACES_ROOT", raising=False)
     actor = make_actor(team_id="team-1")
 
     actor._start_sandbox()
@@ -64,6 +66,7 @@ def test_start_sandbox_stores_absolute_path(
 ) -> None:
     """AC1: _start_sandbox() stores resolved absolute path in state.workspace_path."""
     monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("AKGENTIC_WORKSPACES_ROOT", raising=False)
     actor = make_actor(team_id="team-1")
 
     actor._start_sandbox()
@@ -73,11 +76,28 @@ def test_start_sandbox_stores_absolute_path(
     assert actor.state.workspace_path == (tmp_path / "workspaces" / "team-1").resolve()
 
 
+def test_start_sandbox_uses_custom_workspaces_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Story 6.5: _start_sandbox() uses AKGENTIC_WORKSPACES_ROOT when set."""
+    custom_root = tmp_path / "my-custom-root"
+    monkeypatch.setenv("AKGENTIC_WORKSPACES_ROOT", str(custom_root))
+    actor = make_actor(team_id="team-1")
+
+    actor._start_sandbox()
+
+    expected = custom_root / "team-1"
+    assert expected.exists()
+    assert expected.is_dir()
+    assert actor.state.workspace_path == expected.resolve()
+
+
 def test_start_sandbox_calls_notify_state_change(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """AC1: _start_sandbox() calls state.notify_state_change() — verified via class-level patch."""
     monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("AKGENTIC_WORKSPACES_ROOT", raising=False)
     actor = make_actor(team_id="team-1")
 
     with patch("akgentic.tool.sandbox.actor.SandboxState.notify_state_change") as mock_notify:
@@ -93,6 +113,7 @@ def test_start_sandbox_calls_notify_state_change(
 def test_start_sandbox_is_idempotent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """AC2: Calling _start_sandbox() twice does not raise."""
     monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("AKGENTIC_WORKSPACES_ROOT", raising=False)
     actor = make_actor(team_id="team-1")
 
     actor._start_sandbox()
@@ -110,6 +131,7 @@ def test_start_sandbox_is_idempotent(tmp_path: Path, monkeypatch: pytest.MonkeyP
 def test_stop_sandbox_is_noop(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """AC3: _stop_sandbox() returns None and has no side effects."""
     monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("AKGENTIC_WORKSPACES_ROOT", raising=False)
     actor = make_actor(team_id="team-1")
     actor._start_sandbox()
 
@@ -123,6 +145,7 @@ def test_stop_sandbox_does_not_remove_workspace(
 ) -> None:
     """AC3: _stop_sandbox() leaves the workspace directory intact."""
     monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("AKGENTIC_WORKSPACES_ROOT", raising=False)
     actor = make_actor(team_id="team-1")
     actor._start_sandbox()
 
@@ -143,6 +166,7 @@ def test_exec_no_cwd_uses_workspace_path(
 ) -> None:
     """AC4: _exec(cmd, cwd='') passes state.workspace_path as cwd to subprocess.run."""
     monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("AKGENTIC_WORKSPACES_ROOT", raising=False)
     actor = make_actor(team_id="team-1")
     actor._start_sandbox()
 
@@ -170,6 +194,7 @@ def test_exec_with_cwd_appends_to_workspace_path(
 ) -> None:
     """AC5: _exec(cmd, cwd='src') passes state.workspace_path / 'src' as cwd."""
     monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("AKGENTIC_WORKSPACES_ROOT", raising=False)
     actor = make_actor(team_id="team-1")
     actor._start_sandbox()
 
@@ -198,6 +223,7 @@ def test_exec_returns_exec_result(
 ) -> None:
     """_exec() returns ExecResult with stdout, stderr, exit_code from subprocess.run."""
     monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("AKGENTIC_WORKSPACES_ROOT", raising=False)
     actor = make_actor(team_id="team-1")
     actor._start_sandbox()
 
@@ -217,6 +243,7 @@ def test_exec_captures_non_zero_exit_code(
 ) -> None:
     """_exec() correctly captures non-zero exit codes from subprocess.run."""
     monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("AKGENTIC_WORKSPACES_ROOT", raising=False)
     actor = make_actor(team_id="team-1")
     actor._start_sandbox()
 
@@ -239,6 +266,7 @@ def test_exec_timeout_propagates(
 ) -> None:
     """AC6: subprocess.TimeoutExpired from subprocess.run propagates out of _exec()."""
     monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("AKGENTIC_WORKSPACES_ROOT", raising=False)
     actor = make_actor(team_id="team-1")
     actor._start_sandbox()
 
@@ -259,6 +287,7 @@ def test_public_exec_method_end_to_end(
 ) -> None:
     """AC7: actor.exec() through inherited SandboxActor.exec() delegates to _exec()."""
     monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("AKGENTIC_WORKSPACES_ROOT", raising=False)
     actor = make_actor(team_id="team-1")
     actor.on_start()  # Use the full lifecycle (sets state via SandboxActor.on_start)
 

--- a/tests/sandbox/test_local_sandbox.py
+++ b/tests/sandbox/test_local_sandbox.py
@@ -32,10 +32,12 @@ from akgentic.tool.sandbox.local import LocalSandboxActor
 # ---------------------------------------------------------------------------
 
 
-def make_actor(team_id: str = "team-test") -> LocalSandboxActor:
+def make_actor(team_id: str = "team-test", workspace_id: str | None = None) -> LocalSandboxActor:
     """Create a LocalSandboxActor with config and state pre-initialized (no Pykka runtime)."""
     actor = LocalSandboxActor()
-    actor.config = SandboxConfig(name="sandbox", role="ToolActor", team_id=team_id)
+    actor.config = SandboxConfig(
+        name="sandbox", role="ToolActor", team_id=team_id, workspace_id=workspace_id
+    )
     actor.state = SandboxState()
     actor.state.observer(actor)
     return actor
@@ -352,6 +354,68 @@ def test_workspace_tool_and_local_sandbox_actor_resolve_same_path_custom_root(
 
     # LocalSandboxActor path
     actor = make_actor(team_id="team-1")
+    actor._start_sandbox()
+    sandbox_root = actor.state.workspace_path
+
+    assert sandbox_root is not None
+    assert workspace_tool_root == sandbox_root, (
+        f"WorkspaceTool root ({workspace_tool_root}) != "
+        f"LocalSandboxActor root ({sandbox_root})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Story 6.6: workspace_id overrides team_id for workspace directory name
+# ---------------------------------------------------------------------------
+
+
+def test_start_sandbox_workspace_id_overrides_team_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """FR-SB-33: When workspace_id is set, workspace path uses workspace_id, not team_id."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("AKGENTIC_WORKSPACES_ROOT", raising=False)
+    actor = make_actor(team_id="team-1", workspace_id="test")
+
+    actor._start_sandbox()
+
+    expected = tmp_path / "workspaces" / "test"
+    assert expected.exists()
+    assert expected.is_dir()
+    assert actor.state.workspace_path == expected.resolve()
+
+
+def test_start_sandbox_workspace_id_none_falls_back_to_team_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """FR-SB-33: When workspace_id is None, workspace path uses team_id (unchanged default)."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("AKGENTIC_WORKSPACES_ROOT", raising=False)
+    actor = make_actor(team_id="team-1", workspace_id=None)
+
+    actor._start_sandbox()
+
+    expected = tmp_path / "workspaces" / "team-1"
+    assert expected.exists()
+    assert actor.state.workspace_path == expected.resolve()
+
+
+def test_exec_tool_and_workspace_tool_resolve_same_path_via_workspace_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """FR-SB-35: ExecTool(workspace_id='test') and WorkspaceTool(workspace_id='test')
+    resolve to the same absolute directory when AKGENTIC_WORKSPACES_ROOT is set.
+    """
+    from akgentic.tool.workspace.workspace import get_workspace
+
+    monkeypatch.setenv("AKGENTIC_WORKSPACES_ROOT", str(tmp_path / "workspaces"))
+
+    # WorkspaceTool path via get_workspace (mirrors WorkspaceReadTool.observer logic)
+    workspace = get_workspace("test")
+    workspace_tool_root = workspace._root.resolve()
+
+    # LocalSandboxActor path with workspace_id="test"
+    actor = make_actor(team_id="team-1", workspace_id="test")
     actor._start_sandbox()
     sandbox_root = actor.state.workspace_path
 

--- a/tests/sandbox/test_sandbox_actor.py
+++ b/tests/sandbox/test_sandbox_actor.py
@@ -9,9 +9,9 @@ Covers AC1 through AC9 for Story 6.1:
 
 from __future__ import annotations
 
-import pytest
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+
+import pytest
 
 from akgentic.tool.sandbox.actor import (
     ALLOWED_COMMANDS,
@@ -23,7 +23,6 @@ from akgentic.tool.sandbox.actor import (
     SandboxConfig,
     SandboxState,
 )
-
 
 # ---------------------------------------------------------------------------
 # Minimal concrete stub — required because SandboxActor is abstract
@@ -238,6 +237,15 @@ def test_exec_disallowed_command_error_message_contains_binary() -> None:
         actor.exec("malware --install")
 
 
+def test_exec_empty_command_raises_error() -> None:
+    """exec('') raises CommandNotAllowedError — empty string has no binary token."""
+    actor = ConcreteSandboxActor()
+    actor.on_start()
+
+    with pytest.raises(CommandNotAllowedError, match="empty"):
+        actor.exec("")
+
+
 # ---------------------------------------------------------------------------
 # exec() allowlist edge case (AC6)
 # ---------------------------------------------------------------------------
@@ -320,13 +328,8 @@ def test_on_stop_calls_super_on_stop() -> None:
     actor = FailingStopSandboxActor()
     actor.on_start()
 
-    super_called = False
-
-    import akgentic.tool.sandbox.actor as actor_module
-    original_super = super
-
-    # Patch super() inside on_stop to track the call
-    # Instead, we verify indirectly: on_stop() must not raise
-    # and state observer is still intact (super().on_stop() is a Pykka hook, no-op in unit tests)
+    # Verify indirectly: on_stop() must not raise.
+    # super().on_stop() is a Pykka hook (no-op in unit tests without a running actor system).
+    # If we reach the end of this call without exception, super().on_stop() was not blocked
+    # by the _stop_sandbox() failure.
     actor.on_stop()  # Should not raise
-    # If we reach here, super().on_stop() was not blocked by _stop_sandbox exception

--- a/tests/sandbox/test_sandbox_actor.py
+++ b/tests/sandbox/test_sandbox_actor.py
@@ -1,0 +1,332 @@
+"""Tests for SandboxActor base class — models, allowlist, and lifecycle.
+
+Covers AC1 through AC9 for Story 6.1:
+- SandboxConfig, SandboxState, ExecResult model validation
+- ALLOWED_COMMANDS allowlist pass/fail/edge cases
+- CommandNotAllowedError raised on disallowed binary
+- on_start() / on_stop() lifecycle via a minimal concrete stub
+"""
+
+from __future__ import annotations
+
+import pytest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from akgentic.tool.sandbox.actor import (
+    ALLOWED_COMMANDS,
+    SANDBOX_ACTOR_NAME,
+    SANDBOX_ACTOR_ROLE,
+    CommandNotAllowedError,
+    ExecResult,
+    SandboxActor,
+    SandboxConfig,
+    SandboxState,
+)
+
+
+# ---------------------------------------------------------------------------
+# Minimal concrete stub — required because SandboxActor is abstract
+# ---------------------------------------------------------------------------
+
+
+class ConcreteSandboxActor(SandboxActor):
+    """Minimal non-abstract subclass for unit testing."""
+
+    def _start_sandbox(self) -> None:
+        pass  # no-op for testing
+
+    def _stop_sandbox(self) -> None:
+        pass  # no-op for testing
+
+    def _exec(self, cmd: str, cwd: str) -> ExecResult:
+        return ExecResult(stdout="ok", stderr="", exit_code=0)
+
+
+class FailingStopSandboxActor(ConcreteSandboxActor):
+    """Subclass whose _stop_sandbox always raises, for on_stop() swallow test."""
+
+    def _stop_sandbox(self) -> None:
+        raise RuntimeError("Sandbox stop failed")
+
+
+# ---------------------------------------------------------------------------
+# Module constants
+# ---------------------------------------------------------------------------
+
+
+def test_sandbox_actor_name_constant() -> None:
+    """AC3: SANDBOX_ACTOR_NAME is the expected string."""
+    assert SANDBOX_ACTOR_NAME == "#SandboxActor"
+
+
+def test_sandbox_actor_role_constant() -> None:
+    """AC3: SANDBOX_ACTOR_ROLE is the expected string."""
+    assert SANDBOX_ACTOR_ROLE == "ToolActor"
+
+
+# ---------------------------------------------------------------------------
+# SandboxConfig model validation (AC1)
+# ---------------------------------------------------------------------------
+
+
+def test_sandbox_config_requires_team_id() -> None:
+    """SandboxConfig raises ValidationError when team_id is missing."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        SandboxConfig(name="test", role="ToolActor")  # type: ignore[call-arg]
+
+
+def test_sandbox_config_valid() -> None:
+    """SandboxConfig accepts name, role, and team_id."""
+    config = SandboxConfig(name="sandbox", role="ToolActor", team_id="team-42")
+    assert config.team_id == "team-42"
+    assert config.name == "sandbox"
+    assert config.role == "ToolActor"
+
+
+# ---------------------------------------------------------------------------
+# SandboxState model validation (AC1)
+# ---------------------------------------------------------------------------
+
+
+def test_sandbox_state_defaults() -> None:
+    """SandboxState has workspace_path=None and container_name=None by default."""
+    state = SandboxState()
+    assert state.workspace_path is None
+    assert state.container_name is None
+
+
+def test_sandbox_state_with_values() -> None:
+    """SandboxState accepts Path and string values."""
+    state = SandboxState(workspace_path=Path("/tmp/ws"), container_name="my-container")
+    assert state.workspace_path == Path("/tmp/ws")
+    assert state.container_name == "my-container"
+
+
+# ---------------------------------------------------------------------------
+# ExecResult model validation (AC1)
+# ---------------------------------------------------------------------------
+
+
+def test_exec_result_valid() -> None:
+    """ExecResult accepts stdout, stderr, exit_code."""
+    result = ExecResult(stdout="hello", stderr="", exit_code=0)
+    assert result.stdout == "hello"
+    assert result.stderr == ""
+    assert result.exit_code == 0
+
+
+def test_exec_result_requires_all_fields() -> None:
+    """ExecResult raises ValidationError when required fields are missing."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        ExecResult(stdout="hello", stderr="")  # type: ignore[call-arg]
+
+
+def test_exec_result_non_zero_exit_code() -> None:
+    """ExecResult stores non-zero exit codes."""
+    result = ExecResult(stdout="", stderr="error output", exit_code=1)
+    assert result.exit_code == 1
+    assert result.stderr == "error output"
+
+
+# ---------------------------------------------------------------------------
+# ALLOWED_COMMANDS (AC2)
+# ---------------------------------------------------------------------------
+
+
+def test_allowed_commands_is_frozenset() -> None:
+    """ALLOWED_COMMANDS is a frozenset."""
+    assert isinstance(ALLOWED_COMMANDS, frozenset)
+
+
+def test_allowed_commands_exact_set() -> None:
+    """AC2: ALLOWED_COMMANDS contains exactly the FR-SB-5 binaries."""
+    expected = frozenset(
+        {
+            "python",
+            "python3",
+            "pytest",
+            "ruff",
+            "mypy",
+            "git",
+            "uv",
+            "pip",
+            "cat",
+            "ls",
+            "find",
+            "grep",
+            "mkdir",
+            "cp",
+            "mv",
+            "rm",
+            "echo",
+            "touch",
+            "curl",
+            "wget",
+            "make",
+            "bash",
+            "sh",
+            "node",
+            "npm",
+            "npx",
+        }
+    )
+    assert ALLOWED_COMMANDS == expected
+
+
+# ---------------------------------------------------------------------------
+# exec() allowlist pass (AC4)
+# ---------------------------------------------------------------------------
+
+
+def test_exec_allowed_command_delegates_to_exec_impl() -> None:
+    """AC4: exec('python main.py') delegates to _exec and returns its ExecResult."""
+    actor = ConcreteSandboxActor()
+    actor.on_start()
+
+    result = actor.exec("python main.py")
+
+    assert isinstance(result, ExecResult)
+    assert result.stdout == "ok"
+    assert result.exit_code == 0
+
+
+def test_exec_allowed_command_passes_cmd_and_cwd() -> None:
+    """exec() passes cmd and cwd to _exec unmodified."""
+    actor = ConcreteSandboxActor()
+    actor.on_start()
+
+    received: list[tuple[str, str]] = []
+
+    original_exec = actor._exec
+
+    def capturing_exec(cmd: str, cwd: str) -> ExecResult:
+        received.append((cmd, cwd))
+        return original_exec(cmd, cwd)
+
+    actor._exec = capturing_exec  # type: ignore[method-assign]
+
+    actor.exec("python main.py", "/workspace")
+
+    assert received == [("python main.py", "/workspace")]
+
+
+# ---------------------------------------------------------------------------
+# exec() allowlist fail (AC5)
+# ---------------------------------------------------------------------------
+
+
+def test_exec_disallowed_command_raises_error() -> None:
+    """AC5: exec('malware --install') raises CommandNotAllowedError."""
+    actor = ConcreteSandboxActor()
+    actor.on_start()
+
+    with pytest.raises(CommandNotAllowedError):
+        actor.exec("malware --install")
+
+
+def test_exec_disallowed_command_error_message_contains_binary() -> None:
+    """CommandNotAllowedError message names the disallowed binary."""
+    actor = ConcreteSandboxActor()
+    actor.on_start()
+
+    with pytest.raises(CommandNotAllowedError, match="malware"):
+        actor.exec("malware --install")
+
+
+# ---------------------------------------------------------------------------
+# exec() allowlist edge case (AC6)
+# ---------------------------------------------------------------------------
+
+
+def test_exec_rm_rf_passes_allowlist() -> None:
+    """AC6: exec('rm -rf /') passes — only 'rm' binary is checked, not args."""
+    actor = ConcreteSandboxActor()
+    actor.on_start()
+
+    # Should NOT raise — 'rm' is in ALLOWED_COMMANDS
+    result = actor.exec("rm -rf /")
+    assert isinstance(result, ExecResult)
+
+
+# ---------------------------------------------------------------------------
+# on_start() lifecycle (AC7)
+# ---------------------------------------------------------------------------
+
+
+def test_on_start_initializes_state() -> None:
+    """AC7: on_start() creates a SandboxState instance."""
+    actor = ConcreteSandboxActor()
+    actor.on_start()
+
+    assert isinstance(actor.state, SandboxState)
+
+
+def test_on_start_calls_start_sandbox() -> None:
+    """AC7: on_start() calls _start_sandbox()."""
+    actor = ConcreteSandboxActor()
+    call_count = 0
+
+    original = actor._start_sandbox
+
+    def tracking_start() -> None:
+        nonlocal call_count
+        call_count += 1
+        original()
+
+    actor._start_sandbox = tracking_start  # type: ignore[method-assign]
+    actor.on_start()
+
+    assert call_count == 1
+
+
+def test_on_start_registers_state_observer() -> None:
+    """on_start() registers the actor as a state observer."""
+    actor = ConcreteSandboxActor()
+    actor.on_start()
+
+    # The state's _observer should be the actor itself
+    assert actor.state._observer is actor
+
+
+# ---------------------------------------------------------------------------
+# on_stop() exception swallowing (AC8)
+# ---------------------------------------------------------------------------
+
+
+def test_on_stop_swallows_stop_sandbox_exception() -> None:
+    """AC8: on_stop() swallows exceptions from _stop_sandbox() — does not propagate."""
+    actor = FailingStopSandboxActor()
+    actor.on_start()
+
+    # Must not raise even though _stop_sandbox() raises RuntimeError
+    actor.on_stop()  # Should complete without exception
+
+
+def test_on_stop_no_exception_completes_normally() -> None:
+    """on_stop() completes normally when _stop_sandbox() does not raise."""
+    actor = ConcreteSandboxActor()
+    actor.on_start()
+
+    actor.on_stop()  # Should complete without exception
+
+
+def test_on_stop_calls_super_on_stop() -> None:
+    """AC8: on_stop() calls super().on_stop() even when _stop_sandbox() raises."""
+    actor = FailingStopSandboxActor()
+    actor.on_start()
+
+    super_called = False
+
+    import akgentic.tool.sandbox.actor as actor_module
+    original_super = super
+
+    # Patch super() inside on_stop to track the call
+    # Instead, we verify indirectly: on_stop() must not raise
+    # and state observer is still intact (super().on_stop() is a Pykka hook, no-op in unit tests)
+    actor.on_stop()  # Should not raise
+    # If we reach here, super().on_stop() was not blocked by _stop_sandbox exception

--- a/tests/sandbox/test_sandbox_actor.py
+++ b/tests/sandbox/test_sandbox_actor.py
@@ -103,6 +103,29 @@ def test_sandbox_config_mode_local_explicit() -> None:
     assert config.mode == "local"
 
 
+def test_sandbox_config_workspace_id_defaults_to_none() -> None:
+    """FR-SB-31: SandboxConfig.workspace_id defaults to None."""
+    config = SandboxConfig(name="sandbox", role="ToolActor", team_id="team-1")
+    assert config.workspace_id is None
+
+
+def test_sandbox_config_workspace_id_can_be_set() -> None:
+    """FR-SB-31: SandboxConfig.workspace_id can be set to a string value."""
+    config = SandboxConfig(
+        name="sandbox", role="ToolActor", team_id="team-1", workspace_id="my-workspace"
+    )
+    assert config.workspace_id == "my-workspace"
+
+
+def test_sandbox_config_has_both_team_id_and_workspace_id() -> None:
+    """FR-SB-31: SandboxConfig stores both team_id and workspace_id independently."""
+    config = SandboxConfig(
+        name="sandbox", role="ToolActor", team_id="t1", workspace_id="test"
+    )
+    assert config.team_id == "t1"
+    assert config.workspace_id == "test"
+
+
 # ---------------------------------------------------------------------------
 # SandboxState model validation (AC1)
 # ---------------------------------------------------------------------------

--- a/tests/sandbox/test_sandbox_actor.py
+++ b/tests/sandbox/test_sandbox_actor.py
@@ -85,6 +85,24 @@ def test_sandbox_config_valid() -> None:
     assert config.role == "ToolActor"
 
 
+def test_sandbox_config_mode_defaults_to_local() -> None:
+    """SandboxConfig.mode defaults to 'local' when not provided."""
+    config = SandboxConfig(name="sandbox", role="ToolActor", team_id="team-1")
+    assert config.mode == "local"
+
+
+def test_sandbox_config_mode_docker() -> None:
+    """SandboxConfig accepts mode='docker'."""
+    config = SandboxConfig(name="sandbox", role="ToolActor", team_id="team-1", mode="docker")
+    assert config.mode == "docker"
+
+
+def test_sandbox_config_mode_local_explicit() -> None:
+    """SandboxConfig accepts mode='local' explicitly."""
+    config = SandboxConfig(name="sandbox", role="ToolActor", team_id="team-1", mode="local")
+    assert config.mode == "local"
+
+
 # ---------------------------------------------------------------------------
 # SandboxState model validation (AC1)
 # ---------------------------------------------------------------------------

--- a/tests/workspace/test_workspace.py
+++ b/tests/workspace/test_workspace.py
@@ -278,8 +278,11 @@ class TestFilesystemList:
 
 
 class TestGetWorkspace:
-    def test_get_workspace_local_mode_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("WORKSPACE_MODE", raising=False)
+    def test_get_workspace_default_root_when_env_unset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """get_workspace() uses ./workspaces when AKGENTIC_WORKSPACES_ROOT is not set."""
+        monkeypatch.delenv("AKGENTIC_WORKSPACES_ROOT", raising=False)
         with patch("akgentic.tool.workspace.workspace.Filesystem") as mock_fs_cls:
             mock_instance = MagicMock()
             mock_fs_cls.return_value = mock_instance
@@ -287,27 +290,37 @@ class TestGetWorkspace:
             mock_fs_cls.assert_called_once_with(base_path="./workspaces", workspace_name="team-1")
             assert result is mock_instance
 
-    def test_get_workspace_local_mode_explicit(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("WORKSPACE_MODE", "local")
+    def test_get_workspace_custom_root_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """get_workspace() uses AKGENTIC_WORKSPACES_ROOT value when set."""
+        monkeypatch.setenv("AKGENTIC_WORKSPACES_ROOT", "/workspaces")
+        with patch("akgentic.tool.workspace.workspace.Filesystem") as mock_fs_cls:
+            mock_instance = MagicMock()
+            mock_fs_cls.return_value = mock_instance
+            result = get_workspace("team-1")
+            mock_fs_cls.assert_called_once_with(base_path="/workspaces", workspace_name="team-1")
+            assert result is mock_instance
+
+    def test_get_workspace_custom_tmp_root(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """get_workspace() passes any arbitrary AKGENTIC_WORKSPACES_ROOT value through."""
+        monkeypatch.setenv("AKGENTIC_WORKSPACES_ROOT", "/tmp/test-workspaces")
         with patch("akgentic.tool.workspace.workspace.Filesystem") as mock_fs_cls:
             mock_instance = MagicMock()
             mock_fs_cls.return_value = mock_instance
             result = get_workspace("team-2")
-            mock_fs_cls.assert_called_once_with(base_path="./workspaces", workspace_name="team-2")
+            mock_fs_cls.assert_called_once_with(
+                base_path="/tmp/test-workspaces", workspace_name="team-2"
+            )
             assert result is mock_instance
 
-    def test_get_workspace_docker_mode(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("WORKSPACE_MODE", "docker")
+    def test_get_workspace_workspace_name_passed_through(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """get_workspace() passes workspace_name verbatim to Filesystem."""
+        monkeypatch.delenv("AKGENTIC_WORKSPACES_ROOT", raising=False)
         with patch("akgentic.tool.workspace.workspace.Filesystem") as mock_fs_cls:
             mock_instance = MagicMock()
             mock_fs_cls.return_value = mock_instance
-            result = get_workspace("team-3")
-            mock_fs_cls.assert_called_once_with(base_path="/workspaces", workspace_name="team-3")
-            assert result is mock_instance
-
-    def test_get_workspace_unknown_mode_raises_key_error(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setenv("WORKSPACE_MODE", "s3")
-        with pytest.raises(KeyError):
-            get_workspace("team-1")
+            get_workspace("my-special-team")
+            mock_fs_cls.assert_called_once_with(
+                base_path="./workspaces", workspace_name="my-special-team"
+            )


### PR DESCRIPTION
## Summary

- Adds `workspace_id: str | None = None` to `SandboxConfig` and `ExecTool`, mirroring `WorkspaceTool`'s existing field
- `LocalSandboxActor._start_sandbox()` and `DockerSandboxActor._start_sandbox()` resolve `ws_name = workspace_id or team_id` for the filesystem path; Docker container name always stays `sandbox-{team_id}`
- 12 new tests across 4 test files; all 103 sandbox tests pass; coverage 89% (≥80% threshold met)
- Review fixes: updated stale class docstrings in `LocalSandboxActor` and `DockerSandboxActor` to document the `workspace_id or team_id` resolution logic

Closes #67