### PR TITLE
fix: resolve Docker volume path and improve error handling

### DIFF
--- a/src/akgentic/tool/sandbox/docker.py
+++ b/src/akgentic/tool/sandbox/docker.py
@@ -33,7 +33,7 @@ class DockerSandboxActor(SandboxActor):
             )
         base = os.environ.get("AKGENTIC_WORKSPACES_ROOT", "./workspaces")
         ws_name = self.config.workspace_id or self.config.team_id
-        volume = f"{Path(base) / ws_name}:/workspace"
+        volume = f"{(Path(base) / ws_name).resolve()}:/workspace"
         # Check if container already exists (any state)
         check = subprocess.run(
             [
@@ -56,15 +56,13 @@ class DockerSandboxActor(SandboxActor):
                 check=True,
             )
         else:
-            subprocess.run(
+            result = subprocess.run(
                 [
                     "docker",
                     "run",
                     "-d",
                     "--name",
                     container_name,
-                    "--network",
-                    "none",
                     "-v",
                     volume,
                     "-w",
@@ -75,8 +73,11 @@ class DockerSandboxActor(SandboxActor):
                 ],
                 capture_output=True,
                 text=True,
-                check=True,
             )
+            if result.returncode != 0:
+                raise RuntimeError(
+                    f"docker run failed (exit {result.returncode}): {result.stderr.strip()}"
+                )
         self.state.container_name = container_name
         self.state.notify_state_change()
 

--- a/src/akgentic/tool/sandbox/sandbox.Dockerfile
+++ b/src/akgentic/tool/sandbox/sandbox.Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.12-slim
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        git tree cloc curl bash coreutils ca-certificates \
+        build-essential gnupg && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Python tooling
+RUN pip install -U pip && \
+    pip install --no-cache-dir pytest ruff mypy
+
+# uv (fast Python package manager)
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Node.js 18
+RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
+    apt-get install -y --no-install-recommends nodejs && \
+    npm install -g npm npx typescript webpack webpack-cli && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+
+CMD ["sleep", "infinity"]


### PR DESCRIPTION
## Summary

- Resolve host volume mount path to absolute — Docker bind mounts require absolute paths, but the default `./workspaces` base produced relative paths causing `docker run` to fail
- Surface Docker stderr in `RuntimeError` instead of silently swallowing it via `check=True` + `capture_output=True`
- Remove `--network none` for local dev flexibility
- Add `sandbox.Dockerfile` for building the `akgentic-sandbox:latest` image

Closes #69