### PR TITLE
DocumentReader Pydantic BaseModel and serializable ToolCard field

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ vector_search = [
     "openai>=1.0.0",
     "numpy>=1.26.0",
 ]
+docs = ["markitdown[pdf,docx,xlsx,xls,pptx,outlook]>=0.1"]
 dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.23.0",

--- a/src/akgentic/tool/workspace/__init__.py
+++ b/src/akgentic/tool/workspace/__init__.py
@@ -11,6 +11,11 @@ from akgentic.tool.workspace.edit import (
     normalise_endings,
     parse_patch,
 )
+from akgentic.tool.workspace.readers import (
+    TEXT_EXTENSIONS,
+    DocumentReader,
+    FileTypeReader,
+)
 from akgentic.tool.workspace.tool import (
     WorkspaceDelete,
     WorkspaceEdit,
@@ -33,6 +38,9 @@ from akgentic.tool.workspace.workspace import (
 )
 
 __all__ = [
+    "DocumentReader",
+    "FileTypeReader",
+    "TEXT_EXTENSIONS",
     "EditItem",
     "EditMatcher",
     "FilePatch",

--- a/src/akgentic/tool/workspace/readers.py
+++ b/src/akgentic/tool/workspace/readers.py
@@ -1,0 +1,133 @@
+"""Binary document reader -- MarkItDown-based extraction with two-pass LLM fallback."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from openai import OpenAI
+
+TEXT_EXTENSIONS: frozenset[str] = frozenset(
+    {
+        ".txt",
+        ".md",
+        ".py",
+        ".js",
+        ".ts",
+        ".json",
+        ".yaml",
+        ".yml",
+        ".toml",
+        ".csv",
+        ".html",
+        ".xml",
+        ".rst",
+        ".cfg",
+        ".ini",
+        ".log",
+    }
+)
+
+
+class FileTypeReader(Protocol):
+    """Protocol for file type readers that extract text from binary content."""
+
+    extensions: frozenset[str]
+
+    def extract_text(self, content: bytes, path: str) -> str:
+        """Extract text content from binary file bytes.
+
+        Args:
+            content: Raw bytes of the file.
+            path: Original file path (used for suffix detection).
+
+        Returns:
+            Extracted text as a string.
+        """
+        ...
+
+
+class DocumentReader:
+    """MarkItDown-based document reader with optional LLM vision fallback.
+
+    Pass 1: Extract text via ``MarkItDown()`` (no LLM).
+    Pass 2 (optional): If Pass 1 yields fewer than 50 non-whitespace characters
+    and ``llm_client`` is configured, retry with ``MarkItDown(llm_client=...)``.
+    If both passes yield fewer than 50 non-whitespace characters, returns a
+    placeholder comment.
+    """
+
+    extensions: frozenset[str] = frozenset(
+        {
+            ".pdf",
+            ".docx",
+            ".xlsx",
+            ".xls",
+            ".pptx",
+            ".msg",
+            ".epub",
+            ".jpg",
+            ".jpeg",
+            ".png",
+            ".gif",
+            ".bmp",
+            ".webp",
+        }
+    )
+
+    def __init__(
+        self,
+        llm_client: OpenAI | None = None,
+        llm_model: str = "gpt-4o",
+    ) -> None:
+        self._llm_client = llm_client
+        self._llm_model = llm_model
+
+    def extract_text(self, content: bytes, path: str) -> str:
+        """Extract text from binary file content using MarkItDown.
+
+        Args:
+            content: Raw bytes of the file.
+            path: Original file path (used for suffix detection).
+
+        Returns:
+            Extracted Markdown text, or a placeholder comment if extraction
+            yields no meaningful content.
+
+        Raises:
+            ImportError: If ``markitdown`` is not installed.
+        """
+        try:
+            from markitdown import MarkItDown  # type: ignore[import-not-found]
+        except ImportError as exc:
+            raise ImportError(
+                'markitdown not installed. Run: pip install "akgentic-tool[docs]"'
+            ) from exc
+
+        suffix = Path(path).suffix or ".bin"
+
+        # Pass 1: plain MarkItDown (no LLM)
+        with tempfile.NamedTemporaryFile(suffix=suffix, delete=True) as tmp:
+            tmp.write(content)
+            tmp.flush()
+            md = MarkItDown()
+            result = md.convert(tmp.name)
+            text = result.text_content or ""
+
+        # Pass 2: LLM vision fallback if Pass 1 yielded insufficient content
+        if len("".join(text.split())) < 50 and self._llm_client is not None:
+            with tempfile.NamedTemporaryFile(suffix=suffix, delete=True) as tmp2:
+                tmp2.write(content)
+                tmp2.flush()
+                md_vision = MarkItDown(
+                    llm_client=self._llm_client, llm_model=self._llm_model
+                )
+                result2 = md_vision.convert(tmp2.name)
+                text = result2.text_content or ""
+
+        if len("".join(text.split())) < 50:
+            return "<!-- markitdown: no text extracted -->"
+
+        return text

--- a/src/akgentic/tool/workspace/readers.py
+++ b/src/akgentic/tool/workspace/readers.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import os
 import tempfile
 from pathlib import Path
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
 
 if TYPE_CHECKING:
     from openai import OpenAI
@@ -85,6 +86,31 @@ class DocumentReader:
         self._llm_client = llm_client
         self._llm_model = llm_model
 
+    @staticmethod
+    def _convert_via_tempfile(md: Any, content: bytes, suffix: str) -> str:
+        """Write content to a temp file, convert via MarkItDown, and clean up.
+
+        Uses ``delete=False`` to avoid Windows file-locking issues when
+        MarkItDown re-opens the file by name.
+
+        Args:
+            md: A ``MarkItDown`` instance (plain or LLM-enabled).
+            content: Raw bytes to write.
+            suffix: File suffix for the temp file (e.g. ".pdf").
+
+        Returns:
+            Extracted text content, or empty string if None.
+        """
+        tmp = tempfile.NamedTemporaryFile(suffix=suffix, delete=False)
+        try:
+            tmp.write(content)
+            tmp.flush()
+            tmp.close()
+            result = md.convert(tmp.name)
+            return result.text_content or ""
+        finally:
+            os.unlink(tmp.name)
+
     def extract_text(self, content: bytes, path: str) -> str:
         """Extract text from binary file content using MarkItDown.
 
@@ -109,23 +135,14 @@ class DocumentReader:
         suffix = Path(path).suffix or ".bin"
 
         # Pass 1: plain MarkItDown (no LLM)
-        with tempfile.NamedTemporaryFile(suffix=suffix, delete=True) as tmp:
-            tmp.write(content)
-            tmp.flush()
-            md = MarkItDown()
-            result = md.convert(tmp.name)
-            text = result.text_content or ""
+        text = self._convert_via_tempfile(MarkItDown(), content, suffix)
 
         # Pass 2: LLM vision fallback if Pass 1 yielded insufficient content
         if len("".join(text.split())) < 50 and self._llm_client is not None:
-            with tempfile.NamedTemporaryFile(suffix=suffix, delete=True) as tmp2:
-                tmp2.write(content)
-                tmp2.flush()
-                md_vision = MarkItDown(
-                    llm_client=self._llm_client, llm_model=self._llm_model
-                )
-                result2 = md_vision.convert(tmp2.name)
-                text = result2.text_content or ""
+            md_vision = MarkItDown(
+                llm_client=self._llm_client, llm_model=self._llm_model
+            )
+            text = self._convert_via_tempfile(md_vision, content, suffix)
 
         if len("".join(text.split())) < 50:
             return "<!-- markitdown: no text extracted -->"

--- a/src/akgentic/tool/workspace/readers.py
+++ b/src/akgentic/tool/workspace/readers.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import os
 import tempfile
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, Protocol
+
+from pydantic import BaseModel, PrivateAttr
 
 if TYPE_CHECKING:
     from openai import OpenAI
@@ -50,17 +52,17 @@ class FileTypeReader(Protocol):
         ...
 
 
-class DocumentReader:
-    """MarkItDown-based document reader with optional LLM vision fallback.
+class DocumentReader(BaseModel):
+    """MarkItDown-based document reader, fully Pydantic-serializable.
 
     Pass 1: Extract text via ``MarkItDown()`` (no LLM).
     Pass 2 (optional): If Pass 1 yields fewer than 50 non-whitespace characters
-    and ``llm_client`` is configured, retry with ``MarkItDown(llm_client=...)``.
+    and ``llm_client="openai"`` is set, lazily constructs ``OpenAI()`` and retries.
     If both passes yield fewer than 50 non-whitespace characters, returns a
     placeholder comment.
     """
 
-    extensions: frozenset[str] = frozenset(
+    extensions: ClassVar[frozenset[str]] = frozenset(
         {
             ".pdf",
             ".docx",
@@ -78,13 +80,23 @@ class DocumentReader:
         }
     )
 
-    def __init__(
-        self,
-        llm_client: OpenAI | None = None,
-        llm_model: str = "gpt-4o",
-    ) -> None:
-        self._llm_client = llm_client
-        self._llm_model = llm_model
+    llm_client: Literal["openai"] | None = None
+    llm_model: str = "gpt-4o"
+
+    _openai_client: OpenAI | None = PrivateAttr(default=None)
+
+    def _get_openai_client(self) -> OpenAI | None:
+        """Lazily create and cache an OpenAI client.
+
+        Returns None if ``llm_client`` is not set.
+        """
+        if self.llm_client is None:
+            return None
+        if self._openai_client is None:
+            from openai import OpenAI as _OpenAI  # noqa: PLC0415
+
+            self._openai_client = _OpenAI()
+        return self._openai_client
 
     @staticmethod
     def _convert_via_tempfile(md: Any, content: bytes, suffix: str) -> str:
@@ -138,10 +150,9 @@ class DocumentReader:
         text = self._convert_via_tempfile(MarkItDown(), content, suffix)
 
         # Pass 2: LLM vision fallback if Pass 1 yielded insufficient content
-        if len("".join(text.split())) < 50 and self._llm_client is not None:
-            md_vision = MarkItDown(
-                llm_client=self._llm_client, llm_model=self._llm_model
-            )
+        openai_client = self._get_openai_client()
+        if len("".join(text.split())) < 50 and openai_client is not None:
+            md_vision = MarkItDown(llm_client=openai_client, llm_model=self.llm_model)
             text = self._convert_via_tempfile(md_vision, content, suffix)
 
         if len("".join(text.split())) < 50:

--- a/src/akgentic/tool/workspace/tool.py
+++ b/src/akgentic/tool/workspace/tool.py
@@ -17,7 +17,7 @@ import subprocess
 from pathlib import Path
 from typing import Any, Callable
 
-from pydantic import PrivateAttr
+from pydantic import ConfigDict, PrivateAttr
 
 from akgentic.tool.core import TOOL_CALL, BaseToolParam, Channels, ToolCard, _resolve
 from akgentic.tool.errors import RetriableError
@@ -30,6 +30,7 @@ from akgentic.tool.workspace.edit import (
     normalise_endings,
     parse_patch,
 )
+from akgentic.tool.workspace.readers import DocumentReader
 from akgentic.tool.workspace.workspace import Filesystem, get_workspace
 
 _PERM_ERR_MSG = "Path escapes workspace root — use a path relative to the workspace"
@@ -40,6 +41,7 @@ class WorkspaceRead(BaseToolParam):
 
     expose: set[Channels] = {TOOL_CALL}
     default_limit: int = 2000
+    force_document_regeneration: bool = False
 
 
 class WorkspaceList(BaseToolParam):
@@ -202,6 +204,8 @@ def _build_tree(
 class WorkspaceReadTool(ToolCard):
     """Read-only workspace access: read, list, glob, grep."""
 
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
     name: str = "WorkspaceRead"
     description: str = "Read files, list directories, and search the team workspace"
 
@@ -210,6 +214,7 @@ class WorkspaceReadTool(ToolCard):
     workspace_list: WorkspaceList | bool = True
     workspace_glob: WorkspaceGlob | bool = True
     workspace_grep: WorkspaceGrep | bool = True
+    document_reader: DocumentReader | None = None
 
     # Private runtime state — not part of the serialised config.
     # Default None sentinel lets the workspace property detect uninitialized state
@@ -281,34 +286,80 @@ class WorkspaceReadTool(ToolCard):
             Callable that reads a workspace file with pagination.
         """
         backend = self.workspace
+        document_reader = self.document_reader
 
-        def workspace_read(path: str, offset: int = 1, limit: int = params.default_limit) -> str:
+        def workspace_read(
+            path: str,
+            offset: int = 1,
+            limit: int = params.default_limit,
+            force_document_regeneration: bool = params.force_document_regeneration,
+        ) -> str:
             """Read a file from the team workspace.
 
             Args:
                 path: Relative path from workspace root (e.g. "src/main.py").
                 offset: First line to return, 1-indexed. Defaults to 1.
                 limit: Maximum lines to return. Defaults to 2000.
+                force_document_regeneration: If True, re-extract binary files
+                    even if a cached sidecar exists. Defaults to False.
 
             Returns:
                 File contents with 1-indexed line numbers prefixed.
                 Truncated files include a trailing notice.
 
             Raises:
-                RetriableError: If the path does not exist or escapes the workspace root.
+                RetriableError: If the path does not exist or escapes the
+                    workspace root.
+                ValueError: If the file is a binary format and
+                    ``document_reader`` is not configured.
             """
+            ext = Path(path).suffix.lower()
+            p = Path(path)
+
+            # Sidecar self-read guard: .report.pdf.md -> plain text
+            is_sidecar = p.name.startswith(".") and p.name.endswith(".md")
+
+            # ValueError check outside try -- configuration error, not retryable
+            if (
+                not is_sidecar
+                and document_reader is None
+                and ext in DocumentReader.extensions
+            ):
+                raise ValueError(
+                    "Binary file reading requires document_reader. "
+                    'Install: pip install "akgentic-tool[docs]"'
+                )
+
             try:
-                raw = backend.read(path).decode("utf-8")
+                if (
+                    not is_sidecar
+                    and document_reader is not None
+                    and ext in document_reader.extensions
+                ):
+                    # Binary path: sidecar cache or extraction
+                    sidecar = backend._root / p.parent / f".{p.name}.md"
+                    if sidecar.exists() and not force_document_regeneration:
+                        raw = sidecar.read_text(encoding="utf-8")
+                    else:
+                        content_bytes = backend.read(path)
+                        raw = document_reader.extract_text(content_bytes, path)
+                        sidecar.write_text(raw, encoding="utf-8")
+                else:
+                    # Text path (existing logic)
+                    raw = backend.read(path).decode("utf-8")
+
                 lines = raw.splitlines()
                 total = len(lines)
                 start = max(0, offset - 1)
                 end = min(start + limit, total)
                 numbered = "\n".join(
-                    f"{start + i + 1:<6}{line}" for i, line in enumerate(lines[start:end])
+                    f"{start + i + 1:<6}{line}"
+                    for i, line in enumerate(lines[start:end])
                 )
                 if end < total:
                     numbered += (
-                        f"\n[... truncated: {total} lines total, showing {start + 1}-{end} ...]"
+                        f"\n[... truncated: {total} lines total,"
+                        f" showing {start + 1}-{end} ...]"
                     )
                 return numbered
             except FileNotFoundError:

--- a/src/akgentic/tool/workspace/tool.py
+++ b/src/akgentic/tool/workspace/tool.py
@@ -156,6 +156,33 @@ def _grep_rg(
     return matches
 
 
+_BRACE_RE = _re.compile(r"\{([^{}]+)\}")
+
+
+def _expand_braces(pattern: str) -> list[str]:
+    """Expand a single brace group in a glob pattern into multiple patterns.
+
+    Handles multiple non-nested brace groups via recursion.
+    Patterns without braces are returned as-is (passthrough).
+
+    Args:
+        pattern: Glob pattern, potentially containing brace groups like ``{py,js}``.
+
+    Returns:
+        List of fully expanded patterns (one entry if no braces found).
+    """
+    match = _BRACE_RE.search(pattern)
+    if not match:
+        return [pattern]
+    prefix = pattern[: match.start()]
+    suffix = pattern[match.end() :]
+    alternatives = match.group(1).split(",")
+    expanded: list[str] = []
+    for alt in alternatives:
+        expanded.extend(_expand_braces(f"{prefix}{alt.strip()}{suffix}"))
+    return expanded
+
+
 def _build_tree(
     root: Path,
     prefix: str = "",
@@ -458,8 +485,15 @@ class WorkspaceReadTool(ToolCard):
                         raise PermissionError(f"Path '{path}' escapes workspace root")
                 else:
                     search_root = backend._root
+                seen: set[Path] = set()
+                raw_matches: list[Path] = []
+                for expanded_pattern in _expand_braces(pattern):
+                    for m in search_root.glob(expanded_pattern):
+                        if m.is_file() and m not in seen:
+                            seen.add(m)
+                            raw_matches.append(m)
                 all_matches = sorted(
-                    (match for match in search_root.glob(pattern) if match.is_file()),
+                    raw_matches,
                     key=lambda match: match.stat().st_mtime,
                     reverse=True,
                 )

--- a/src/akgentic/tool/workspace/tool.py
+++ b/src/akgentic/tool/workspace/tool.py
@@ -17,7 +17,7 @@ import subprocess
 from pathlib import Path
 from typing import Any, Callable
 
-from pydantic import ConfigDict, PrivateAttr
+from pydantic import PrivateAttr
 
 from akgentic.tool.core import TOOL_CALL, BaseToolParam, Channels, ToolCard, _resolve
 from akgentic.tool.errors import RetriableError
@@ -218,9 +218,7 @@ def _build_tree(
             # Recurse if max_depth is unlimited (0) or we haven't reached the limit
             if max_depth == 0 or current_depth + 1 < max_depth:
                 extension = "    " if is_last else "│   "
-                lines.extend(
-                    _build_tree(entry, prefix + extension, current_depth + 1, max_depth)
-                )
+                lines.extend(_build_tree(entry, prefix + extension, current_depth + 1, max_depth))
         else:
             size = entry.stat().st_size
             lines.append(f"{prefix}{connector}{entry.name} ({size} bytes)")
@@ -229,9 +227,13 @@ def _build_tree(
 
 
 class WorkspaceReadTool(ToolCard):
-    """Read-only workspace access: read, list, glob, grep."""
+    """Read-only workspace access: read, list, glob, grep.
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+    ``document_reader`` controls binary file extraction:
+    - ``True`` (default): uses a default ``DocumentReader()`` (Pass 1 only, no LLM).
+    - ``False``: binary reads raise ``ValueError`` with install hint.
+    - ``DocumentReader(...)`` instance: custom extraction config (e.g. with LLM).
+    """
 
     name: str = "WorkspaceRead"
     description: str = "Read files, list directories, and search the team workspace"
@@ -241,7 +243,7 @@ class WorkspaceReadTool(ToolCard):
     workspace_list: WorkspaceList | bool = True
     workspace_glob: WorkspaceGlob | bool = True
     workspace_grep: WorkspaceGrep | bool = True
-    document_reader: DocumentReader | None = None
+    document_reader: DocumentReader | bool = True
 
     # Private runtime state — not part of the serialised config.
     # Default None sentinel lets the workspace property detect uninitialized state
@@ -277,9 +279,7 @@ class WorkspaceReadTool(ToolCard):
             RuntimeError: If :meth:`observer` has not been called yet.
         """
         if not isinstance(self._workspace, Filesystem):
-            raise RuntimeError(
-                "WorkspaceReadTool.workspace accessed before observer() was called."
-            )
+            raise RuntimeError("WorkspaceReadTool.workspace accessed before observer() was called.")
         return self._workspace
 
     def get_tools(self) -> list[Callable[..., Any]]:
@@ -313,7 +313,13 @@ class WorkspaceReadTool(ToolCard):
             Callable that reads a workspace file with pagination.
         """
         backend = self.workspace
-        document_reader = self.document_reader
+        _dr_cfg = self.document_reader
+        if _dr_cfg is True:
+            document_reader: DocumentReader | None = DocumentReader()
+        elif _dr_cfg is False:
+            document_reader = None
+        else:
+            document_reader = _dr_cfg
 
         def workspace_read(
             path: str,
@@ -347,11 +353,7 @@ class WorkspaceReadTool(ToolCard):
             is_sidecar = p.name.startswith(".") and p.name.endswith(".md")
 
             # ValueError check outside try -- configuration error, not retryable
-            if (
-                not is_sidecar
-                and document_reader is None
-                and ext in DocumentReader.extensions
-            ):
+            if not is_sidecar and document_reader is None and ext in DocumentReader.extensions:
                 raise ValueError(
                     "Binary file reading requires document_reader. "
                     'Install: pip install "akgentic-tool[docs]"'
@@ -380,13 +382,11 @@ class WorkspaceReadTool(ToolCard):
                 start = max(0, offset - 1)
                 end = min(start + limit, total)
                 numbered = "\n".join(
-                    f"{start + i + 1:<6}{line}"
-                    for i, line in enumerate(lines[start:end])
+                    f"{start + i + 1:<6}{line}" for i, line in enumerate(lines[start:end])
                 )
                 if end < total:
                     numbered += (
-                        f"\n[... truncated: {total} lines total,"
-                        f" showing {start + 1}-{end} ...]"
+                        f"\n[... truncated: {total} lines total, showing {start + 1}-{end} ...]"
                     )
                 return numbered
             except FileNotFoundError:
@@ -875,9 +875,7 @@ class WorkspaceTool(WorkspaceReadTool):
                         match = matcher.find(content, item.old_string)
                         if match is None:
                             return f"[ERROR] old_string not found in {item.path}"
-                        content = (
-                            content[: match.start] + item.new_string + content[match.end :]
-                        )
+                        content = content[: match.start] + item.new_string + content[match.end :]
 
                     normalised = normalise_endings(content, line_ending)
                     backend.write(item.path, normalised.encode("utf-8"))
@@ -953,8 +951,7 @@ class WorkspaceTool(WorkspaceReadTool):
                         else:
                             apply_file_patch(backend, fp)
                             is_add = bool(fp.hunks) and all(
-                                all(pl.startswith("+") for pl in h.lines if pl)
-                                for h in fp.hunks
+                                all(pl.startswith("+") for pl in h.lines if pl) for h in fp.hunks
                             )
                             if is_add:
                                 results.append(f"created: {fp.path}")

--- a/src/akgentic/tool/workspace/tool.py
+++ b/src/akgentic/tool/workspace/tool.py
@@ -160,7 +160,7 @@ _BRACE_RE = _re.compile(r"\{([^{}]+)\}")
 
 
 def _expand_braces(pattern: str) -> list[str]:
-    """Expand a single brace group in a glob pattern into multiple patterns.
+    """Expand brace groups in a glob pattern into multiple patterns.
 
     Handles multiple non-nested brace groups via recursion.
     Patterns without braces are returned as-is (passthrough).

--- a/tests/workspace/test_read_tool.py
+++ b/tests/workspace/test_read_tool.py
@@ -1129,6 +1129,20 @@ class TestDocumentReaderSerialization:
         """ClassVar extensions must not appear in model_dump()."""
         assert "extensions" not in DocumentReader().model_dump()
 
+    def test_model_validate_roundtrip_default(self) -> None:
+        """model_dump() -> model_validate() round-trips for default DocumentReader."""
+        original = DocumentReader()
+        restored = DocumentReader.model_validate(original.model_dump())
+        assert restored.llm_client == original.llm_client
+        assert restored.llm_model == original.llm_model
+
+    def test_model_validate_roundtrip_with_openai(self) -> None:
+        """model_dump() -> model_validate() round-trips for llm_client='openai'."""
+        original = DocumentReader(llm_client="openai")
+        restored = DocumentReader.model_validate(original.model_dump())
+        assert restored.llm_client == "openai"
+        assert restored.llm_model == "gpt-4o"
+
 
 class TestWorkspaceReadToolSerialization:
     """Verify WorkspaceReadTool.model_dump() succeeds without ConfigDict (AC: 5)."""
@@ -1153,6 +1167,13 @@ class TestWorkspaceReadToolSerialization:
             "llm_client": "openai",
             "llm_model": "gpt-4o",
         }
+
+    def test_model_validate_roundtrip_with_document_reader(self) -> None:
+        """model_dump -> model_validate round-trips with DocumentReader."""
+        original = WorkspaceReadTool(document_reader=DocumentReader(llm_client="openai"))
+        restored = WorkspaceReadTool.model_validate(original.model_dump())
+        assert isinstance(restored.document_reader, DocumentReader)
+        assert restored.document_reader.llm_client == "openai"
 
 
 class TestDocumentReaderLazyInit:

--- a/tests/workspace/test_read_tool.py
+++ b/tests/workspace/test_read_tool.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from akgentic.tool.errors import RetriableError
-from akgentic.tool.workspace.readers import DocumentReader, TEXT_EXTENSIONS
+from akgentic.tool.workspace.readers import DocumentReader
 from akgentic.tool.workspace.tool import (
     WorkspaceGlob,
     WorkspaceGrep,
@@ -892,6 +892,15 @@ class TestBinaryFileReading:
         )
         result = read_fn("data.custom")
         assert "custom format data" in result
+
+    def test_binary_file_not_found_raises_retriable_error(self, tmp_path: Path) -> None:
+        """Binary file that doesn't exist -> RetriableError (not ValueError)."""
+        reader = DocumentReader()
+        tool, _fs = make_wired_tool(tmp_path, document_reader=reader)
+
+        read_fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_read")
+        with pytest.raises(RetriableError, match="File not found: missing.pdf"):
+            read_fn("missing.pdf")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/workspace/test_read_tool.py
+++ b/tests/workspace/test_read_tool.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from akgentic.tool.errors import RetriableError
+from akgentic.tool.workspace.readers import DocumentReader, TEXT_EXTENSIONS
 from akgentic.tool.workspace.tool import (
     WorkspaceGlob,
     WorkspaceGrep,
@@ -677,3 +678,320 @@ class TestRetriableErrorReadTool:
         grep_fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_grep")
         with pytest.raises(RetriableError, match="Path escapes workspace root"):
             grep_fn("pattern", path="../../escape")
+
+
+# ---------------------------------------------------------------------------
+# Helpers for binary reading tests
+# ---------------------------------------------------------------------------
+
+
+def make_wired_tool(
+    tmp_path: Path,
+    document_reader: DocumentReader | None = None,
+) -> tuple[WorkspaceReadTool, Filesystem]:
+    """Build a WorkspaceReadTool wired to a Filesystem, returning both."""
+    tid = uuid.uuid4()
+    fs = Filesystem(str(tmp_path), str(tid))
+    observer = make_observer(team_id=tid)
+    tool = WorkspaceReadTool(document_reader=document_reader)
+    with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
+        tool.observer(observer)
+    return tool, fs
+
+
+# ---------------------------------------------------------------------------
+# Story 5.8: Binary file reading — DocumentReader and sidecar cache
+# ---------------------------------------------------------------------------
+
+
+class TestBinaryFileReading:
+    """Tests for binary file reading dispatch in workspace_read (AC 1-10)."""
+
+    def test_document_reader_none_raises_value_error(self, tmp_path: Path) -> None:
+        """AC 1: workspace_read on binary ext with document_reader=None -> ValueError."""
+        tool, fs = make_wired_tool(tmp_path, document_reader=None)
+        pdf_path = fs._root / "report.pdf"
+        pdf_path.write_bytes(b"%PDF fake")
+
+        read_fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_read")
+        with pytest.raises(ValueError, match='pip install "akgentic-tool\\[docs\\]"'):
+            read_fn("report.pdf")
+
+    def test_pass1_success_extracts_and_writes_sidecar(self, tmp_path: Path) -> None:
+        """AC 2: Pass 1 success -> sidecar written, content returned paginated."""
+        reader = DocumentReader()
+        tool, fs = make_wired_tool(tmp_path, document_reader=reader)
+        pdf_path = fs._root / "report.pdf"
+        pdf_path.write_bytes(b"%PDF fake content")
+
+        extracted = "# Report\n" + "x" * 60
+        with patch.object(reader, "extract_text", return_value=extracted):
+            read_fn = next(
+                t for t in tool.get_tools() if t.__name__ == "workspace_read"
+            )
+            result = read_fn("report.pdf")
+
+        assert "# Report" in result
+        sidecar = fs._root / ".report.pdf.md"
+        assert sidecar.exists()
+        assert "# Report" in sidecar.read_text(encoding="utf-8")
+
+    def test_sidecar_cache_hit(self, tmp_path: Path) -> None:
+        """AC 3: Sidecar exists + force_document_regeneration=False -> no extraction."""
+        reader = DocumentReader()
+        tool, fs = make_wired_tool(tmp_path, document_reader=reader)
+        pdf_path = fs._root / "report.pdf"
+        pdf_path.write_bytes(b"%PDF fake")
+        sidecar = fs._root / ".report.pdf.md"
+        sidecar.write_text("# Cached Content\nline two", encoding="utf-8")
+
+        with patch.object(reader, "extract_text") as mock_extract:
+            read_fn = next(
+                t for t in tool.get_tools() if t.__name__ == "workspace_read"
+            )
+            result = read_fn("report.pdf")
+            mock_extract.assert_not_called()
+
+        assert "# Cached Content" in result
+
+    def test_force_regeneration_bypasses_cache(self, tmp_path: Path) -> None:
+        """AC 4: force_document_regeneration=True -> re-extracts even if sidecar exists."""
+        reader = DocumentReader()
+        tool, fs = make_wired_tool(tmp_path, document_reader=reader)
+        pdf_path = fs._root / "report.pdf"
+        pdf_path.write_bytes(b"%PDF fake")
+        sidecar = fs._root / ".report.pdf.md"
+        sidecar.write_text("# Old Cache", encoding="utf-8")
+
+        extracted = "# Fresh Extract\n" + "y" * 60
+        with patch.object(reader, "extract_text", return_value=extracted):
+            read_fn = next(
+                t for t in tool.get_tools() if t.__name__ == "workspace_read"
+            )
+            result = read_fn("report.pdf", force_document_regeneration=True)
+
+        assert "# Fresh Extract" in result
+        assert "# Old Cache" not in sidecar.read_text(encoding="utf-8")
+
+    def test_pass1_empty_no_llm_returns_placeholder(self, tmp_path: Path) -> None:
+        """AC 5: Pass 1 empty + no LLM -> placeholder written and returned."""
+        reader = DocumentReader(llm_client=None)
+        tool, fs = make_wired_tool(tmp_path, document_reader=reader)
+        pdf_path = fs._root / "scan.pdf"
+        pdf_path.write_bytes(b"%PDF image only")
+
+        placeholder = "<!-- markitdown: no text extracted -->"
+        with patch.object(reader, "extract_text", return_value=placeholder):
+            read_fn = next(
+                t for t in tool.get_tools() if t.__name__ == "workspace_read"
+            )
+            result = read_fn("scan.pdf")
+
+        assert "markitdown: no text extracted" in result
+        sidecar = fs._root / ".scan.pdf.md"
+        assert sidecar.exists()
+        assert "markitdown: no text extracted" in sidecar.read_text(encoding="utf-8")
+
+    def test_pass1_empty_pass2_with_llm_returns_content(self, tmp_path: Path) -> None:
+        """AC 6: Pass 1 empty + LLM configured -> Pass 2 invoked, content returned."""
+        mock_llm_client = MagicMock()
+        reader = DocumentReader(llm_client=mock_llm_client, llm_model="gpt-4o")
+        tool, fs = make_wired_tool(tmp_path, document_reader=reader)
+        pdf_path = fs._root / "scan.pdf"
+        pdf_path.write_bytes(b"%PDF image only")
+
+        extracted = "# OCR Result\n" + "z" * 60
+        with patch.object(reader, "extract_text", return_value=extracted):
+            read_fn = next(
+                t for t in tool.get_tools() if t.__name__ == "workspace_read"
+            )
+            result = read_fn("scan.pdf")
+
+        assert "# OCR Result" in result
+
+    def test_both_passes_empty_returns_placeholder(self, tmp_path: Path) -> None:
+        """AC 7: Both passes return empty -> placeholder written and returned."""
+        mock_llm_client = MagicMock()
+        reader = DocumentReader(llm_client=mock_llm_client)
+        tool, fs = make_wired_tool(tmp_path, document_reader=reader)
+        img_path = fs._root / "photo.png"
+        img_path.write_bytes(b"\x89PNG fake")
+
+        placeholder = "<!-- markitdown: no text extracted -->"
+        with patch.object(reader, "extract_text", return_value=placeholder):
+            read_fn = next(
+                t for t in tool.get_tools() if t.__name__ == "workspace_read"
+            )
+            result = read_fn("photo.png")
+
+        assert "markitdown: no text extracted" in result
+        sidecar = fs._root / ".photo.png.md"
+        assert sidecar.exists()
+
+    def test_text_extension_uses_text_path(self, tmp_path: Path) -> None:
+        """AC 8: Text extension -> DocumentReader never invoked."""
+        reader = DocumentReader()
+        tool, fs = make_wired_tool(tmp_path, document_reader=reader)
+        txt_path = fs._root / "notes.txt"
+        txt_path.write_text("Hello, world!", encoding="utf-8")
+
+        with patch.object(reader, "extract_text") as mock_extract:
+            read_fn = next(
+                t for t in tool.get_tools() if t.__name__ == "workspace_read"
+            )
+            result = read_fn("notes.txt")
+            mock_extract.assert_not_called()
+
+        assert "Hello, world!" in result
+
+    def test_sidecar_self_read_guard(self, tmp_path: Path) -> None:
+        """AC 9: .report.pdf.md reads as plain text, no extraction."""
+        reader = DocumentReader()
+        tool, fs = make_wired_tool(tmp_path, document_reader=reader)
+        sidecar = fs._root / ".report.pdf.md"
+        sidecar.write_text("# Sidecar Content", encoding="utf-8")
+
+        with patch.object(reader, "extract_text") as mock_extract:
+            read_fn = next(
+                t for t in tool.get_tools() if t.__name__ == "workspace_read"
+            )
+            result = read_fn(".report.pdf.md")
+            mock_extract.assert_not_called()
+
+        assert "# Sidecar Content" in result
+
+    def test_subdirectory_binary_file_sidecar_path(self, tmp_path: Path) -> None:
+        """Sidecar for binary file in subdirectory is placed in same directory."""
+        reader = DocumentReader()
+        tool, fs = make_wired_tool(tmp_path, document_reader=reader)
+        docs_dir = fs._root / "docs"
+        docs_dir.mkdir()
+        pdf_path = docs_dir / "slides.pptx"
+        pdf_path.write_bytes(b"PK fake pptx")
+
+        extracted = "# Slides\n" + "a" * 60
+        with patch.object(reader, "extract_text", return_value=extracted):
+            read_fn = next(
+                t for t in tool.get_tools() if t.__name__ == "workspace_read"
+            )
+            result = read_fn("docs/slides.pptx")
+
+        assert "# Slides" in result
+        sidecar = docs_dir / ".slides.pptx.md"
+        assert sidecar.exists()
+
+    def test_unknown_extension_uses_text_path(self, tmp_path: Path) -> None:
+        """Unknown extension falls through to UTF-8 decode path."""
+        reader = DocumentReader()
+        tool, fs = make_wired_tool(tmp_path, document_reader=reader)
+        file_path = fs._root / "data.custom"
+        file_path.write_text("custom format data", encoding="utf-8")
+
+        read_fn = next(
+            t for t in tool.get_tools() if t.__name__ == "workspace_read"
+        )
+        result = read_fn("data.custom")
+        assert "custom format data" in result
+
+
+# ---------------------------------------------------------------------------
+# Story 5.8: DocumentReader.extract_text unit tests (mocked markitdown)
+# ---------------------------------------------------------------------------
+
+
+class TestDocumentReaderExtractText:
+    """Unit tests for DocumentReader.extract_text with mocked markitdown module."""
+
+    def _make_mock_markitdown_module(self) -> MagicMock:
+        """Create a mock markitdown module with MarkItDown class."""
+        mock_module = MagicMock()
+        return mock_module
+
+    def test_pass1_success_returns_content(self) -> None:
+        """Pass 1 yields >= 50 non-ws chars -> returns content directly."""
+        reader = DocumentReader()
+        mock_md_module = self._make_mock_markitdown_module()
+        mock_result = MagicMock()
+        mock_result.text_content = "# Report\n" + "x" * 60
+        mock_md_module.MarkItDown.return_value.convert.return_value = mock_result
+
+        import sys
+
+        with patch.dict(sys.modules, {"markitdown": mock_md_module}):
+            result = reader.extract_text(b"%PDF fake", "report.pdf")
+
+        assert result == "# Report\n" + "x" * 60
+
+    def test_pass1_empty_no_llm_returns_placeholder(self) -> None:
+        """Pass 1 empty + no LLM -> placeholder returned."""
+        reader = DocumentReader(llm_client=None)
+        mock_md_module = self._make_mock_markitdown_module()
+        mock_result = MagicMock()
+        mock_result.text_content = ""
+        mock_md_module.MarkItDown.return_value.convert.return_value = mock_result
+
+        import sys
+
+        with patch.dict(sys.modules, {"markitdown": mock_md_module}):
+            result = reader.extract_text(b"%PDF fake", "scan.pdf")
+
+        assert result == "<!-- markitdown: no text extracted -->"
+
+    def test_pass1_empty_pass2_with_llm(self) -> None:
+        """Pass 1 empty + LLM -> Pass 2 invoked with llm_client."""
+        mock_llm = MagicMock()
+        reader = DocumentReader(llm_client=mock_llm, llm_model="gpt-4o")
+        mock_md_module = self._make_mock_markitdown_module()
+
+        empty_result = MagicMock()
+        empty_result.text_content = ""
+        vision_result = MagicMock()
+        vision_result.text_content = "# OCR\n" + "z" * 60
+
+        call_count = 0
+
+        def mock_md_class(*args: object, **kwargs: object) -> MagicMock:
+            nonlocal call_count
+            call_count += 1
+            instance = MagicMock()
+            if call_count == 1:
+                instance.convert.return_value = empty_result
+            else:
+                instance.convert.return_value = vision_result
+            return instance
+
+        mock_md_module.MarkItDown = mock_md_class
+
+        import sys
+
+        with patch.dict(sys.modules, {"markitdown": mock_md_module}):
+            result = reader.extract_text(b"%PDF image", "scan.pdf")
+
+        assert result == "# OCR\n" + "z" * 60
+        assert call_count == 2
+
+    def test_both_passes_empty_returns_placeholder(self) -> None:
+        """Both passes empty -> placeholder."""
+        mock_llm = MagicMock()
+        reader = DocumentReader(llm_client=mock_llm)
+        mock_md_module = self._make_mock_markitdown_module()
+        empty_result = MagicMock()
+        empty_result.text_content = ""
+        mock_md_module.MarkItDown.return_value.convert.return_value = empty_result
+
+        import sys
+
+        with patch.dict(sys.modules, {"markitdown": mock_md_module}):
+            result = reader.extract_text(b"\x89PNG", "photo.png")
+
+        assert result == "<!-- markitdown: no text extracted -->"
+
+    def test_markitdown_not_installed_raises_import_error(self) -> None:
+        """When markitdown is not installed, raises ImportError with hint."""
+        reader = DocumentReader()
+        import sys
+
+        # Ensure markitdown is not available
+        with patch.dict(sys.modules, {"markitdown": None}):
+            with pytest.raises(ImportError, match='pip install "akgentic-tool\\[docs\\]"'):
+                reader.extract_text(b"fake", "file.pdf")

--- a/tests/workspace/test_read_tool.py
+++ b/tests/workspace/test_read_tool.py
@@ -1028,6 +1028,10 @@ class TestExpandBraces:
         result = _expand_braces("**/*.{py, js, ts}")
         assert result == ["**/*.py", "**/*.js", "**/*.ts"]
 
+    def test_expand_braces_single_alternative(self) -> None:
+        """Single alternative in braces degenerates to one pattern."""
+        assert _expand_braces("**/*.{py}") == ["**/*.py"]
+
 
 # ---------------------------------------------------------------------------
 # Story 5.9: workspace_glob brace expansion integration tests
@@ -1043,8 +1047,9 @@ class TestWorkspaceGlobBraceExpansion:
         (root / "b.js").write_bytes(b"b")
         glob_fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_glob")
         result = glob_fn("**/*.{py,js}")
-        assert "a.py" in result
-        assert "b.js" in result
+        lines = result.splitlines()
+        assert "a.py" in lines
+        assert "b.js" in lines
 
     def test_no_brace_passthrough(self, tmp_path: Path) -> None:
         """AC 5: No-brace pattern behaves identically to pre-brace implementation."""
@@ -1077,8 +1082,9 @@ class TestWorkspaceGlobBraceExpansion:
         (lib / "b.js").write_bytes(b"b")
         glob_fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_glob")
         result = glob_fn("{src,lib}/**/*.{py,js}")
-        assert "a.py" in result
-        assert "b.js" in result
+        lines = result.splitlines()
+        assert "src/a.py" in lines
+        assert "lib/b.js" in lines
 
     def test_mtime_sort_preserved(self, tmp_path: Path) -> None:
         """AC 1: Results are sorted newest-first by mtime."""

--- a/tests/workspace/test_read_tool.py
+++ b/tests/workspace/test_read_tool.py
@@ -97,9 +97,7 @@ class TestObserverWiring:
         observer = make_observer(team_id=team_id)
         fs = Filesystem(str(tmp_path), str(team_id))
         tool = WorkspaceReadTool()
-        with patch(
-            "akgentic.tool.workspace.tool.get_workspace", return_value=fs
-        ) as mock_gw:
+        with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs) as mock_gw:
             result = tool.observer(observer)
             mock_gw.assert_called_once_with(str(team_id))
             assert tool.workspace is fs
@@ -109,9 +107,7 @@ class TestObserverWiring:
         observer = make_observer()
         fs = Filesystem(str(tmp_path), "explicit-ws")
         tool = WorkspaceReadTool(workspace_id="explicit-ws")
-        with patch(
-            "akgentic.tool.workspace.tool.get_workspace", return_value=fs
-        ) as mock_gw:
+        with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs) as mock_gw:
             tool.observer(observer)
             mock_gw.assert_called_once_with("explicit-ws")
 
@@ -404,8 +400,9 @@ class TestGrepRg:
         assert result is None
 
     def test_returns_none_on_subprocess_error(self, tmp_path: Path) -> None:
-        with patch("shutil.which", return_value="/usr/bin/rg"), patch(
-            "subprocess.run", side_effect=OSError("no rg")
+        with (
+            patch("shutil.which", return_value="/usr/bin/rg"),
+            patch("subprocess.run", side_effect=OSError("no rg")),
         ):
             result = _grep_rg(tmp_path, "pattern", "", 100)
         assert result is None
@@ -413,9 +410,12 @@ class TestGrepRg:
     def test_returns_none_on_timeout(self, tmp_path: Path) -> None:
         import subprocess as _subprocess
 
-        with patch("shutil.which", return_value="/usr/bin/rg"), patch(
-            "subprocess.run",
-            side_effect=_subprocess.TimeoutExpired(cmd=["rg"], timeout=15),
+        with (
+            patch("shutil.which", return_value="/usr/bin/rg"),
+            patch(
+                "subprocess.run",
+                side_effect=_subprocess.TimeoutExpired(cmd=["rg"], timeout=15),
+            ),
         ):
             result = _grep_rg(tmp_path, "pattern", "", 100)
         assert result is None
@@ -424,8 +424,9 @@ class TestGrepRg:
         mock_result = MagicMock()
         mock_result.returncode = 2
         mock_result.stdout = ""
-        with patch("shutil.which", return_value="/usr/bin/rg"), patch(
-            "subprocess.run", return_value=mock_result
+        with (
+            patch("shutil.which", return_value="/usr/bin/rg"),
+            patch("subprocess.run", return_value=mock_result),
         ):
             result = _grep_rg(tmp_path, "pattern", "", 100)
         assert result is None
@@ -436,8 +437,9 @@ class TestGrepRg:
         mock_result = MagicMock()
         mock_result.returncode = 0
         mock_result.stdout = f"{fake_file}:3:import os\n"
-        with patch("shutil.which", return_value="/usr/bin/rg"), patch(
-            "subprocess.run", return_value=mock_result
+        with (
+            patch("shutil.which", return_value="/usr/bin/rg"),
+            patch("subprocess.run", return_value=mock_result),
         ):
             result = _grep_rg(tmp_path, "import", "", 100)
         assert result is not None
@@ -495,11 +497,10 @@ class TestWorkspaceGrep:
         root = tool.workspace._root
         fake_match = (root / "x.py", 1, "import os")
         fn = tool.get_tools()[3]
-        with patch(
-            "akgentic.tool.workspace.tool._grep_rg", return_value=[fake_match]
-        ) as mock_rg, patch(
-            "akgentic.tool.workspace.tool._grep_python"
-        ) as mock_py:
+        with (
+            patch("akgentic.tool.workspace.tool._grep_rg", return_value=[fake_match]) as mock_rg,
+            patch("akgentic.tool.workspace.tool._grep_python") as mock_py,
+        ):
             result = fn("import os")
         mock_rg.assert_called_once()
         mock_py.assert_not_called()
@@ -688,7 +689,7 @@ class TestRetriableErrorReadTool:
 
 def make_wired_tool(
     tmp_path: Path,
-    document_reader: DocumentReader | None = None,
+    document_reader: DocumentReader | bool = True,
 ) -> tuple[WorkspaceReadTool, Filesystem]:
     """Build a WorkspaceReadTool wired to a Filesystem, returning both."""
     tid = uuid.uuid4()
@@ -709,8 +710,8 @@ class TestBinaryFileReading:
     """Tests for binary file reading dispatch in workspace_read (AC 1-10)."""
 
     def test_document_reader_none_raises_value_error(self, tmp_path: Path) -> None:
-        """AC 1: workspace_read on binary ext with document_reader=None -> ValueError."""
-        tool, fs = make_wired_tool(tmp_path, document_reader=None)
+        """AC 1: workspace_read on binary ext with document_reader=False -> ValueError."""
+        tool, fs = make_wired_tool(tmp_path, document_reader=False)
         pdf_path = fs._root / "report.pdf"
         pdf_path.write_bytes(b"%PDF fake")
 
@@ -726,10 +727,8 @@ class TestBinaryFileReading:
         pdf_path.write_bytes(b"%PDF fake content")
 
         extracted = "# Report\n" + "x" * 60
-        with patch.object(reader, "extract_text", return_value=extracted):
-            read_fn = next(
-                t for t in tool.get_tools() if t.__name__ == "workspace_read"
-            )
+        with patch.object(DocumentReader, "extract_text", return_value=extracted):
+            read_fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_read")
             result = read_fn("report.pdf")
 
         assert "# Report" in result
@@ -746,10 +745,8 @@ class TestBinaryFileReading:
         sidecar = fs._root / ".report.pdf.md"
         sidecar.write_text("# Cached Content\nline two", encoding="utf-8")
 
-        with patch.object(reader, "extract_text") as mock_extract:
-            read_fn = next(
-                t for t in tool.get_tools() if t.__name__ == "workspace_read"
-            )
+        with patch.object(DocumentReader, "extract_text") as mock_extract:
+            read_fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_read")
             result = read_fn("report.pdf")
             mock_extract.assert_not_called()
 
@@ -765,10 +762,8 @@ class TestBinaryFileReading:
         sidecar.write_text("# Old Cache", encoding="utf-8")
 
         extracted = "# Fresh Extract\n" + "y" * 60
-        with patch.object(reader, "extract_text", return_value=extracted):
-            read_fn = next(
-                t for t in tool.get_tools() if t.__name__ == "workspace_read"
-            )
+        with patch.object(DocumentReader, "extract_text", return_value=extracted):
+            read_fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_read")
             result = read_fn("report.pdf", force_document_regeneration=True)
 
         assert "# Fresh Extract" in result
@@ -782,10 +777,8 @@ class TestBinaryFileReading:
         pdf_path.write_bytes(b"%PDF image only")
 
         placeholder = "<!-- markitdown: no text extracted -->"
-        with patch.object(reader, "extract_text", return_value=placeholder):
-            read_fn = next(
-                t for t in tool.get_tools() if t.__name__ == "workspace_read"
-            )
+        with patch.object(DocumentReader, "extract_text", return_value=placeholder):
+            read_fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_read")
             result = read_fn("scan.pdf")
 
         assert "markitdown: no text extracted" in result
@@ -795,34 +788,28 @@ class TestBinaryFileReading:
 
     def test_pass1_empty_pass2_with_llm_returns_content(self, tmp_path: Path) -> None:
         """AC 6: Pass 1 empty + LLM configured -> Pass 2 invoked, content returned."""
-        mock_llm_client = MagicMock()
-        reader = DocumentReader(llm_client=mock_llm_client, llm_model="gpt-4o")
+        reader = DocumentReader(llm_client="openai", llm_model="gpt-4o")
         tool, fs = make_wired_tool(tmp_path, document_reader=reader)
         pdf_path = fs._root / "scan.pdf"
         pdf_path.write_bytes(b"%PDF image only")
 
         extracted = "# OCR Result\n" + "z" * 60
-        with patch.object(reader, "extract_text", return_value=extracted):
-            read_fn = next(
-                t for t in tool.get_tools() if t.__name__ == "workspace_read"
-            )
+        with patch.object(DocumentReader, "extract_text", return_value=extracted):
+            read_fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_read")
             result = read_fn("scan.pdf")
 
         assert "# OCR Result" in result
 
     def test_both_passes_empty_returns_placeholder(self, tmp_path: Path) -> None:
         """AC 7: Both passes return empty -> placeholder written and returned."""
-        mock_llm_client = MagicMock()
-        reader = DocumentReader(llm_client=mock_llm_client)
+        reader = DocumentReader(llm_client="openai")
         tool, fs = make_wired_tool(tmp_path, document_reader=reader)
         img_path = fs._root / "photo.png"
         img_path.write_bytes(b"\x89PNG fake")
 
         placeholder = "<!-- markitdown: no text extracted -->"
-        with patch.object(reader, "extract_text", return_value=placeholder):
-            read_fn = next(
-                t for t in tool.get_tools() if t.__name__ == "workspace_read"
-            )
+        with patch.object(DocumentReader, "extract_text", return_value=placeholder):
+            read_fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_read")
             result = read_fn("photo.png")
 
         assert "markitdown: no text extracted" in result
@@ -836,10 +823,8 @@ class TestBinaryFileReading:
         txt_path = fs._root / "notes.txt"
         txt_path.write_text("Hello, world!", encoding="utf-8")
 
-        with patch.object(reader, "extract_text") as mock_extract:
-            read_fn = next(
-                t for t in tool.get_tools() if t.__name__ == "workspace_read"
-            )
+        with patch.object(DocumentReader, "extract_text") as mock_extract:
+            read_fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_read")
             result = read_fn("notes.txt")
             mock_extract.assert_not_called()
 
@@ -852,10 +837,8 @@ class TestBinaryFileReading:
         sidecar = fs._root / ".report.pdf.md"
         sidecar.write_text("# Sidecar Content", encoding="utf-8")
 
-        with patch.object(reader, "extract_text") as mock_extract:
-            read_fn = next(
-                t for t in tool.get_tools() if t.__name__ == "workspace_read"
-            )
+        with patch.object(DocumentReader, "extract_text") as mock_extract:
+            read_fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_read")
             result = read_fn(".report.pdf.md")
             mock_extract.assert_not_called()
 
@@ -871,10 +854,8 @@ class TestBinaryFileReading:
         pdf_path.write_bytes(b"PK fake pptx")
 
         extracted = "# Slides\n" + "a" * 60
-        with patch.object(reader, "extract_text", return_value=extracted):
-            read_fn = next(
-                t for t in tool.get_tools() if t.__name__ == "workspace_read"
-            )
+        with patch.object(DocumentReader, "extract_text", return_value=extracted):
+            read_fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_read")
             result = read_fn("docs/slides.pptx")
 
         assert "# Slides" in result
@@ -888,9 +869,7 @@ class TestBinaryFileReading:
         file_path = fs._root / "data.custom"
         file_path.write_text("custom format data", encoding="utf-8")
 
-        read_fn = next(
-            t for t in tool.get_tools() if t.__name__ == "workspace_read"
-        )
+        read_fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_read")
         result = read_fn("data.custom")
         assert "custom format data" in result
 
@@ -948,9 +927,8 @@ class TestDocumentReaderExtractText:
         assert result == "<!-- markitdown: no text extracted -->"
 
     def test_pass1_empty_pass2_with_llm(self) -> None:
-        """Pass 1 empty + LLM -> Pass 2 invoked with llm_client."""
-        mock_llm = MagicMock()
-        reader = DocumentReader(llm_client=mock_llm, llm_model="gpt-4o")
+        """Pass 1 empty + LLM -> Pass 2 invoked with lazily-created OpenAI client."""
+        reader = DocumentReader(llm_client="openai", llm_model="gpt-4o")
         mock_md_module = self._make_mock_markitdown_module()
 
         empty_result = MagicMock()
@@ -974,7 +952,10 @@ class TestDocumentReaderExtractText:
 
         import sys
 
-        with patch.dict(sys.modules, {"markitdown": mock_md_module}):
+        mock_openai_instance = MagicMock()
+        mock_openai_module = MagicMock()
+        mock_openai_module.OpenAI = MagicMock(return_value=mock_openai_instance)
+        with patch.dict(sys.modules, {"markitdown": mock_md_module, "openai": mock_openai_module}):
             result = reader.extract_text(b"%PDF image", "scan.pdf")
 
         assert result == "# OCR\n" + "z" * 60
@@ -982,8 +963,7 @@ class TestDocumentReaderExtractText:
 
     def test_both_passes_empty_returns_placeholder(self) -> None:
         """Both passes empty -> placeholder."""
-        mock_llm = MagicMock()
-        reader = DocumentReader(llm_client=mock_llm)
+        reader = DocumentReader(llm_client="openai")
         mock_md_module = self._make_mock_markitdown_module()
         empty_result = MagicMock()
         empty_result.text_content = ""
@@ -991,7 +971,10 @@ class TestDocumentReaderExtractText:
 
         import sys
 
-        with patch.dict(sys.modules, {"markitdown": mock_md_module}):
+        mock_openai_instance = MagicMock()
+        mock_openai_module = MagicMock()
+        mock_openai_module.OpenAI = MagicMock(return_value=mock_openai_instance)
+        with patch.dict(sys.modules, {"markitdown": mock_md_module, "openai": mock_openai_module}):
             result = reader.extract_text(b"\x89PNG", "photo.png")
 
         assert result == "<!-- markitdown: no text extracted -->"
@@ -1117,3 +1100,85 @@ class TestWorkspaceGlobBraceExpansion:
         lines = [ln for ln in result.split("\n") if not ln.startswith("[")]
         assert len(lines) <= 100
         assert "truncated" in result
+
+
+# ---------------------------------------------------------------------------
+# Story 5.10: DocumentReader serialization tests
+# ---------------------------------------------------------------------------
+
+
+class TestDocumentReaderSerialization:
+    """Verify DocumentReader.model_dump() round-trips cleanly (AC: 2)."""
+
+    def test_model_dump_default(self) -> None:
+        """Default DocumentReader dumps to expected dict."""
+        assert DocumentReader().model_dump() == {"llm_client": None, "llm_model": "gpt-4o"}
+
+    def test_model_dump_with_openai(self) -> None:
+        """DocumentReader with llm_client='openai' dumps correctly."""
+        assert DocumentReader(llm_client="openai").model_dump() == {
+            "llm_client": "openai",
+            "llm_model": "gpt-4o",
+        }
+
+    def test_no_openai_client_in_dump(self) -> None:
+        """Private _openai_client must not appear in model_dump()."""
+        assert "_openai_client" not in DocumentReader().model_dump()
+
+    def test_extensions_not_in_dump(self) -> None:
+        """ClassVar extensions must not appear in model_dump()."""
+        assert "extensions" not in DocumentReader().model_dump()
+
+
+class TestWorkspaceReadToolSerialization:
+    """Verify WorkspaceReadTool.model_dump() succeeds without ConfigDict (AC: 5)."""
+
+    def test_default_tool_model_dump_succeeds(self) -> None:
+        """model_dump() does not raise on default WorkspaceReadTool."""
+        result = WorkspaceReadTool().model_dump()
+        assert isinstance(result, dict)
+
+    def test_document_reader_true_in_dump(self) -> None:
+        """Default document_reader=True serializes as True."""
+        assert WorkspaceReadTool().model_dump()["document_reader"] is True
+
+    def test_document_reader_false_in_dump(self) -> None:
+        """document_reader=False serializes as False."""
+        assert WorkspaceReadTool(document_reader=False).model_dump()["document_reader"] is False
+
+    def test_document_reader_instance_in_dump(self) -> None:
+        """DocumentReader instance serializes to its model_dump() dict."""
+        tool = WorkspaceReadTool(document_reader=DocumentReader(llm_client="openai"))
+        assert tool.model_dump()["document_reader"] == {
+            "llm_client": "openai",
+            "llm_model": "gpt-4o",
+        }
+
+
+class TestDocumentReaderLazyInit:
+    """Verify lazy OpenAI client creation via _get_openai_client() (AC: 3)."""
+
+    def test_get_openai_client_returns_none_when_disabled(self) -> None:
+        """No llm_client -> _get_openai_client() returns None."""
+        assert DocumentReader()._get_openai_client() is None
+
+    def test_get_openai_client_lazy_creation(self) -> None:
+        """llm_client='openai' -> lazily constructs OpenAI() on first call."""
+        reader = DocumentReader(llm_client="openai")
+        # Ensure private attrs are initialised (coverage hooks can interfere)
+        if reader.__pydantic_private__ is None:
+            reader.__pydantic_private__ = {"_openai_client": None}
+        result = reader._get_openai_client()
+        # After call, a real OpenAI client is returned and cached
+        assert result is not None
+        assert reader._openai_client is result
+
+    def test_get_openai_client_cached(self) -> None:
+        """Second _get_openai_client() call reuses cached client."""
+        reader = DocumentReader(llm_client="openai")
+        if reader.__pydantic_private__ is None:
+            reader.__pydantic_private__ = {"_openai_client": None}
+        first = reader._get_openai_client()
+        second = reader._get_openai_client()
+        # Same object identity — no second construction
+        assert first is second

--- a/tests/workspace/test_read_tool.py
+++ b/tests/workspace/test_read_tool.py
@@ -17,6 +17,7 @@ from akgentic.tool.workspace.tool import (
     WorkspaceList,
     WorkspaceRead,
     WorkspaceReadTool,
+    _expand_braces,
     _grep_python,
     _grep_rg,
 )
@@ -1004,3 +1005,109 @@ class TestDocumentReaderExtractText:
         with patch.dict(sys.modules, {"markitdown": None}):
             with pytest.raises(ImportError, match='pip install "akgentic-tool\\[docs\\]"'):
                 reader.extract_text(b"fake", "file.pdf")
+
+
+# ---------------------------------------------------------------------------
+# Story 5.9: _expand_braces unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestExpandBraces:
+    def test_expand_braces_no_braces(self) -> None:
+        assert _expand_braces("**/*.py") == ["**/*.py"]
+
+    def test_expand_braces_single_group(self) -> None:
+        result = _expand_braces("**/*.{py,js}")
+        assert result == ["**/*.py", "**/*.js"]
+
+    def test_expand_braces_multiple_groups(self) -> None:
+        result = _expand_braces("{src,lib}/**/*.{py,js}")
+        assert result == ["src/**/*.py", "src/**/*.js", "lib/**/*.py", "lib/**/*.js"]
+
+    def test_expand_braces_strips_whitespace(self) -> None:
+        result = _expand_braces("**/*.{py, js, ts}")
+        assert result == ["**/*.py", "**/*.js", "**/*.ts"]
+
+
+# ---------------------------------------------------------------------------
+# Story 5.9: workspace_glob brace expansion integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceGlobBraceExpansion:
+    def test_single_brace_group_multi_extension(self, tmp_path: Path) -> None:
+        """AC 1: workspace_glob("**/*.{py,js}") returns both .py and .js files."""
+        tool = make_tool(tmp_path)
+        root = tool.workspace._root
+        (root / "a.py").write_bytes(b"a")
+        (root / "b.js").write_bytes(b"b")
+        glob_fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_glob")
+        result = glob_fn("**/*.{py,js}")
+        assert "a.py" in result
+        assert "b.js" in result
+
+    def test_no_brace_passthrough(self, tmp_path: Path) -> None:
+        """AC 5: No-brace pattern behaves identically to pre-brace implementation."""
+        tool = make_tool(tmp_path)
+        root = tool.workspace._root
+        (root / "c.py").write_bytes(b"c")
+        glob_fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_glob")
+        result = glob_fn("**/*.py")
+        assert "c.py" in result
+
+    def test_deduplication(self, tmp_path: Path) -> None:
+        """AC 2: Duplicate expansions produce deduplicated results."""
+        tool = make_tool(tmp_path)
+        root = tool.workspace._root
+        (root / "x.py").write_bytes(b"x")
+        glob_fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_glob")
+        result = glob_fn("**/*.{py,py}")
+        lines = [ln for ln in result.split("\n") if not ln.startswith("[")]
+        assert lines.count("x.py") == 1
+
+    def test_multiple_brace_groups_combinatorial(self, tmp_path: Path) -> None:
+        """AC 3, 4: Multiple brace groups expand combinatorially and merge results."""
+        tool = make_tool(tmp_path)
+        root = tool.workspace._root
+        src = root / "src"
+        src.mkdir()
+        lib = root / "lib"
+        lib.mkdir()
+        (src / "a.py").write_bytes(b"a")
+        (lib / "b.js").write_bytes(b"b")
+        glob_fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_glob")
+        result = glob_fn("{src,lib}/**/*.{py,js}")
+        assert "a.py" in result
+        assert "b.js" in result
+
+    def test_mtime_sort_preserved(self, tmp_path: Path) -> None:
+        """AC 1: Results are sorted newest-first by mtime."""
+        tool = make_tool(tmp_path)
+        root = tool.workspace._root
+        old_file = root / "old.py"
+        new_file = root / "new.py"
+        old_file.write_bytes(b"old")
+        time.sleep(0.05)
+        new_file.write_bytes(b"new")
+        glob_fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_glob")
+        result = glob_fn("**/*.{py,ts}")
+        lines = [ln for ln in result.split("\n") if not ln.startswith("[")]
+        assert lines[0] == "new.py"
+        assert lines[1] == "old.py"
+
+    def test_max_results_cap_preserved(self, tmp_path: Path) -> None:
+        """AC 6: max_results cap and truncation notice still work with brace expansion."""
+        tool = WorkspaceReadTool(workspace_glob=WorkspaceGlob(max_results=100))
+        team_id = uuid.uuid4()
+        fs = Filesystem(str(tmp_path), str(team_id))
+        root = fs._root
+        for i in range(110):
+            (root / f"f{i:03d}.py").write_bytes(b"x")
+        observer = make_observer(team_id=team_id)
+        with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
+            tool.observer(observer)
+        glob_fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_glob")
+        result = glob_fn("**/*.{py,js}")
+        lines = [ln for ln in result.split("\n") if not ln.startswith("[")]
+        assert len(lines) <= 100
+        assert "truncated" in result


### PR DESCRIPTION
## Summary

- Convert `DocumentReader` from plain class to Pydantic `BaseModel` with `ClassVar`, `Literal`, and `PrivateAttr`
- Remove `ConfigDict(arbitrary_types_allowed=True)` from `WorkspaceReadTool` (Golden Rule 1b fix)
- Change `document_reader` field from `DocumentReader | None = None` to `DocumentReader | bool = True`
- Add inline True/False/instance resolution in `_read_factory`
- Add 14 new tests: serialization, lazy init, and model_validate roundtrip
- Re-export `DocumentReader`, `FileTypeReader`, `TEXT_EXTENSIONS` from `__init__.py`
- Add `docs` optional extra for markitdown in pyproject.toml

Closes #75