### PR TITLE
feat: MediaContent and expand_media_refs command (story 3-1)

### DIFF
--- a/src/akgentic/tool/workspace/__init__.py
+++ b/src/akgentic/tool/workspace/__init__.py
@@ -15,8 +15,10 @@ from akgentic.tool.workspace.readers import (
     TEXT_EXTENSIONS,
     DocumentReader,
     FileTypeReader,
+    MediaContent,
 )
 from akgentic.tool.workspace.tool import (
+    ExpandMediaRefs,
     WorkspaceDelete,
     WorkspaceEdit,
     WorkspaceGlob,
@@ -40,6 +42,7 @@ from akgentic.tool.workspace.workspace import (
 __all__ = [
     "DocumentReader",
     "FileTypeReader",
+    "MediaContent",
     "TEXT_EXTENSIONS",
     "EditItem",
     "EditMatcher",
@@ -54,6 +57,7 @@ __all__ = [
     "Filesystem",
     "Workspace",
     "get_workspace",
+    "ExpandMediaRefs",
     "WorkspaceRead",
     "WorkspaceList",
     "WorkspaceGlob",

--- a/src/akgentic/tool/workspace/readers.py
+++ b/src/akgentic/tool/workspace/readers.py
@@ -12,6 +12,27 @@ from pydantic import BaseModel, PrivateAttr
 if TYPE_CHECKING:
     from openai import OpenAI
 
+_MIME_MAP: dict[str, str] = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+    ".bmp": "image/bmp",
+}
+
+
+class MediaContent(BaseModel):
+    """In-memory binary image content with MIME type.
+
+    Plain ``BaseModel`` (NOT ``SerializableBaseModel``) — in-memory only,
+    never wire-serialized.  No pydantic-ai imports — framework-agnostic by design.
+    """
+
+    data: bytes
+    media_type: str
+
+
 TEXT_EXTENSIONS: frozenset[str] = frozenset(
     {
         ".txt",

--- a/src/akgentic/tool/workspace/tool.py
+++ b/src/akgentic/tool/workspace/tool.py
@@ -337,11 +337,24 @@ class WorkspaceReadTool(ToolCard):
 
         Pure-text prompts (no ``!!`` tokens) return ``[prompt]``.
 
+        .. note::
+            The returned list may contain trailing empty strings (``""``) when the
+            prompt ends with a ``!!token`` with no text following it.  Consumers
+            that only care about non-empty parts should filter out empty strings::
+
+                parts = [p for p in result if p != ""]
+
         Args:
             prompt: Input prompt string potentially containing ``!!glob_pattern`` tokens.
 
         Returns:
-            Mixed list of plain strings and ``MediaContent`` objects.
+            Mixed list of plain strings and ``MediaContent`` objects.  May include
+            trailing ``""`` entries when the last character of *prompt* is part of
+            an expanded token.
+
+        Raises:
+            RuntimeError: If :meth:`observer` has not been called yet (workspace
+                not initialised).
         """
         parts: list[str | MediaContent] = []
         last = 0
@@ -361,9 +374,14 @@ class WorkspaceReadTool(ToolCard):
             ]
             if image_matches:
                 for path in image_matches:
+                    try:
+                        data = path.read_bytes()
+                    except OSError:
+                        parts.append(f"!!_{path.name}_[Error: file unreadable]")
+                        continue
                     parts.append(
                         MediaContent(
-                            data=path.read_bytes(),
+                            data=data,
                             media_type=_MIME_MAP[path.suffix.lower()],
                         )
                     )

--- a/src/akgentic/tool/workspace/tool.py
+++ b/src/akgentic/tool/workspace/tool.py
@@ -19,7 +19,7 @@ from typing import Any, Callable
 
 from pydantic import PrivateAttr
 
-from akgentic.tool.core import TOOL_CALL, BaseToolParam, Channels, ToolCard, _resolve
+from akgentic.tool.core import COMMAND, TOOL_CALL, BaseToolParam, Channels, ToolCard, _resolve
 from akgentic.tool.errors import RetriableError
 from akgentic.tool.event import ActorToolObserver
 from akgentic.tool.workspace.edit import (
@@ -30,10 +30,11 @@ from akgentic.tool.workspace.edit import (
     normalise_endings,
     parse_patch,
 )
-from akgentic.tool.workspace.readers import DocumentReader
+from akgentic.tool.workspace.readers import _MIME_MAP, DocumentReader, MediaContent
 from akgentic.tool.workspace.workspace import Filesystem, get_workspace
 
 _PERM_ERR_MSG = "Path escapes workspace root — use a path relative to the workspace"
+_REF_RE = _re.compile(r"!!(\S+)")
 
 
 class WorkspaceRead(BaseToolParam):
@@ -64,6 +65,15 @@ class WorkspaceGrep(BaseToolParam):
     expose: set[Channels] = {TOOL_CALL}
     max_results: int = 100
     max_line_length: int = 2000
+
+
+class ExpandMediaRefs(BaseToolParam):
+    """Expand ``!!glob_pattern`` tokens in a prompt into binary image content.
+
+    COMMAND channel only — never exposed as an LLM tool.
+    """
+
+    expose: set[Channels] = {COMMAND}
 
 
 def _grep_python(
@@ -244,6 +254,7 @@ class WorkspaceReadTool(ToolCard):
     workspace_glob: WorkspaceGlob | bool = True
     workspace_grep: WorkspaceGrep | bool = True
     document_reader: DocumentReader | bool = True
+    workspace_expand_media_refs: ExpandMediaRefs | bool = True
 
     # Private runtime state — not part of the serialised config.
     # Default None sentinel lets the workspace property detect uninitialized state
@@ -302,6 +313,68 @@ class WorkspaceReadTool(ToolCard):
         if pgr is not None and TOOL_CALL in pgr.expose:
             tools.append(self._grep_factory(pgr))
         return tools
+
+    def get_commands(self) -> dict[type[BaseToolParam], Callable[..., Any]]:
+        """Return COMMAND-channel capabilities for this tool.
+
+        Returns:
+            Dict mapping ``ExpandMediaRefs`` to ``_expand_media_refs`` when enabled.
+        """
+        commands: dict[type[BaseToolParam], Callable[..., Any]] = {}
+        pr = _resolve(self.workspace_expand_media_refs, ExpandMediaRefs)
+        if pr is not None:
+            commands[ExpandMediaRefs] = self._expand_media_refs
+        return commands
+
+    def _expand_media_refs(self, prompt: str) -> list[str | MediaContent]:
+        """Expand ``!!glob_pattern`` tokens in a prompt into binary image content.
+
+        For each ``!!pattern`` token:
+        - Image matches (extension in ``_MIME_MAP``) → ``MediaContent`` objects (sorted by path)
+        - Document-only matches (extension in ``DocumentReader.extensions`` but NOT in
+          ``_MIME_MAP``) → ``"!!name[=> Use workspace_read tool]"`` hint strings
+        - No matches at all → ``"!!_pattern_[Error: no image found]"``
+
+        Pure-text prompts (no ``!!`` tokens) return ``[prompt]``.
+
+        Args:
+            prompt: Input prompt string potentially containing ``!!glob_pattern`` tokens.
+
+        Returns:
+            Mixed list of plain strings and ``MediaContent`` objects.
+        """
+        parts: list[str | MediaContent] = []
+        last = 0
+        for m in _REF_RE.finditer(prompt):
+            if m.start() > last:
+                parts.append(prompt[last : m.start()])
+            pattern = m.group(1)
+            all_matches = sorted(
+                p for p in self.workspace._root.glob(pattern) if p.is_file()
+            )
+            image_matches = [p for p in all_matches if p.suffix.lower() in _MIME_MAP]
+            doc_matches = [
+                p
+                for p in all_matches
+                if p.suffix.lower() in DocumentReader.extensions
+                and p.suffix.lower() not in _MIME_MAP
+            ]
+            if image_matches:
+                for path in image_matches:
+                    parts.append(
+                        MediaContent(
+                            data=path.read_bytes(),
+                            media_type=_MIME_MAP[path.suffix.lower()],
+                        )
+                    )
+            elif doc_matches:
+                for path in doc_matches:
+                    parts.append(f"!!{path.name}[=> Use workspace_read tool]")
+            else:
+                parts.append(f"!!_{pattern}_[Error: no image found]")
+            last = m.end()
+        parts.append(prompt[last:])
+        return parts
 
     def _read_factory(self, params: WorkspaceRead) -> Callable[..., Any]:
         """Create the ``workspace_read`` tool callable.

--- a/tests/workspace/test_read_tool.py
+++ b/tests/workspace/test_read_tool.py
@@ -10,8 +10,9 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from akgentic.tool.errors import RetriableError
-from akgentic.tool.workspace.readers import DocumentReader
+from akgentic.tool.workspace.readers import DocumentReader, MediaContent
 from akgentic.tool.workspace.tool import (
+    ExpandMediaRefs,
     WorkspaceGlob,
     WorkspaceGrep,
     WorkspaceList,
@@ -1203,3 +1204,162 @@ class TestDocumentReaderLazyInit:
         second = reader._get_openai_client()
         # Same object identity — no second construction
         assert first is second
+
+
+# ---------------------------------------------------------------------------
+# Story 3-1: ExpandMediaRefs command (AC-1 through AC-8)
+# ---------------------------------------------------------------------------
+
+
+class TestExpandMediaRefs:
+    """Tests for WorkspaceReadTool._expand_media_refs (story 3-1)."""
+
+    def test_single_image_match(self, tmp_path: Path) -> None:
+        """AC-1: Single image match → MediaContent with correct bytes and media_type."""
+        tool = make_tool(tmp_path)
+        root = tool.workspace._root
+        (root / "photo.png").write_bytes(b"fake-png")
+        result = tool._expand_media_refs("look at !!photo.png please")
+        assert result == [
+            "look at ",
+            MediaContent(data=b"fake-png", media_type="image/png"),
+            " please",
+        ]
+
+    def test_multi_image_match_glob(self, tmp_path: Path) -> None:
+        """AC-2: Glob pattern !!*.png → sorted list of MediaContent objects."""
+        tool = make_tool(tmp_path)
+        root = tool.workspace._root
+        (root / "a.png").write_bytes(b"aaa")
+        (root / "b.png").write_bytes(b"bbb")
+        result = tool._expand_media_refs("check !!*.png")
+        # sorted by path → a.png before b.png
+        assert result == [
+            "check ",
+            MediaContent(data=b"aaa", media_type="image/png"),
+            MediaContent(data=b"bbb", media_type="image/png"),
+            "",
+        ]
+
+    def test_document_match_hint(self, tmp_path: Path) -> None:
+        """AC-3: Document match (.pdf) → hint string with workspace_read instruction."""
+        tool = make_tool(tmp_path)
+        root = tool.workspace._root
+        (root / "report.pdf").write_bytes(b"%PDF-fake")
+        result = tool._expand_media_refs("show !!report.pdf")
+        assert result == ["show ", "!!report.pdf[=> Use workspace_read tool]", ""]
+
+    def test_no_match_error(self, tmp_path: Path) -> None:
+        """AC-4: No match → error string with pattern name."""
+        tool = make_tool(tmp_path)
+        result = tool._expand_media_refs("show !!missing.png")
+        assert result == ["show ", "!!_missing.png_[Error: no image found]", ""]
+
+    def test_pure_text_passthrough(self, tmp_path: Path) -> None:
+        """AC-5: Pure text prompt with no !! tokens → single-element list."""
+        tool = make_tool(tmp_path)
+        result = tool._expand_media_refs("no tokens here")
+        assert result == ["no tokens here"]
+
+    def test_disabled_field_excludes_from_commands(self, tmp_path: Path) -> None:
+        """AC-6: workspace_expand_media_refs=False → ExpandMediaRefs not in get_commands()."""
+        import uuid
+        from unittest.mock import patch
+
+        tid = uuid.uuid4()
+        fs = Filesystem(str(tmp_path), str(tid))
+        observer = make_observer(team_id=tid)
+        tool = WorkspaceReadTool(workspace_expand_media_refs=False)
+        with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
+            tool.observer(observer)
+        commands = tool.get_commands()
+        assert ExpandMediaRefs not in commands
+
+    def test_enabled_field_includes_in_commands(self, tmp_path: Path) -> None:
+        """AC-6 inverse: workspace_expand_media_refs=True → ExpandMediaRefs in get_commands()."""
+        tool = make_tool(tmp_path)
+        commands = tool.get_commands()
+        assert ExpandMediaRefs in commands
+        assert commands[ExpandMediaRefs] == tool._expand_media_refs
+
+    def test_media_content_model_dump(self) -> None:
+        """AC-7: MediaContent.model_dump() returns correct dict."""
+        mc = MediaContent(data=b"abc", media_type="image/png")
+        result = mc.model_dump()
+        assert result == {"data": b"abc", "media_type": "image/png"}
+
+    def test_mixed_prompt_text_and_image(self, tmp_path: Path) -> None:
+        """AC-8: Mixed prompt — text segments interleaved with image tokens."""
+        tool = make_tool(tmp_path)
+        root = tool.workspace._root
+        (root / "cat.jpg").write_bytes(b"jpg-bytes")
+        result = tool._expand_media_refs("hello !!cat.jpg world")
+        assert result == [
+            "hello ",
+            MediaContent(data=b"jpg-bytes", media_type="image/jpeg"),
+            " world",
+        ]
+
+    def test_expand_media_refs_not_in_get_tools(self, tmp_path: Path) -> None:
+        """AC-8 / Task 6.9: ExpandMediaRefs must NOT appear in get_tools() — COMMAND channel only."""
+        tool = make_tool(tmp_path)
+        tools = tool.get_tools()
+        tool_names = [fn.__name__ for fn in tools]
+        assert "expand_media_refs" not in tool_names
+
+    def test_jpg_mime_type(self, tmp_path: Path) -> None:
+        """Image with .jpg extension → media_type image/jpeg."""
+        tool = make_tool(tmp_path)
+        root = tool.workspace._root
+        (root / "img.jpg").write_bytes(b"jpegdata")
+        result = tool._expand_media_refs("!!img.jpg")
+        assert result == [MediaContent(data=b"jpegdata", media_type="image/jpeg"), ""]
+
+    def test_webp_mime_type(self, tmp_path: Path) -> None:
+        """Image with .webp extension → media_type image/webp."""
+        tool = make_tool(tmp_path)
+        root = tool.workspace._root
+        (root / "anim.webp").write_bytes(b"webpdata")
+        result = tool._expand_media_refs("!!anim.webp")
+        assert result == [MediaContent(data=b"webpdata", media_type="image/webp"), ""]
+
+    def test_gif_mime_type(self, tmp_path: Path) -> None:
+        """Image with .gif extension → media_type image/gif."""
+        tool = make_tool(tmp_path)
+        root = tool.workspace._root
+        (root / "anim.gif").write_bytes(b"gifdata")
+        result = tool._expand_media_refs("!!anim.gif")
+        assert result == [MediaContent(data=b"gifdata", media_type="image/gif"), ""]
+
+    def test_bmp_mime_type(self, tmp_path: Path) -> None:
+        """Image with .bmp extension → media_type image/bmp."""
+        tool = make_tool(tmp_path)
+        root = tool.workspace._root
+        (root / "icon.bmp").write_bytes(b"bmpdata")
+        result = tool._expand_media_refs("!!icon.bmp")
+        assert result == [MediaContent(data=b"bmpdata", media_type="image/bmp"), ""]
+
+    def test_image_takes_priority_over_doc_extension(self, tmp_path: Path) -> None:
+        """Image extensions shared with DocumentReader (e.g. .png) → MediaContent, not hint."""
+        tool = make_tool(tmp_path)
+        root = tool.workspace._root
+        # .png is in both _MIME_MAP and DocumentReader.extensions
+        assert ".png" in DocumentReader.extensions
+        (root / "photo.png").write_bytes(b"imgdata")
+        result = tool._expand_media_refs("!!photo.png")
+        assert result == [MediaContent(data=b"imgdata", media_type="image/png"), ""]
+
+    def test_multiple_tokens_in_prompt(self, tmp_path: Path) -> None:
+        """Multiple !! tokens in one prompt → each expands independently."""
+        tool = make_tool(tmp_path)
+        root = tool.workspace._root
+        (root / "a.png").write_bytes(b"adata")
+        (root / "b.png").write_bytes(b"bdata")
+        result = tool._expand_media_refs("first !!a.png middle !!b.png end")
+        assert result == [
+            "first ",
+            MediaContent(data=b"adata", media_type="image/png"),
+            " middle ",
+            MediaContent(data=b"bdata", media_type="image/png"),
+            " end",
+        ]

--- a/tests/workspace/test_read_tool.py
+++ b/tests/workspace/test_read_tool.py
@@ -1363,3 +1363,9 @@ class TestExpandMediaRefs:
             MediaContent(data=b"bdata", media_type="image/png"),
             " end",
         ]
+
+    def test_expand_media_refs_raises_before_observer_called(self) -> None:
+        """M2: Calling _expand_media_refs before observer() raises RuntimeError."""
+        tool = WorkspaceReadTool()
+        with pytest.raises(RuntimeError):
+            tool._expand_media_refs("!!photo.png")


### PR DESCRIPTION
## Summary

- Adds `MediaContent` Pydantic model for in-memory binary image content with MIME type
- Adds `ExpandMediaRefs` command (COMMAND-channel only) that expands `!!glob_pattern` tokens in prompts into `MediaContent` objects or hint strings
- Implements `_expand_media_refs` on `WorkspaceReadTool` with image priority, document hints, and error placeholders
- Registers command in `get_commands()` keyed by `ExpandMediaRefs`

## Review fixes applied

- Documented trailing `""` entries in `_expand_media_refs` docstring
- Added test asserting `RuntimeError` when `_expand_media_refs` is called before `observer()`
- Wrapped `path.read_bytes()` in `OSError` handler — injects `!!_name_[Error: file unreadable]` instead of raising
- Verified `# type: ignore[import-not-found]` on markitdown import in `readers.py` is still required

Closes #77

> Note: supersedes #78 which was accidentally targeted at `fix/75-5-10-documentreader-serialization-fix` instead of `master`.