### PR TITLE
Binary File Reading: DocumentReader and Markdown Sidecar Cache

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ vector_search = [
     "openai>=1.0.0",
     "numpy>=1.26.0",
 ]
+docs = ["markitdown[pdf,docx,xlsx,xls,pptx,outlook]>=0.1"]
 dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.23.0",

--- a/src/akgentic/tool/workspace/__init__.py
+++ b/src/akgentic/tool/workspace/__init__.py
@@ -11,6 +11,11 @@ from akgentic.tool.workspace.edit import (
     normalise_endings,
     parse_patch,
 )
+from akgentic.tool.workspace.readers import (
+    TEXT_EXTENSIONS,
+    DocumentReader,
+    FileTypeReader,
+)
 from akgentic.tool.workspace.tool import (
     WorkspaceDelete,
     WorkspaceEdit,
@@ -33,6 +38,9 @@ from akgentic.tool.workspace.workspace import (
 )
 
 __all__ = [
+    "DocumentReader",
+    "FileTypeReader",
+    "TEXT_EXTENSIONS",
     "EditItem",
     "EditMatcher",
     "FilePatch",

--- a/src/akgentic/tool/workspace/readers.py
+++ b/src/akgentic/tool/workspace/readers.py
@@ -1,0 +1,133 @@
+"""Binary document reader -- MarkItDown-based extraction with two-pass LLM fallback."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from openai import OpenAI
+
+TEXT_EXTENSIONS: frozenset[str] = frozenset(
+    {
+        ".txt",
+        ".md",
+        ".py",
+        ".js",
+        ".ts",
+        ".json",
+        ".yaml",
+        ".yml",
+        ".toml",
+        ".csv",
+        ".html",
+        ".xml",
+        ".rst",
+        ".cfg",
+        ".ini",
+        ".log",
+    }
+)
+
+
+class FileTypeReader(Protocol):
+    """Protocol for file type readers that extract text from binary content."""
+
+    extensions: frozenset[str]
+
+    def extract_text(self, content: bytes, path: str) -> str:
+        """Extract text content from binary file bytes.
+
+        Args:
+            content: Raw bytes of the file.
+            path: Original file path (used for suffix detection).
+
+        Returns:
+            Extracted text as a string.
+        """
+        ...
+
+
+class DocumentReader:
+    """MarkItDown-based document reader with optional LLM vision fallback.
+
+    Pass 1: Extract text via ``MarkItDown()`` (no LLM).
+    Pass 2 (optional): If Pass 1 yields fewer than 50 non-whitespace characters
+    and ``llm_client`` is configured, retry with ``MarkItDown(llm_client=...)``.
+    If both passes yield fewer than 50 non-whitespace characters, returns a
+    placeholder comment.
+    """
+
+    extensions: frozenset[str] = frozenset(
+        {
+            ".pdf",
+            ".docx",
+            ".xlsx",
+            ".xls",
+            ".pptx",
+            ".msg",
+            ".epub",
+            ".jpg",
+            ".jpeg",
+            ".png",
+            ".gif",
+            ".bmp",
+            ".webp",
+        }
+    )
+
+    def __init__(
+        self,
+        llm_client: OpenAI | None = None,
+        llm_model: str = "gpt-4o",
+    ) -> None:
+        self._llm_client = llm_client
+        self._llm_model = llm_model
+
+    def extract_text(self, content: bytes, path: str) -> str:
+        """Extract text from binary file content using MarkItDown.
+
+        Args:
+            content: Raw bytes of the file.
+            path: Original file path (used for suffix detection).
+
+        Returns:
+            Extracted Markdown text, or a placeholder comment if extraction
+            yields no meaningful content.
+
+        Raises:
+            ImportError: If ``markitdown`` is not installed.
+        """
+        try:
+            from markitdown import MarkItDown  # type: ignore[import-not-found]
+        except ImportError as exc:
+            raise ImportError(
+                'markitdown not installed. Run: pip install "akgentic-tool[docs]"'
+            ) from exc
+
+        suffix = Path(path).suffix or ".bin"
+
+        # Pass 1: plain MarkItDown (no LLM)
+        with tempfile.NamedTemporaryFile(suffix=suffix, delete=True) as tmp:
+            tmp.write(content)
+            tmp.flush()
+            md = MarkItDown()
+            result = md.convert(tmp.name)
+            text = result.text_content or ""
+
+        # Pass 2: LLM vision fallback if Pass 1 yielded insufficient content
+        if len("".join(text.split())) < 50 and self._llm_client is not None:
+            with tempfile.NamedTemporaryFile(suffix=suffix, delete=True) as tmp2:
+                tmp2.write(content)
+                tmp2.flush()
+                md_vision = MarkItDown(
+                    llm_client=self._llm_client, llm_model=self._llm_model
+                )
+                result2 = md_vision.convert(tmp2.name)
+                text = result2.text_content or ""
+
+        if len("".join(text.split())) < 50:
+            return "<!-- markitdown: no text extracted -->"
+
+        return text

--- a/src/akgentic/tool/workspace/readers.py
+++ b/src/akgentic/tool/workspace/readers.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import os
 import tempfile
 from pathlib import Path
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
 
 if TYPE_CHECKING:
     from openai import OpenAI
@@ -85,6 +86,31 @@ class DocumentReader:
         self._llm_client = llm_client
         self._llm_model = llm_model
 
+    @staticmethod
+    def _convert_via_tempfile(md: Any, content: bytes, suffix: str) -> str:
+        """Write content to a temp file, convert via MarkItDown, and clean up.
+
+        Uses ``delete=False`` to avoid Windows file-locking issues when
+        MarkItDown re-opens the file by name.
+
+        Args:
+            md: A ``MarkItDown`` instance (plain or LLM-enabled).
+            content: Raw bytes to write.
+            suffix: File suffix for the temp file (e.g. ".pdf").
+
+        Returns:
+            Extracted text content, or empty string if None.
+        """
+        tmp = tempfile.NamedTemporaryFile(suffix=suffix, delete=False)
+        try:
+            tmp.write(content)
+            tmp.flush()
+            tmp.close()
+            result = md.convert(tmp.name)
+            return result.text_content or ""
+        finally:
+            os.unlink(tmp.name)
+
     def extract_text(self, content: bytes, path: str) -> str:
         """Extract text from binary file content using MarkItDown.
 
@@ -109,23 +135,14 @@ class DocumentReader:
         suffix = Path(path).suffix or ".bin"
 
         # Pass 1: plain MarkItDown (no LLM)
-        with tempfile.NamedTemporaryFile(suffix=suffix, delete=True) as tmp:
-            tmp.write(content)
-            tmp.flush()
-            md = MarkItDown()
-            result = md.convert(tmp.name)
-            text = result.text_content or ""
+        text = self._convert_via_tempfile(MarkItDown(), content, suffix)
 
         # Pass 2: LLM vision fallback if Pass 1 yielded insufficient content
         if len("".join(text.split())) < 50 and self._llm_client is not None:
-            with tempfile.NamedTemporaryFile(suffix=suffix, delete=True) as tmp2:
-                tmp2.write(content)
-                tmp2.flush()
-                md_vision = MarkItDown(
-                    llm_client=self._llm_client, llm_model=self._llm_model
-                )
-                result2 = md_vision.convert(tmp2.name)
-                text = result2.text_content or ""
+            md_vision = MarkItDown(
+                llm_client=self._llm_client, llm_model=self._llm_model
+            )
+            text = self._convert_via_tempfile(md_vision, content, suffix)
 
         if len("".join(text.split())) < 50:
             return "<!-- markitdown: no text extracted -->"

--- a/src/akgentic/tool/workspace/tool.py
+++ b/src/akgentic/tool/workspace/tool.py
@@ -17,7 +17,7 @@ import subprocess
 from pathlib import Path
 from typing import Any, Callable
 
-from pydantic import PrivateAttr
+from pydantic import ConfigDict, PrivateAttr
 
 from akgentic.tool.core import TOOL_CALL, BaseToolParam, Channels, ToolCard, _resolve
 from akgentic.tool.errors import RetriableError
@@ -30,6 +30,7 @@ from akgentic.tool.workspace.edit import (
     normalise_endings,
     parse_patch,
 )
+from akgentic.tool.workspace.readers import DocumentReader
 from akgentic.tool.workspace.workspace import Filesystem, get_workspace
 
 _PERM_ERR_MSG = "Path escapes workspace root — use a path relative to the workspace"
@@ -40,6 +41,7 @@ class WorkspaceRead(BaseToolParam):
 
     expose: set[Channels] = {TOOL_CALL}
     default_limit: int = 2000
+    force_document_regeneration: bool = False
 
 
 class WorkspaceList(BaseToolParam):
@@ -202,6 +204,8 @@ def _build_tree(
 class WorkspaceReadTool(ToolCard):
     """Read-only workspace access: read, list, glob, grep."""
 
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
     name: str = "WorkspaceRead"
     description: str = "Read files, list directories, and search the team workspace"
 
@@ -210,6 +214,7 @@ class WorkspaceReadTool(ToolCard):
     workspace_list: WorkspaceList | bool = True
     workspace_glob: WorkspaceGlob | bool = True
     workspace_grep: WorkspaceGrep | bool = True
+    document_reader: DocumentReader | None = None
 
     # Private runtime state — not part of the serialised config.
     # Default None sentinel lets the workspace property detect uninitialized state
@@ -281,34 +286,80 @@ class WorkspaceReadTool(ToolCard):
             Callable that reads a workspace file with pagination.
         """
         backend = self.workspace
+        document_reader = self.document_reader
 
-        def workspace_read(path: str, offset: int = 1, limit: int = params.default_limit) -> str:
+        def workspace_read(
+            path: str,
+            offset: int = 1,
+            limit: int = params.default_limit,
+            force_document_regeneration: bool = params.force_document_regeneration,
+        ) -> str:
             """Read a file from the team workspace.
 
             Args:
                 path: Relative path from workspace root (e.g. "src/main.py").
                 offset: First line to return, 1-indexed. Defaults to 1.
                 limit: Maximum lines to return. Defaults to 2000.
+                force_document_regeneration: If True, re-extract binary files
+                    even if a cached sidecar exists. Defaults to False.
 
             Returns:
                 File contents with 1-indexed line numbers prefixed.
                 Truncated files include a trailing notice.
 
             Raises:
-                RetriableError: If the path does not exist or escapes the workspace root.
+                RetriableError: If the path does not exist or escapes the
+                    workspace root.
+                ValueError: If the file is a binary format and
+                    ``document_reader`` is not configured.
             """
+            ext = Path(path).suffix.lower()
+            p = Path(path)
+
+            # Sidecar self-read guard: .report.pdf.md -> plain text
+            is_sidecar = p.name.startswith(".") and p.name.endswith(".md")
+
+            # ValueError check outside try -- configuration error, not retryable
+            if (
+                not is_sidecar
+                and document_reader is None
+                and ext in DocumentReader.extensions
+            ):
+                raise ValueError(
+                    "Binary file reading requires document_reader. "
+                    'Install: pip install "akgentic-tool[docs]"'
+                )
+
             try:
-                raw = backend.read(path).decode("utf-8")
+                if (
+                    not is_sidecar
+                    and document_reader is not None
+                    and ext in document_reader.extensions
+                ):
+                    # Binary path: sidecar cache or extraction
+                    sidecar = backend._root / p.parent / f".{p.name}.md"
+                    if sidecar.exists() and not force_document_regeneration:
+                        raw = sidecar.read_text(encoding="utf-8")
+                    else:
+                        content_bytes = backend.read(path)
+                        raw = document_reader.extract_text(content_bytes, path)
+                        sidecar.write_text(raw, encoding="utf-8")
+                else:
+                    # Text path (existing logic)
+                    raw = backend.read(path).decode("utf-8")
+
                 lines = raw.splitlines()
                 total = len(lines)
                 start = max(0, offset - 1)
                 end = min(start + limit, total)
                 numbered = "\n".join(
-                    f"{start + i + 1:<6}{line}" for i, line in enumerate(lines[start:end])
+                    f"{start + i + 1:<6}{line}"
+                    for i, line in enumerate(lines[start:end])
                 )
                 if end < total:
                     numbered += (
-                        f"\n[... truncated: {total} lines total, showing {start + 1}-{end} ...]"
+                        f"\n[... truncated: {total} lines total,"
+                        f" showing {start + 1}-{end} ...]"
                     )
                 return numbered
             except FileNotFoundError:

--- a/tests/workspace/test_read_tool.py
+++ b/tests/workspace/test_read_tool.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from akgentic.tool.errors import RetriableError
-from akgentic.tool.workspace.readers import DocumentReader, TEXT_EXTENSIONS
+from akgentic.tool.workspace.readers import DocumentReader
 from akgentic.tool.workspace.tool import (
     WorkspaceGlob,
     WorkspaceGrep,
@@ -892,6 +892,15 @@ class TestBinaryFileReading:
         )
         result = read_fn("data.custom")
         assert "custom format data" in result
+
+    def test_binary_file_not_found_raises_retriable_error(self, tmp_path: Path) -> None:
+        """Binary file that doesn't exist -> RetriableError (not ValueError)."""
+        reader = DocumentReader()
+        tool, _fs = make_wired_tool(tmp_path, document_reader=reader)
+
+        read_fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_read")
+        with pytest.raises(RetriableError, match="File not found: missing.pdf"):
+            read_fn("missing.pdf")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/workspace/test_read_tool.py
+++ b/tests/workspace/test_read_tool.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from akgentic.tool.errors import RetriableError
+from akgentic.tool.workspace.readers import DocumentReader, TEXT_EXTENSIONS
 from akgentic.tool.workspace.tool import (
     WorkspaceGlob,
     WorkspaceGrep,
@@ -677,3 +678,320 @@ class TestRetriableErrorReadTool:
         grep_fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_grep")
         with pytest.raises(RetriableError, match="Path escapes workspace root"):
             grep_fn("pattern", path="../../escape")
+
+
+# ---------------------------------------------------------------------------
+# Helpers for binary reading tests
+# ---------------------------------------------------------------------------
+
+
+def make_wired_tool(
+    tmp_path: Path,
+    document_reader: DocumentReader | None = None,
+) -> tuple[WorkspaceReadTool, Filesystem]:
+    """Build a WorkspaceReadTool wired to a Filesystem, returning both."""
+    tid = uuid.uuid4()
+    fs = Filesystem(str(tmp_path), str(tid))
+    observer = make_observer(team_id=tid)
+    tool = WorkspaceReadTool(document_reader=document_reader)
+    with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
+        tool.observer(observer)
+    return tool, fs
+
+
+# ---------------------------------------------------------------------------
+# Story 5.8: Binary file reading — DocumentReader and sidecar cache
+# ---------------------------------------------------------------------------
+
+
+class TestBinaryFileReading:
+    """Tests for binary file reading dispatch in workspace_read (AC 1-10)."""
+
+    def test_document_reader_none_raises_value_error(self, tmp_path: Path) -> None:
+        """AC 1: workspace_read on binary ext with document_reader=None -> ValueError."""
+        tool, fs = make_wired_tool(tmp_path, document_reader=None)
+        pdf_path = fs._root / "report.pdf"
+        pdf_path.write_bytes(b"%PDF fake")
+
+        read_fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_read")
+        with pytest.raises(ValueError, match='pip install "akgentic-tool\\[docs\\]"'):
+            read_fn("report.pdf")
+
+    def test_pass1_success_extracts_and_writes_sidecar(self, tmp_path: Path) -> None:
+        """AC 2: Pass 1 success -> sidecar written, content returned paginated."""
+        reader = DocumentReader()
+        tool, fs = make_wired_tool(tmp_path, document_reader=reader)
+        pdf_path = fs._root / "report.pdf"
+        pdf_path.write_bytes(b"%PDF fake content")
+
+        extracted = "# Report\n" + "x" * 60
+        with patch.object(reader, "extract_text", return_value=extracted):
+            read_fn = next(
+                t for t in tool.get_tools() if t.__name__ == "workspace_read"
+            )
+            result = read_fn("report.pdf")
+
+        assert "# Report" in result
+        sidecar = fs._root / ".report.pdf.md"
+        assert sidecar.exists()
+        assert "# Report" in sidecar.read_text(encoding="utf-8")
+
+    def test_sidecar_cache_hit(self, tmp_path: Path) -> None:
+        """AC 3: Sidecar exists + force_document_regeneration=False -> no extraction."""
+        reader = DocumentReader()
+        tool, fs = make_wired_tool(tmp_path, document_reader=reader)
+        pdf_path = fs._root / "report.pdf"
+        pdf_path.write_bytes(b"%PDF fake")
+        sidecar = fs._root / ".report.pdf.md"
+        sidecar.write_text("# Cached Content\nline two", encoding="utf-8")
+
+        with patch.object(reader, "extract_text") as mock_extract:
+            read_fn = next(
+                t for t in tool.get_tools() if t.__name__ == "workspace_read"
+            )
+            result = read_fn("report.pdf")
+            mock_extract.assert_not_called()
+
+        assert "# Cached Content" in result
+
+    def test_force_regeneration_bypasses_cache(self, tmp_path: Path) -> None:
+        """AC 4: force_document_regeneration=True -> re-extracts even if sidecar exists."""
+        reader = DocumentReader()
+        tool, fs = make_wired_tool(tmp_path, document_reader=reader)
+        pdf_path = fs._root / "report.pdf"
+        pdf_path.write_bytes(b"%PDF fake")
+        sidecar = fs._root / ".report.pdf.md"
+        sidecar.write_text("# Old Cache", encoding="utf-8")
+
+        extracted = "# Fresh Extract\n" + "y" * 60
+        with patch.object(reader, "extract_text", return_value=extracted):
+            read_fn = next(
+                t for t in tool.get_tools() if t.__name__ == "workspace_read"
+            )
+            result = read_fn("report.pdf", force_document_regeneration=True)
+
+        assert "# Fresh Extract" in result
+        assert "# Old Cache" not in sidecar.read_text(encoding="utf-8")
+
+    def test_pass1_empty_no_llm_returns_placeholder(self, tmp_path: Path) -> None:
+        """AC 5: Pass 1 empty + no LLM -> placeholder written and returned."""
+        reader = DocumentReader(llm_client=None)
+        tool, fs = make_wired_tool(tmp_path, document_reader=reader)
+        pdf_path = fs._root / "scan.pdf"
+        pdf_path.write_bytes(b"%PDF image only")
+
+        placeholder = "<!-- markitdown: no text extracted -->"
+        with patch.object(reader, "extract_text", return_value=placeholder):
+            read_fn = next(
+                t for t in tool.get_tools() if t.__name__ == "workspace_read"
+            )
+            result = read_fn("scan.pdf")
+
+        assert "markitdown: no text extracted" in result
+        sidecar = fs._root / ".scan.pdf.md"
+        assert sidecar.exists()
+        assert "markitdown: no text extracted" in sidecar.read_text(encoding="utf-8")
+
+    def test_pass1_empty_pass2_with_llm_returns_content(self, tmp_path: Path) -> None:
+        """AC 6: Pass 1 empty + LLM configured -> Pass 2 invoked, content returned."""
+        mock_llm_client = MagicMock()
+        reader = DocumentReader(llm_client=mock_llm_client, llm_model="gpt-4o")
+        tool, fs = make_wired_tool(tmp_path, document_reader=reader)
+        pdf_path = fs._root / "scan.pdf"
+        pdf_path.write_bytes(b"%PDF image only")
+
+        extracted = "# OCR Result\n" + "z" * 60
+        with patch.object(reader, "extract_text", return_value=extracted):
+            read_fn = next(
+                t for t in tool.get_tools() if t.__name__ == "workspace_read"
+            )
+            result = read_fn("scan.pdf")
+
+        assert "# OCR Result" in result
+
+    def test_both_passes_empty_returns_placeholder(self, tmp_path: Path) -> None:
+        """AC 7: Both passes return empty -> placeholder written and returned."""
+        mock_llm_client = MagicMock()
+        reader = DocumentReader(llm_client=mock_llm_client)
+        tool, fs = make_wired_tool(tmp_path, document_reader=reader)
+        img_path = fs._root / "photo.png"
+        img_path.write_bytes(b"\x89PNG fake")
+
+        placeholder = "<!-- markitdown: no text extracted -->"
+        with patch.object(reader, "extract_text", return_value=placeholder):
+            read_fn = next(
+                t for t in tool.get_tools() if t.__name__ == "workspace_read"
+            )
+            result = read_fn("photo.png")
+
+        assert "markitdown: no text extracted" in result
+        sidecar = fs._root / ".photo.png.md"
+        assert sidecar.exists()
+
+    def test_text_extension_uses_text_path(self, tmp_path: Path) -> None:
+        """AC 8: Text extension -> DocumentReader never invoked."""
+        reader = DocumentReader()
+        tool, fs = make_wired_tool(tmp_path, document_reader=reader)
+        txt_path = fs._root / "notes.txt"
+        txt_path.write_text("Hello, world!", encoding="utf-8")
+
+        with patch.object(reader, "extract_text") as mock_extract:
+            read_fn = next(
+                t for t in tool.get_tools() if t.__name__ == "workspace_read"
+            )
+            result = read_fn("notes.txt")
+            mock_extract.assert_not_called()
+
+        assert "Hello, world!" in result
+
+    def test_sidecar_self_read_guard(self, tmp_path: Path) -> None:
+        """AC 9: .report.pdf.md reads as plain text, no extraction."""
+        reader = DocumentReader()
+        tool, fs = make_wired_tool(tmp_path, document_reader=reader)
+        sidecar = fs._root / ".report.pdf.md"
+        sidecar.write_text("# Sidecar Content", encoding="utf-8")
+
+        with patch.object(reader, "extract_text") as mock_extract:
+            read_fn = next(
+                t for t in tool.get_tools() if t.__name__ == "workspace_read"
+            )
+            result = read_fn(".report.pdf.md")
+            mock_extract.assert_not_called()
+
+        assert "# Sidecar Content" in result
+
+    def test_subdirectory_binary_file_sidecar_path(self, tmp_path: Path) -> None:
+        """Sidecar for binary file in subdirectory is placed in same directory."""
+        reader = DocumentReader()
+        tool, fs = make_wired_tool(tmp_path, document_reader=reader)
+        docs_dir = fs._root / "docs"
+        docs_dir.mkdir()
+        pdf_path = docs_dir / "slides.pptx"
+        pdf_path.write_bytes(b"PK fake pptx")
+
+        extracted = "# Slides\n" + "a" * 60
+        with patch.object(reader, "extract_text", return_value=extracted):
+            read_fn = next(
+                t for t in tool.get_tools() if t.__name__ == "workspace_read"
+            )
+            result = read_fn("docs/slides.pptx")
+
+        assert "# Slides" in result
+        sidecar = docs_dir / ".slides.pptx.md"
+        assert sidecar.exists()
+
+    def test_unknown_extension_uses_text_path(self, tmp_path: Path) -> None:
+        """Unknown extension falls through to UTF-8 decode path."""
+        reader = DocumentReader()
+        tool, fs = make_wired_tool(tmp_path, document_reader=reader)
+        file_path = fs._root / "data.custom"
+        file_path.write_text("custom format data", encoding="utf-8")
+
+        read_fn = next(
+            t for t in tool.get_tools() if t.__name__ == "workspace_read"
+        )
+        result = read_fn("data.custom")
+        assert "custom format data" in result
+
+
+# ---------------------------------------------------------------------------
+# Story 5.8: DocumentReader.extract_text unit tests (mocked markitdown)
+# ---------------------------------------------------------------------------
+
+
+class TestDocumentReaderExtractText:
+    """Unit tests for DocumentReader.extract_text with mocked markitdown module."""
+
+    def _make_mock_markitdown_module(self) -> MagicMock:
+        """Create a mock markitdown module with MarkItDown class."""
+        mock_module = MagicMock()
+        return mock_module
+
+    def test_pass1_success_returns_content(self) -> None:
+        """Pass 1 yields >= 50 non-ws chars -> returns content directly."""
+        reader = DocumentReader()
+        mock_md_module = self._make_mock_markitdown_module()
+        mock_result = MagicMock()
+        mock_result.text_content = "# Report\n" + "x" * 60
+        mock_md_module.MarkItDown.return_value.convert.return_value = mock_result
+
+        import sys
+
+        with patch.dict(sys.modules, {"markitdown": mock_md_module}):
+            result = reader.extract_text(b"%PDF fake", "report.pdf")
+
+        assert result == "# Report\n" + "x" * 60
+
+    def test_pass1_empty_no_llm_returns_placeholder(self) -> None:
+        """Pass 1 empty + no LLM -> placeholder returned."""
+        reader = DocumentReader(llm_client=None)
+        mock_md_module = self._make_mock_markitdown_module()
+        mock_result = MagicMock()
+        mock_result.text_content = ""
+        mock_md_module.MarkItDown.return_value.convert.return_value = mock_result
+
+        import sys
+
+        with patch.dict(sys.modules, {"markitdown": mock_md_module}):
+            result = reader.extract_text(b"%PDF fake", "scan.pdf")
+
+        assert result == "<!-- markitdown: no text extracted -->"
+
+    def test_pass1_empty_pass2_with_llm(self) -> None:
+        """Pass 1 empty + LLM -> Pass 2 invoked with llm_client."""
+        mock_llm = MagicMock()
+        reader = DocumentReader(llm_client=mock_llm, llm_model="gpt-4o")
+        mock_md_module = self._make_mock_markitdown_module()
+
+        empty_result = MagicMock()
+        empty_result.text_content = ""
+        vision_result = MagicMock()
+        vision_result.text_content = "# OCR\n" + "z" * 60
+
+        call_count = 0
+
+        def mock_md_class(*args: object, **kwargs: object) -> MagicMock:
+            nonlocal call_count
+            call_count += 1
+            instance = MagicMock()
+            if call_count == 1:
+                instance.convert.return_value = empty_result
+            else:
+                instance.convert.return_value = vision_result
+            return instance
+
+        mock_md_module.MarkItDown = mock_md_class
+
+        import sys
+
+        with patch.dict(sys.modules, {"markitdown": mock_md_module}):
+            result = reader.extract_text(b"%PDF image", "scan.pdf")
+
+        assert result == "# OCR\n" + "z" * 60
+        assert call_count == 2
+
+    def test_both_passes_empty_returns_placeholder(self) -> None:
+        """Both passes empty -> placeholder."""
+        mock_llm = MagicMock()
+        reader = DocumentReader(llm_client=mock_llm)
+        mock_md_module = self._make_mock_markitdown_module()
+        empty_result = MagicMock()
+        empty_result.text_content = ""
+        mock_md_module.MarkItDown.return_value.convert.return_value = empty_result
+
+        import sys
+
+        with patch.dict(sys.modules, {"markitdown": mock_md_module}):
+            result = reader.extract_text(b"\x89PNG", "photo.png")
+
+        assert result == "<!-- markitdown: no text extracted -->"
+
+    def test_markitdown_not_installed_raises_import_error(self) -> None:
+        """When markitdown is not installed, raises ImportError with hint."""
+        reader = DocumentReader()
+        import sys
+
+        # Ensure markitdown is not available
+        with patch.dict(sys.modules, {"markitdown": None}):
+            with pytest.raises(ImportError, match='pip install "akgentic-tool\\[docs\\]"'):
+                reader.extract_text(b"fake", "file.pdf")


### PR DESCRIPTION
## Summary
- Implements Story 5.8: `workspace_read` transparently handles binary file formats (PDF, DOCX, XLSX, PPTX, images) via `DocumentReader` with MarkItDown two-pass extraction and LLM vision fallback
- Adds sidecar `.{filename}.md` caching with `force_document_regeneration` bypass
- `markitdown` is an optional dependency (`pip install "akgentic-tool[docs]"`) — binary reads raise `ValueError` with install hint when not configured

## Changes
- **NEW** `readers.py`: `FileTypeReader` protocol, `DocumentReader` class, `TEXT_EXTENSIONS` constant
- **MODIFIED** `tool.py`: `WorkspaceRead` param model (`force_document_regeneration`), `WorkspaceReadTool` (`document_reader` field, `ConfigDict`), `_read_factory` binary dispatch
- **MODIFIED** `__init__.py`: export `DocumentReader`, `FileTypeReader`, `TEXT_EXTENSIONS`
- **MODIFIED** `pyproject.toml`: `docs` optional extra for markitdown
- **MODIFIED** `test_read_tool.py`: 17 new tests (11 integration + 5 unit + 1 review fix)

## Review Fixes Applied
- Removed unused `TEXT_EXTENSIONS` import and fixed import sorting in tests (ruff F401/I001)
- Added missing test for binary file `FileNotFoundError` -> `RetriableError` error path
- Fixed Windows portability: `NamedTemporaryFile(delete=False)` + manual `os.unlink` to avoid file locking
- Extracted `_convert_via_tempfile` helper to eliminate duplicate temp-file logic

## Quality Gates
- ruff: 0 errors
- mypy (strict): 0 errors
- pytest: 215 passed, 97.35% branch coverage

Closes #71