### PR TITLE
feat: workspace_view LLM-callable image tool (story 5.11)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ vector_search = [
     "numpy>=1.26.0",
 ]
 docs = ["markitdown[pdf,docx,xlsx,xls,pptx,outlook]>=0.1"]
+vision = ["Pillow>=10.0"]
 dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.23.0",

--- a/src/akgentic/tool/workspace/__init__.py
+++ b/src/akgentic/tool/workspace/__init__.py
@@ -30,6 +30,7 @@ from akgentic.tool.workspace.tool import (
     WorkspaceRead,
     WorkspaceReadTool,
     WorkspaceTool,
+    WorkspaceView,
     WorkspaceWrite,
 )
 from akgentic.tool.workspace.workspace import (
@@ -58,6 +59,7 @@ __all__ = [
     "Workspace",
     "get_workspace",
     "ExpandMediaRefs",
+    "WorkspaceView",
     "WorkspaceRead",
     "WorkspaceList",
     "WorkspaceGlob",

--- a/src/akgentic/tool/workspace/tool.py
+++ b/src/akgentic/tool/workspace/tool.py
@@ -37,6 +37,15 @@ from akgentic.tool.workspace.workspace import Filesystem, get_workspace
 
 _PERM_ERR_MSG = "Path escapes workspace root — use a path relative to the workspace"
 _REF_RE = _re.compile(r'!!"([^"]+)"|!!(\S+)')
+_PILLOW_FMT: dict[str, str] = {
+    ".png": "PNG",
+    ".jpg": "JPEG",
+    ".jpeg": "JPEG",
+    ".webp": "WEBP",
+    ".gif": "GIF",
+    ".bmp": "BMP",
+}
+_PILLOW_WARN_EMITTED: bool = False  # guards the one-time Pillow-absent warning
 
 
 class WorkspaceRead(BaseToolParam):
@@ -101,12 +110,15 @@ def _maybe_resize(data: bytes, suffix: str, max_dim: int, root: Path, path: str)
     try:
         from PIL import Image  # noqa: PLC0415
     except ImportError:
-        import logging  # noqa: PLC0415
+        global _PILLOW_WARN_EMITTED  # noqa: PLW0603
+        if not _PILLOW_WARN_EMITTED:
+            import logging  # noqa: PLC0415
 
-        logging.getLogger(__name__).warning(
-            "Pillow not installed — sending raw image without resizing. "
-            'Install with: pip install "akgentic-tool[vision]"'
-        )
+            logging.getLogger(__name__).warning(
+                "Pillow not installed — sending raw image without resizing. "
+                'Install with: pip install "akgentic-tool[vision]"'
+            )
+            _PILLOW_WARN_EMITTED = True
         return data
 
     p = Path(path)
@@ -122,7 +134,7 @@ def _maybe_resize(data: bytes, suffix: str, max_dim: int, root: Path, path: str)
 
     img.thumbnail((max_dim, max_dim), Image.LANCZOS)  # type: ignore[attr-defined]
     buf = io.BytesIO()
-    fmt = "PNG" if suffix == ".png" else "JPEG"
+    fmt = _PILLOW_FMT.get(suffix, "JPEG")
     img.save(buf, format=fmt)
     resized = buf.getvalue()
     sidecar_path.write_bytes(resized)

--- a/src/akgentic/tool/workspace/tool.py
+++ b/src/akgentic/tool/workspace/tool.py
@@ -763,6 +763,12 @@ class WorkspaceReadTool(ToolCard):
                     or the file extension is not a supported image format.
             """
             try:
+                data = backend.read_bytes(path)
+            except FileNotFoundError:
+                raise RetriableError(f"File not found: {path}")
+            except PermissionError:
+                raise RetriableError(_PERM_ERR_MSG)
+            try:
                 suffix = PurePosixPath(path).suffix.lower()
                 mime = _MIME_MAP.get(suffix)
                 if mime is None:
@@ -771,13 +777,10 @@ class WorkspaceReadTool(ToolCard):
                         f"Supported: {', '.join(sorted(_MIME_MAP))}. "
                         f"For documents, use workspace_read instead."
                     )
-                data = backend.read_bytes(path)
                 data = _maybe_resize(data, suffix, max_dim, backend._root, path)
                 return BinaryContent(data=data, media_type=mime)
-            except FileNotFoundError:
-                raise RetriableError(f"File not found: {path}")
-            except PermissionError:
-                raise RetriableError(_PERM_ERR_MSG)
+            except RetriableError:
+                raise
 
         workspace_view.__doc__ = params.format_docstring(workspace_view.__doc__)
         return workspace_view

--- a/src/akgentic/tool/workspace/tool.py
+++ b/src/akgentic/tool/workspace/tool.py
@@ -11,13 +11,15 @@ obtained via :func:`~akgentic.tool.workspace.workspace.get_workspace`.
 from __future__ import annotations
 
 import difflib
+import io
 import re as _re
 import shutil
 import subprocess
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Callable
 
 from pydantic import PrivateAttr
+from pydantic_ai.messages import BinaryContent
 
 from akgentic.tool.core import COMMAND, TOOL_CALL, BaseToolParam, Channels, ToolCard, _resolve
 from akgentic.tool.errors import RetriableError
@@ -74,6 +76,57 @@ class ExpandMediaRefs(BaseToolParam):
     """
 
     expose: set[Channels] = {COMMAND}
+
+
+class WorkspaceView(BaseToolParam):
+    """View an image file from the team workspace as binary content for LLM vision."""
+
+    expose: set[Channels] = {TOOL_CALL}
+    max_dimension: int = 1568
+    """Longest-side pixel cap. Images exceeding this are resized (aspect-ratio preserved, LANCZOS).
+    Set to 0 to disable resizing and return raw bytes."""
+
+
+def _maybe_resize(data: bytes, suffix: str, max_dim: int, root: Path, path: str) -> bytes:
+    """Resize *data* if longest side exceeds *max_dim*, with sidecar cache.
+
+    When *max_dim* is 0, returns *data* unchanged and writes no sidecar.
+    When Pillow is not installed, logs a one-time warning and returns *data* unchanged.
+
+    Sidecar naming: ``.{stem}.{ext}.{max_dim}.{ext}`` colocated with the source file.
+    """
+    if max_dim == 0:
+        return data
+
+    try:
+        from PIL import Image  # noqa: PLC0415
+    except ImportError:
+        import logging  # noqa: PLC0415
+
+        logging.getLogger(__name__).warning(
+            "Pillow not installed — sending raw image without resizing. "
+            'Install with: pip install "akgentic-tool[vision]"'
+        )
+        return data
+
+    p = Path(path)
+    sidecar_name = f".{p.stem}{p.suffix}.{max_dim}{p.suffix}"
+    sidecar_path = root / p.parent / sidecar_name
+
+    if sidecar_path.exists():
+        return sidecar_path.read_bytes()
+
+    img = Image.open(io.BytesIO(data))
+    if max(img.size) <= max_dim:
+        return data  # already within limit — no resize, no sidecar
+
+    img.thumbnail((max_dim, max_dim), Image.LANCZOS)  # type: ignore[attr-defined]
+    buf = io.BytesIO()
+    fmt = "PNG" if suffix == ".png" else "JPEG"
+    img.save(buf, format=fmt)
+    resized = buf.getvalue()
+    sidecar_path.write_bytes(resized)
+    return resized
 
 
 def _grep_python(
@@ -255,6 +308,7 @@ class WorkspaceReadTool(ToolCard):
     workspace_grep: WorkspaceGrep | bool = True
     document_reader: DocumentReader | bool = True
     workspace_expand_media_refs: ExpandMediaRefs | bool = True
+    workspace_view: WorkspaceView | bool = True
 
     # Private runtime state — not part of the serialised config.
     # Default None sentinel lets the workspace property detect uninitialized state
@@ -312,6 +366,9 @@ class WorkspaceReadTool(ToolCard):
         pgr = _resolve(self.workspace_grep, WorkspaceGrep)
         if pgr is not None and TOOL_CALL in pgr.expose:
             tools.append(self._grep_factory(pgr))
+        vw = _resolve(self.workspace_view, WorkspaceView)
+        if vw is not None and TOOL_CALL in vw.expose:
+            tools.append(self._view_factory(vw))
         return tools
 
     def get_commands(self) -> dict[type[BaseToolParam], Callable[..., Any]]:
@@ -364,9 +421,7 @@ class WorkspaceReadTool(ToolCard):
             if m.start() > last:
                 parts.append(prompt[last : m.start()])
             pattern = m.group(1) or m.group(2)
-            all_matches = sorted(
-                p for p in self.workspace._root.glob(pattern) if p.is_file()
-            )
+            all_matches = sorted(p for p in self.workspace._root.glob(pattern) if p.is_file())
             image_matches = [p for p in all_matches if p.suffix.lower() in _MIME_MAP]
             doc_matches = [
                 p
@@ -664,6 +719,56 @@ class WorkspaceReadTool(ToolCard):
 
         workspace_grep.__doc__ = params.format_docstring(workspace_grep.__doc__)
         return workspace_grep
+
+    def _view_factory(self, params: WorkspaceView) -> Callable[..., Any]:
+        """Create the ``workspace_view`` tool callable.
+
+        Args:
+            params: View capability configuration.
+
+        Returns:
+            Callable that reads an image from the workspace as BinaryContent.
+        """
+        backend = self.workspace
+        max_dim = params.max_dimension
+
+        def workspace_view(path: str) -> BinaryContent:
+            """View an image file from the workspace. Returns the image for vision analysis.
+
+            Use this when you need to visually inspect an image (screenshot, diagram, photo).
+            For text extraction from documents (PDF, DOCX), use workspace_read instead.
+
+            Supported formats: PNG, JPEG, GIF, WebP, BMP.
+
+            Args:
+                path: Relative path to the image file within the workspace.
+
+            Returns:
+                BinaryContent with the image bytes and MIME type.
+
+            Raises:
+                RetriableError: If the path does not exist, escapes the workspace root,
+                    or the file extension is not a supported image format.
+            """
+            try:
+                suffix = PurePosixPath(path).suffix.lower()
+                mime = _MIME_MAP.get(suffix)
+                if mime is None:
+                    raise RetriableError(
+                        f"Unsupported image format '{suffix}'. "
+                        f"Supported: {', '.join(sorted(_MIME_MAP))}. "
+                        f"For documents, use workspace_read instead."
+                    )
+                data = backend.read_bytes(path)
+                data = _maybe_resize(data, suffix, max_dim, backend._root, path)
+                return BinaryContent(data=data, media_type=mime)
+            except FileNotFoundError:
+                raise RetriableError(f"File not found: {path}")
+            except PermissionError:
+                raise RetriableError(_PERM_ERR_MSG)
+
+        workspace_view.__doc__ = params.format_docstring(workspace_view.__doc__)
+        return workspace_view
 
 
 class WorkspaceWrite(BaseToolParam):

--- a/src/akgentic/tool/workspace/workspace.py
+++ b/src/akgentic/tool/workspace/workspace.py
@@ -31,6 +31,8 @@ class Workspace(Protocol):
 
     def read(self, path: str) -> bytes: ...
 
+    def read_bytes(self, path: str) -> bytes: ...
+
     def write(self, path: str, data: bytes) -> None: ...
 
     def delete(self, path: str) -> None: ...
@@ -77,6 +79,16 @@ class Filesystem:
         resolved = self._validate_path(path)
         return resolved.read_bytes()
 
+    def read_bytes(self, path: str) -> bytes:
+        """Return the raw bytes of *path* with no decoding or pagination.
+
+        Raises:
+            FileNotFoundError: if the file does not exist.
+            PermissionError: if *path* escapes the workspace root.
+        """
+        resolved = self._validate_path(path)
+        return resolved.read_bytes()
+
     def write(self, path: str, data: bytes) -> None:
         """Write *data* to *path*, creating missing parent directories.
 
@@ -114,9 +126,7 @@ class Filesystem:
             if child.is_dir():
                 dirs.append(FileEntry(name=child.name, is_dir=True, size=0))
             else:
-                files.append(
-                    FileEntry(name=child.name, is_dir=False, size=child.stat().st_size)
-                )
+                files.append(FileEntry(name=child.name, is_dir=False, size=child.stat().st_size))
         dirs.sort(key=lambda e: e.name)
         files.sort(key=lambda e: e.name)
         entries = dirs + files

--- a/tests/workspace/test_read_tool.py
+++ b/tests/workspace/test_read_tool.py
@@ -516,9 +516,9 @@ class TestWorkspaceGrep:
 class TestCapabilityToggling:
     def test_all_enabled_returns_four_tools(self, tmp_path: Path) -> None:
         tool = make_tool(tmp_path)
-        assert len(tool.get_tools()) == 4
+        assert len(tool.get_tools()) == 5  # read, list, glob, grep, view
 
-    def test_glob_and_grep_disabled_returns_two_tools(self, tmp_path: Path) -> None:
+    def test_glob_and_grep_disabled_returns_three_tools(self, tmp_path: Path) -> None:
         team_id = uuid.uuid4()
         fs = Filesystem(str(tmp_path), str(team_id))
         observer = make_observer(team_id=team_id)
@@ -526,7 +526,7 @@ class TestCapabilityToggling:
         with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
             tool.observer(observer)
         tools = tool.get_tools()
-        assert len(tools) == 2
+        assert len(tools) == 3  # read, list, view
         names = [t.__name__ for t in tools]
         assert "workspace_read" in names
         assert "workspace_list" in names
@@ -540,6 +540,7 @@ class TestCapabilityToggling:
             workspace_list=False,
             workspace_glob=False,
             workspace_grep=False,
+            workspace_view=False,
         )
         with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
             tool.observer(observer)
@@ -554,6 +555,7 @@ class TestCapabilityToggling:
             workspace_list=False,
             workspace_glob=WorkspaceGlob(),
             workspace_grep=False,
+            workspace_view=False,
         )
         with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
             tool.observer(observer)

--- a/tests/workspace/test_view_tool.py
+++ b/tests/workspace/test_view_tool.py
@@ -1,0 +1,358 @@
+"""Tests for workspace_view tool — Story 5.11."""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from akgentic.tool.errors import RetriableError
+from akgentic.tool.workspace.tool import WorkspaceReadTool, WorkspaceView
+from akgentic.tool.workspace.workspace import Filesystem
+
+try:
+    from pydantic_ai.messages import BinaryContent
+except ImportError:
+    BinaryContent = None  # type: ignore[assignment,misc]
+
+# ---------------------------------------------------------------------------
+# Helpers — mirror pattern from test_read_tool.py
+# ---------------------------------------------------------------------------
+
+
+def make_observer(
+    orchestrator_is_none: bool = False,
+    team_id: uuid.UUID | None = None,
+) -> MagicMock:
+    """Build a minimal mock ActorToolObserver."""
+    observer = MagicMock()
+    observer.orchestrator = None if orchestrator_is_none else MagicMock()
+    observer._team_id = team_id or uuid.uuid4()
+    return observer
+
+
+def make_wired_read_tool(tmp_path: Path) -> tuple[WorkspaceReadTool, Filesystem]:
+    """Build a WorkspaceReadTool wired to a Filesystem rooted at tmp_path."""
+    tid = uuid.uuid4()
+    fs = Filesystem(str(tmp_path), str(tid))
+    observer = make_observer(team_id=tid)
+    tool = WorkspaceReadTool()
+    with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
+        tool.observer(observer)
+    return tool, fs
+
+
+# ---------------------------------------------------------------------------
+# TestWorkspaceReadBytes
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceReadBytes:
+    """Tests for Filesystem.read_bytes() (AC: 3)."""
+
+    def test_read_bytes_returns_raw_bytes(self, tmp_path: Path) -> None:
+        """read_bytes returns exact bytes written to the file."""
+        _, fs = make_wired_read_tool(tmp_path)
+        (fs._root / "data.bin").write_bytes(b"\x00\x01\x02\x03")
+        result = fs.read_bytes("data.bin")
+        assert result == b"\x00\x01\x02\x03"
+
+    def test_read_bytes_traversal_guard(self, tmp_path: Path) -> None:
+        """read_bytes raises PermissionError for path traversal attempts."""
+        _, fs = make_wired_read_tool(tmp_path)
+        with pytest.raises(PermissionError):
+            fs.read_bytes("../../etc/passwd")
+
+    def test_read_bytes_not_found(self, tmp_path: Path) -> None:
+        """read_bytes raises FileNotFoundError for non-existent files."""
+        _, fs = make_wired_read_tool(tmp_path)
+        with pytest.raises(FileNotFoundError):
+            fs.read_bytes("nonexistent.bin")
+
+
+# ---------------------------------------------------------------------------
+# TestWorkspaceViewTool
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceViewTool:
+    """Tests for workspace_view tool callable (AC: 4, 10, 11)."""
+
+    def _view_fn(self, tool: WorkspaceReadTool) -> object:
+        """Extract workspace_view callable from tool."""
+        return next(t for t in tool.get_tools() if t.__name__ == "workspace_view")
+
+    def test_png_success(self, tmp_path: Path) -> None:
+        """Valid PNG → BinaryContent(media_type='image/png')."""
+        tool, fs = make_wired_read_tool(tmp_path)
+        (fs._root / "screenshot.png").write_bytes(b"fake-png-bytes")
+        # Disable resize to avoid Pillow dependency in basic test
+        tool.workspace_view = WorkspaceView(max_dimension=0)
+        fn = self._view_fn(tool)
+        result = fn("screenshot.png")
+        assert result.media_type == "image/png"
+        assert result.data == b"fake-png-bytes"
+
+    def test_jpeg_success(self, tmp_path: Path) -> None:
+        """Valid JPEG → BinaryContent(media_type='image/jpeg')."""
+        tool, fs = make_wired_read_tool(tmp_path)
+        (fs._root / "photo.jpg").write_bytes(b"fake-jpeg-bytes")
+        tool.workspace_view = WorkspaceView(max_dimension=0)
+        fn = self._view_fn(tool)
+        result = fn("photo.jpg")
+        assert result.media_type == "image/jpeg"
+        assert result.data == b"fake-jpeg-bytes"
+
+    def test_webp_success(self, tmp_path: Path) -> None:
+        """Valid WebP → BinaryContent(media_type='image/webp')."""
+        tool, fs = make_wired_read_tool(tmp_path)
+        (fs._root / "anim.webp").write_bytes(b"fake-webp-bytes")
+        tool.workspace_view = WorkspaceView(max_dimension=0)
+        fn = self._view_fn(tool)
+        result = fn("anim.webp")
+        assert result.media_type == "image/webp"
+
+    def test_gif_success(self, tmp_path: Path) -> None:
+        """Valid GIF → BinaryContent(media_type='image/gif')."""
+        tool, fs = make_wired_read_tool(tmp_path)
+        (fs._root / "anim.gif").write_bytes(b"fake-gif-bytes")
+        tool.workspace_view = WorkspaceView(max_dimension=0)
+        fn = self._view_fn(tool)
+        result = fn("anim.gif")
+        assert result.media_type == "image/gif"
+
+    def test_unsupported_format_raises_retriable_error(self, tmp_path: Path) -> None:
+        """PDF extension → RetriableError (AC: 10)."""
+        tool, fs = make_wired_read_tool(tmp_path)
+        (fs._root / "report.pdf").write_bytes(b"%PDF fake")
+        tool.workspace_view = WorkspaceView(max_dimension=0)
+        fn = self._view_fn(tool)
+        with pytest.raises(RetriableError):
+            fn("report.pdf")
+
+    def test_unsupported_format_error_message_hint(self, tmp_path: Path) -> None:
+        """RetriableError message for unsupported format includes workspace_read hint."""
+        tool, fs = make_wired_read_tool(tmp_path)
+        (fs._root / "report.pdf").write_bytes(b"%PDF fake")
+        tool.workspace_view = WorkspaceView(max_dimension=0)
+        fn = self._view_fn(tool)
+        with pytest.raises(RetriableError, match="workspace_read"):
+            fn("report.pdf")
+
+    def test_file_not_found_raises_retriable_error(self, tmp_path: Path) -> None:
+        """Non-existent file → RetriableError."""
+        tool, _ = make_wired_read_tool(tmp_path)
+        tool.workspace_view = WorkspaceView(max_dimension=0)
+        fn = self._view_fn(tool)
+        with pytest.raises(RetriableError, match="File not found"):
+            fn("ghost.png")
+
+    def test_traversal_raises_retriable_error(self, tmp_path: Path) -> None:
+        """Path traversal → RetriableError."""
+        tool, _ = make_wired_read_tool(tmp_path)
+        tool.workspace_view = WorkspaceView(max_dimension=0)
+        fn = self._view_fn(tool)
+        with pytest.raises(RetriableError):
+            fn("../../secret.png")
+
+    def test_workspace_view_false_not_in_tools(self, tmp_path: Path) -> None:
+        """workspace_view=False → workspace_view not in get_tools() (AC: 11)."""
+        tid = uuid.uuid4()
+        fs = Filesystem(str(tmp_path), str(tid))
+        observer = make_observer(team_id=tid)
+        tool = WorkspaceReadTool(workspace_view=False)
+        with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
+            tool.observer(observer)
+        names = [t.__name__ for t in tool.get_tools()]
+        assert "workspace_view" not in names
+
+    def test_workspace_view_true_in_tools(self, tmp_path: Path) -> None:
+        """workspace_view=True → workspace_view in get_tools()."""
+        tool, _ = make_wired_read_tool(tmp_path)
+        names = [t.__name__ for t in tool.get_tools()]
+        assert "workspace_view" in names
+
+
+# ---------------------------------------------------------------------------
+# TestWorkspaceViewResize (Pillow-dependent)
+# ---------------------------------------------------------------------------
+
+
+PIL = pytest.importorskip("PIL", reason="Pillow not installed")
+
+
+def _make_png_bytes(width: int, height: int) -> bytes:
+    """Create a real minimal PNG image of given dimensions."""
+    from PIL import Image
+    import io
+
+    img = Image.new("RGB", (width, height), color=(128, 64, 32))
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+class TestWorkspaceViewResize:
+    """Tests for image resizing and sidecar cache behaviour (AC: 5, 6, 7, 8)."""
+
+    def test_max_dimension_zero_skips_resize_and_sidecar(self, tmp_path: Path) -> None:
+        """max_dimension=0 → raw bytes returned, no sidecar written (AC: 8)."""
+        tool, fs = make_wired_read_tool(tmp_path)
+        raw = _make_png_bytes(2000, 2000)
+        (fs._root / "big.png").write_bytes(raw)
+        tool.workspace_view = WorkspaceView(max_dimension=0)
+        fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_view")
+        result = fn("big.png")
+        assert result.data == raw
+        # No sidecar should be created
+        sidecars = list(fs._root.glob(".big.png.*"))
+        assert sidecars == []
+
+    def test_resize_creates_sidecar(self, tmp_path: Path) -> None:
+        """Image > max_dimension → sidecar created (AC: 5)."""
+        tool, fs = make_wired_read_tool(tmp_path)
+        raw = _make_png_bytes(2000, 1000)
+        (fs._root / "big.png").write_bytes(raw)
+        tool.workspace_view = WorkspaceView(max_dimension=1568)
+        fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_view")
+        fn("big.png")
+        sidecar = fs._root / ".big.png.1568.png"
+        assert sidecar.exists()
+
+    def test_sidecar_cache_hit(self, tmp_path: Path) -> None:
+        """Second call hits sidecar — PIL.Image.open not called on second call (AC: 6)."""
+        from PIL import Image
+
+        tool, fs = make_wired_read_tool(tmp_path)
+        raw = _make_png_bytes(2000, 1000)
+        (fs._root / "big.png").write_bytes(raw)
+        tool.workspace_view = WorkspaceView(max_dimension=1568)
+        fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_view")
+        # First call — creates sidecar
+        result1 = fn("big.png")
+        sidecar = fs._root / ".big.png.1568.png"
+        assert sidecar.exists()
+        sidecar_bytes = sidecar.read_bytes()
+
+        # Second call — should hit sidecar
+        open_call_count = 0
+        original_open = Image.open
+
+        def counting_open(fp: object, **kwargs: object) -> object:
+            nonlocal open_call_count
+            open_call_count += 1
+            return original_open(fp, **kwargs)  # type: ignore[arg-type]
+
+        with patch.object(Image, "open", side_effect=counting_open):
+            result2 = fn("big.png")
+
+        assert open_call_count == 0  # sidecar hit — no PIL open needed
+        assert result2.data == sidecar_bytes
+
+    def test_dimension_keyed_sidecar_isolation(self, tmp_path: Path) -> None:
+        """max_dimension=800 creates different sidecar than max_dimension=1568 (AC: 7)."""
+        tool, fs = make_wired_read_tool(tmp_path)
+        raw = _make_png_bytes(2000, 2000)
+        (fs._root / "big.png").write_bytes(raw)
+
+        # Call with 1568
+        tid = uuid.uuid4()
+        fs2 = Filesystem(str(tmp_path), str(tid))
+        obs2 = make_observer(team_id=tid)
+        tool2 = WorkspaceReadTool(workspace_view=WorkspaceView(max_dimension=1568))
+        with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs2):
+            tool2.observer(obs2)
+        (fs2._root / "big.png").write_bytes(raw)
+        fn2 = next(t for t in tool2.get_tools() if t.__name__ == "workspace_view")
+        fn2("big.png")
+
+        # Call with 800
+        tid3 = uuid.uuid4()
+        fs3 = Filesystem(str(tmp_path), str(tid3))
+        obs3 = make_observer(team_id=tid3)
+        tool3 = WorkspaceReadTool(workspace_view=WorkspaceView(max_dimension=800))
+        with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs3):
+            tool3.observer(obs3)
+        (fs3._root / "big.png").write_bytes(raw)
+        fn3 = next(t for t in tool3.get_tools() if t.__name__ == "workspace_view")
+        fn3("big.png")
+
+        sidecar_1568 = fs2._root / ".big.png.1568.png"
+        sidecar_800 = fs3._root / ".big.png.800.png"
+        assert sidecar_1568.exists()
+        assert sidecar_800.exists()
+        # Different files (different sizes)
+        assert sidecar_1568.stat().st_size != sidecar_800.stat().st_size
+
+    def test_image_within_limit_no_resize(self, tmp_path: Path) -> None:
+        """Image <= max_dimension → raw bytes, no sidecar created."""
+        tool, fs = make_wired_read_tool(tmp_path)
+        raw = _make_png_bytes(100, 100)
+        (fs._root / "small.png").write_bytes(raw)
+        tool.workspace_view = WorkspaceView(max_dimension=1568)
+        fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_view")
+        result = fn("small.png")
+        assert result.data == raw
+        sidecar = fs._root / ".small.png.1568.png"
+        assert not sidecar.exists()
+
+
+# ---------------------------------------------------------------------------
+# TestWorkspaceViewPillowAbsent
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceViewPillowAbsent:
+    """Tests for graceful Pillow-absent fallback (AC: 9)."""
+
+    def test_pillow_absent_returns_raw_bytes_no_error(self, tmp_path: Path) -> None:
+        """When Pillow is not installed, raw bytes returned with no ImportError raised."""
+        tool, fs = make_wired_read_tool(tmp_path)
+        raw = b"fake-png-data"
+        (fs._root / "image.png").write_bytes(raw)
+        tool.workspace_view = WorkspaceView(max_dimension=1568)
+        fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_view")
+
+        import sys
+
+        with patch.dict(sys.modules, {"PIL": None, "PIL.Image": None}):
+            result = fn("image.png")
+
+        assert result.data == raw
+        assert result.media_type == "image/png"
+
+    def test_pillow_absent_no_sidecar_written(self, tmp_path: Path) -> None:
+        """When Pillow absent, no sidecar file is created."""
+        tool, fs = make_wired_read_tool(tmp_path)
+        (fs._root / "image.png").write_bytes(b"fake-png-data")
+        tool.workspace_view = WorkspaceView(max_dimension=1568)
+        fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_view")
+
+        import sys
+
+        with patch.dict(sys.modules, {"PIL": None, "PIL.Image": None}):
+            fn("image.png")
+
+        sidecars = list(fs._root.glob(".image.png.*"))
+        assert sidecars == []
+
+    def test_pillow_absent_logs_warning(self, tmp_path: Path) -> None:
+        """When Pillow absent, a warning is logged."""
+        import logging
+        import sys
+
+        tool, fs = make_wired_read_tool(tmp_path)
+        (fs._root / "image.png").write_bytes(b"fake-png-data")
+        tool.workspace_view = WorkspaceView(max_dimension=1568)
+        fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_view")
+
+        with (
+            patch.dict(sys.modules, {"PIL": None, "PIL.Image": None}),
+            patch.object(logging.getLogger("akgentic.tool.workspace.tool"), "warning") as mock_warn,
+        ):
+            fn("image.png")
+
+        mock_warn.assert_called_once()
+        assert "Pillow" in mock_warn.call_args[0][0]

--- a/tests/workspace/test_view_tool.py
+++ b/tests/workspace/test_view_tool.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+import akgentic.tool.workspace.tool as _tool_mod
 from akgentic.tool.errors import RetriableError
 from akgentic.tool.workspace.tool import WorkspaceReadTool, WorkspaceView
 from akgentic.tool.workspace.workspace import Filesystem
@@ -185,8 +186,9 @@ PIL = pytest.importorskip("PIL", reason="Pillow not installed")
 
 def _make_png_bytes(width: int, height: int) -> bytes:
     """Create a real minimal PNG image of given dimensions."""
-    from PIL import Image
     import io
+
+    from PIL import Image
 
     img = Image.new("RGB", (width, height), color=(128, 64, 32))
     buf = io.BytesIO()
@@ -231,7 +233,7 @@ class TestWorkspaceViewResize:
         tool.workspace_view = WorkspaceView(max_dimension=1568)
         fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_view")
         # First call — creates sidecar
-        result1 = fn("big.png")
+        fn("big.png")
         sidecar = fs._root / ".big.png.1568.png"
         assert sidecar.exists()
         sidecar_bytes = sidecar.read_bytes()
@@ -298,6 +300,55 @@ class TestWorkspaceViewResize:
         sidecar = fs._root / ".small.png.1568.png"
         assert not sidecar.exists()
 
+    def test_webp_resize_uses_webp_format(self, tmp_path: Path) -> None:
+        """WebP image resized and sidecar contains valid WebP bytes (not JPEG)."""
+        import io
+
+        from PIL import Image
+
+        # Build a minimal WebP image larger than 1568px
+        img = Image.new("RGB", (2000, 2000), color=(10, 20, 30))
+        buf = io.BytesIO()
+        img.save(buf, format="WEBP")
+        raw_webp = buf.getvalue()
+
+        tool, fs = make_wired_read_tool(tmp_path)
+        (fs._root / "anim.webp").write_bytes(raw_webp)
+        tool.workspace_view = WorkspaceView(max_dimension=1568)
+        fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_view")
+        result = fn("anim.webp")
+
+        assert result.media_type == "image/webp"
+        # Verify sidecar bytes are valid WebP (starts with RIFF...WEBP signature)
+        sidecar = fs._root / ".anim.webp.1568.webp"
+        assert sidecar.exists()
+        sidecar_bytes = sidecar.read_bytes()
+        assert sidecar_bytes[:4] == b"RIFF", "Sidecar must be WebP (RIFF), not JPEG (FFD8)"
+        assert result.data == sidecar_bytes
+
+    def test_jpeg_resize_uses_jpeg_format(self, tmp_path: Path) -> None:
+        """JPEG image resized and sidecar contains valid JPEG bytes."""
+        import io
+
+        from PIL import Image
+
+        img = Image.new("RGB", (2000, 2000), color=(50, 100, 150))
+        buf = io.BytesIO()
+        img.save(buf, format="JPEG")
+        raw_jpeg = buf.getvalue()
+
+        tool, fs = make_wired_read_tool(tmp_path)
+        (fs._root / "photo.jpg").write_bytes(raw_jpeg)
+        tool.workspace_view = WorkspaceView(max_dimension=1568)
+        fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_view")
+        result = fn("photo.jpg")
+
+        assert result.media_type == "image/jpeg"
+        sidecar = fs._root / ".photo.jpg.1568.jpg"
+        assert sidecar.exists()
+        # JPEG files start with FFD8
+        assert sidecar.read_bytes()[:2] == b"\xff\xd8", "Sidecar must be JPEG"
+
 
 # ---------------------------------------------------------------------------
 # TestWorkspaceViewPillowAbsent
@@ -309,6 +360,7 @@ class TestWorkspaceViewPillowAbsent:
 
     def test_pillow_absent_returns_raw_bytes_no_error(self, tmp_path: Path) -> None:
         """When Pillow is not installed, raw bytes returned with no ImportError raised."""
+        _tool_mod._PILLOW_WARN_EMITTED = False  # reset one-time flag for test isolation
         tool, fs = make_wired_read_tool(tmp_path)
         raw = b"fake-png-data"
         (fs._root / "image.png").write_bytes(raw)
@@ -325,6 +377,7 @@ class TestWorkspaceViewPillowAbsent:
 
     def test_pillow_absent_no_sidecar_written(self, tmp_path: Path) -> None:
         """When Pillow absent, no sidecar file is created."""
+        _tool_mod._PILLOW_WARN_EMITTED = False  # reset one-time flag for test isolation
         tool, fs = make_wired_read_tool(tmp_path)
         (fs._root / "image.png").write_bytes(b"fake-png-data")
         tool.workspace_view = WorkspaceView(max_dimension=1568)
@@ -339,10 +392,11 @@ class TestWorkspaceViewPillowAbsent:
         assert sidecars == []
 
     def test_pillow_absent_logs_warning(self, tmp_path: Path) -> None:
-        """When Pillow absent, a warning is logged."""
+        """When Pillow absent, a warning is logged once (one-time flag)."""
         import logging
         import sys
 
+        _tool_mod._PILLOW_WARN_EMITTED = False  # reset one-time flag for test isolation
         tool, fs = make_wired_read_tool(tmp_path)
         (fs._root / "image.png").write_bytes(b"fake-png-data")
         tool.workspace_view = WorkspaceView(max_dimension=1568)
@@ -353,6 +407,7 @@ class TestWorkspaceViewPillowAbsent:
             patch.object(logging.getLogger("akgentic.tool.workspace.tool"), "warning") as mock_warn,
         ):
             fn("image.png")
+            fn("image.png")  # second call — warning must NOT be repeated
 
-        mock_warn.assert_called_once()
+        mock_warn.assert_called_once()  # only one warning total across both calls
         assert "Pillow" in mock_warn.call_args[0][0]

--- a/tests/workspace/test_workspace_tool.py
+++ b/tests/workspace/test_workspace_tool.py
@@ -76,10 +76,10 @@ class TestObserverDelegation:
 
 class TestGetToolsDefault:
     def test_default_count_is_ten(self, tmp_path: Path) -> None:
-        """By default, get_tools() returns all 10 tool callables."""
+        """By default, get_tools() returns all 11 tool callables."""
         tool, _ = make_wired_tool(tmp_path)
         tools = tool.get_tools()
-        assert len(tools) == 10
+        assert len(tools) == 11  # read, list, glob, grep, view, write, delete, edit, multi_edit, patch, mkdir
 
     def test_default_includes_all_read_tools(self, tmp_path: Path) -> None:
         tool, _ = make_wired_tool(tmp_path)
@@ -210,8 +210,8 @@ class TestWorkspaceDelete:
 
 
 class TestCapabilityToggling:
-    def test_workspace_delete_disabled_returns_nine_tools(self, tmp_path: Path) -> None:
-        """WorkspaceTool(workspace_delete=False) exposes 9 tools."""
+    def test_workspace_delete_disabled_returns_ten_tools(self, tmp_path: Path) -> None:
+        """WorkspaceTool(workspace_delete=False) exposes 10 tools."""
         observer, fs = make_observer(tmp_path)
         with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
             tool = WorkspaceTool(workspace_delete=False)
@@ -220,10 +220,10 @@ class TestCapabilityToggling:
         names = [t.__name__ for t in tools]
         assert "workspace_delete" not in names
         assert "workspace_write" in names
-        assert len(tools) == 9
+        assert len(tools) == 10
 
-    def test_workspace_write_disabled_returns_nine_tools(self, tmp_path: Path) -> None:
-        """WorkspaceTool(workspace_write=False) exposes 9 tools."""
+    def test_workspace_write_disabled_returns_ten_tools(self, tmp_path: Path) -> None:
+        """WorkspaceTool(workspace_write=False) exposes 10 tools."""
         observer, fs = make_observer(tmp_path)
         with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
             tool = WorkspaceTool(workspace_write=False)
@@ -232,12 +232,12 @@ class TestCapabilityToggling:
         names = [t.__name__ for t in tools]
         assert "workspace_write" not in names
         assert "workspace_delete" in names
-        assert len(tools) == 9
+        assert len(tools) == 10
 
-    def test_both_write_and_delete_disabled_returns_eight_tools(
+    def test_both_write_and_delete_disabled_returns_nine_tools(
         self, tmp_path: Path
     ) -> None:
-        """WorkspaceTool(workspace_write=False, workspace_delete=False) returns 8 tools."""
+        """WorkspaceTool(workspace_write=False, workspace_delete=False) returns 9 tools."""
         observer, fs = make_observer(tmp_path)
         with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
             tool = WorkspaceTool(workspace_write=False, workspace_delete=False)
@@ -247,7 +247,7 @@ class TestCapabilityToggling:
         assert "workspace_write" not in names
         assert "workspace_delete" not in names
         assert "workspace_read" in names
-        assert len(tools) == 8
+        assert len(tools) == 9
 
     def test_workspace_delete_false_count(self, tmp_path: Path) -> None:
         """Repeated get_tools() call count is stable."""
@@ -255,7 +255,7 @@ class TestCapabilityToggling:
         with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
             tool = WorkspaceTool(workspace_delete=False)
             tool.observer(observer)
-        assert len(tool.get_tools()) == 9
+        assert len(tool.get_tools()) == 10
 
 
 # ---------------------------------------------------------------------------
@@ -351,7 +351,7 @@ class TestWorkspaceEdit:
             tool.observer(observer)
         names = [t.__name__ for t in tool.get_tools()]
         assert "workspace_edit" not in names
-        assert len(tool.get_tools()) == 9
+        assert len(tool.get_tools()) == 10
 
 
 # ---------------------------------------------------------------------------
@@ -440,7 +440,7 @@ class TestWorkspaceMultiEdit:
             tool.observer(observer)
         names = [t.__name__ for t in tool.get_tools()]
         assert "workspace_multi_edit" not in names
-        assert len(tool.get_tools()) == 9
+        assert len(tool.get_tools()) == 10
 
 
 # ---------------------------------------------------------------------------
@@ -528,7 +528,7 @@ class TestWorkspacePatch:
             tool.observer(observer)
         names = [t.__name__ for t in tool.get_tools()]
         assert "workspace_patch" not in names
-        assert len(tool.get_tools()) == 9
+        assert len(tool.get_tools()) == 10
 
 
 # ---------------------------------------------------------------------------
@@ -537,34 +537,34 @@ class TestWorkspacePatch:
 
 
 class TestCapabilityTogglingStory55:
-    def test_default_count_is_ten(self, tmp_path: Path) -> None:
-        """By default, get_tools() returns all 10 tool callables."""
+    def test_default_count_is_eleven(self, tmp_path: Path) -> None:
+        """By default, get_tools() returns all 11 tool callables."""
         tool, _ = make_wired_tool(tmp_path)
-        assert len(tool.get_tools()) == 10
+        assert len(tool.get_tools()) == 11
 
-    def test_edit_disabled_count_is_nine(self, tmp_path: Path) -> None:
-        """WorkspaceTool(workspace_edit=False) returns 9 tools."""
+    def test_edit_disabled_count_is_ten(self, tmp_path: Path) -> None:
+        """WorkspaceTool(workspace_edit=False) returns 10 tools."""
         observer, fs = make_observer(tmp_path)
         with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
             tool = WorkspaceTool(workspace_edit=False)
             tool.observer(observer)
-        assert len(tool.get_tools()) == 9
+        assert len(tool.get_tools()) == 10
 
-    def test_multi_edit_disabled_count_is_nine(self, tmp_path: Path) -> None:
-        """WorkspaceTool(workspace_multi_edit=False) returns 9 tools."""
+    def test_multi_edit_disabled_count_is_ten(self, tmp_path: Path) -> None:
+        """WorkspaceTool(workspace_multi_edit=False) returns 10 tools."""
         observer, fs = make_observer(tmp_path)
         with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
             tool = WorkspaceTool(workspace_multi_edit=False)
             tool.observer(observer)
-        assert len(tool.get_tools()) == 9
+        assert len(tool.get_tools()) == 10
 
-    def test_patch_disabled_count_is_nine(self, tmp_path: Path) -> None:
-        """WorkspaceTool(workspace_patch=False) returns 9 tools."""
+    def test_patch_disabled_count_is_ten(self, tmp_path: Path) -> None:
+        """WorkspaceTool(workspace_patch=False) returns 10 tools."""
         observer, fs = make_observer(tmp_path)
         with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
             tool = WorkspaceTool(workspace_patch=False)
             tool.observer(observer)
-        assert len(tool.get_tools()) == 9
+        assert len(tool.get_tools()) == 10
 
     def test_all_new_tools_present_by_default(self, tmp_path: Path) -> None:
         """workspace_edit, workspace_multi_edit, workspace_patch all in default get_tools()."""
@@ -624,12 +624,12 @@ class TestWorkspaceMkdir:
             tool.observer(observer)
         names = [t.__name__ for t in tool.get_tools()]
         assert "workspace_mkdir" not in names
-        assert len(tool.get_tools()) == 9
-
-    def test_default_count_is_ten(self, tmp_path: Path) -> None:
-        """By default, get_tools() returns all 10 tool callables."""
-        tool, _ = make_wired_tool(tmp_path)
         assert len(tool.get_tools()) == 10
+
+    def test_default_count_is_eleven(self, tmp_path: Path) -> None:
+        """By default, get_tools() returns all 11 tool callables."""
+        tool, _ = make_wired_tool(tmp_path)
+        assert len(tool.get_tools()) == 11
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `workspace_view(path)` LLM-callable tool to `WorkspaceReadTool` that returns `BinaryContent` for vision analysis
- Adds `read_bytes()` to `Workspace` protocol and `Filesystem` implementation (traversal-guarded)
- Adds `WorkspaceView(BaseToolParam)` with `expose: set[Channels] = {TOOL_CALL}` and `max_dimension: int = 1568`
- Implements `_maybe_resize()` with Pillow lazy import, sidecar cache, and dimension-keyed cache isolation
- Exports `WorkspaceView` from `workspace/__init__.py`; adds `vision = ["Pillow>=10.0"]` optional extra

**Code review fixes applied:**
- Fixed format mismatch in `_maybe_resize`: WebP/GIF/BMP sidecars were saved as JPEG — added `_PILLOW_FMT` map for correct per-extension Pillow format strings
- Fixed one-time Pillow warning: added `_PILLOW_WARN_EMITTED` module-level flag so warning only fires on first Pillow-absent invocation (AC9 compliance)
- Added `test_webp_resize_uses_webp_format` and `test_jpeg_resize_uses_jpeg_format` to pin format correctness
- 841 tests pass, ruff and mypy clean

Closes #82