### PR TITLE
fix: surface field length limits in planning tool (story 4-5)

### DIFF
--- a/src/akgentic/tool/planning/planning.py
+++ b/src/akgentic/tool/planning/planning.py
@@ -254,7 +254,12 @@ class PlanningTool(ToolCard):
         observer = self._observer
 
         def update_planning(update: UpdatePlan) -> str:
-            """Update team tasks (create, update, delete)."""
+            """Update team tasks (create, update, delete).
+
+            Field constraints (violating them causes a validation error):
+            - description: max 300 characters — keep it concise.
+            - output: max 150 characters — will be truncated automatically if exceeded.
+            """
             observer.notify_event(
                 ToolCallEvent(tool_name="Update planning", args=[update], kwargs={})
             )

--- a/src/akgentic/tool/planning/planning_actor.py
+++ b/src/akgentic/tool/planning/planning_actor.py
@@ -4,7 +4,7 @@ import datetime
 import logging
 from typing import TYPE_CHECKING, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from akgentic.core.actor_address import ActorAddress
 from akgentic.core.agent import Akgent, BaseConfig, BaseState
@@ -22,7 +22,9 @@ TaskStatus = Literal["pending", "started", "completed", "abort"]
 class TaskCreate(SerializableBaseModel):
     id: int = Field(..., description="Unique identifier of the task.")
     status: TaskStatus = Field(..., description="Status of the task.")
-    description: str = Field(..., max_length=300, description="Short description of the task.")
+    description: str = Field(
+        ..., max_length=300, description="Short description of the task (max 300 chars)."
+    )
     owner: str = Field(..., description="Assigned team member name; empty if not yet assigned.")
     dependencies: list[int] = Field(
         default_factory=list,
@@ -34,16 +36,26 @@ class TaskUpdate(SerializableBaseModel):
     id: int = Field(..., description="Unique identifier of the task.")
     status: TaskStatus | None = Field(default=None, description="New status of the task.")
     description: str | None = Field(
-        default=None, max_length=300, description="New description of the task."
+        default=None, max_length=300, description="New description of the task (max 300 chars)."
     )
     output: str | None = Field(
-        default=None, max_length=150, description="New output or result of the task."
+        default=None,
+        max_length=150,
+        description="New output or result of the task (max 150 chars; truncated automatically).",
     )
     owner: str | None = Field(default=None, description="New assigned team member name;")
     dependencies: list[int] | None = Field(
         default=None,
         description="New list of task IDs that must be completed first.",
     )
+
+    @field_validator("output", mode="before")
+    @classmethod
+    def truncate_output(cls, v: object) -> object:
+        """Silently truncate output to 150 chars to avoid validation errors."""
+        if isinstance(v, str) and len(v) > 150:
+            return v[:147] + "..."
+        return v
 
 
 class Task(TaskCreate):

--- a/tests/test_planning_actor.py
+++ b/tests/test_planning_actor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+from pydantic import ValidationError
 
 from akgentic.tool.errors import RetriableError
 from akgentic.tool.planning.planning_actor import (
@@ -194,3 +195,73 @@ def test_update_planning_all_success() -> None:
     assert len(items) == 2
     assert items[0].status == "completed"
     assert items[1].id == 2
+
+
+# ---------------------------------------------------------------------------
+# Field length constraints
+# ---------------------------------------------------------------------------
+
+
+class TestFieldLengthConstraints:
+    """Tests for max_length constraints on TaskCreate and TaskUpdate."""
+
+    def test_task_create_description_at_limit_accepted(self) -> None:
+        """description of exactly 300 chars is valid."""
+        t = TaskCreate(id=1, status="pending", description="x" * 300, owner="Alice")
+        assert len(t.description) == 300
+
+    def test_task_create_description_over_limit_raises(self) -> None:
+        """description > 300 chars raises ValidationError."""
+        with pytest.raises(ValidationError, match="300"):
+            TaskCreate(id=1, status="pending", description="x" * 301, owner="Alice")
+
+    def test_task_update_description_at_limit_accepted(self) -> None:
+        """TaskUpdate description of exactly 300 chars is valid."""
+        t = TaskUpdate(id=1, description="y" * 300)
+        assert t.description is not None
+        assert len(t.description) == 300
+
+    def test_task_update_description_over_limit_raises(self) -> None:
+        """TaskUpdate description > 300 chars raises ValidationError."""
+        with pytest.raises(ValidationError, match="300"):
+            TaskUpdate(id=1, description="y" * 301)
+
+    def test_task_update_output_at_limit_accepted(self) -> None:
+        """output of exactly 150 chars is stored as-is."""
+        t = TaskUpdate(id=1, output="z" * 150)
+        assert t.output == "z" * 150
+
+    def test_task_update_output_truncated_at_151(self) -> None:
+        """output of 151 chars is truncated to 150 chars (147 + '...')."""
+        t = TaskUpdate(id=1, output="a" * 151)
+        assert t.output is not None
+        assert len(t.output) == 150
+        assert t.output.endswith("...")
+
+    def test_task_update_output_long_string_truncated(self) -> None:
+        """output of 500 chars is truncated to 150 chars ending with '...'."""
+        t = TaskUpdate(id=1, output="b" * 500)
+        assert t.output is not None
+        assert len(t.output) == 150
+        assert t.output.endswith("...")
+        assert t.output.startswith("b" * 147)
+
+    def test_task_update_output_none_unchanged(self) -> None:
+        """None output passes through the validator unchanged."""
+        t = TaskUpdate(id=1, output=None)
+        assert t.output is None
+
+    def test_task_update_output_short_string_unchanged(self) -> None:
+        """output shorter than 150 chars is not modified."""
+        t = TaskUpdate(id=1, output="short result")
+        assert t.output == "short result"
+
+    def test_field_descriptions_mention_max_length(self) -> None:
+        """Field descriptions must state the char limit so LLMs see it in the schema."""
+        schema = TaskCreate.model_json_schema()
+        desc_field = schema["properties"]["description"]
+        assert "300" in desc_field.get("description", "")
+
+        update_schema = TaskUpdate.model_json_schema()
+        assert "300" in update_schema["properties"]["description"].get("description", "")
+        assert "150" in update_schema["properties"]["output"].get("description", "")


### PR DESCRIPTION
## Summary

- `TaskUpdate.output` now auto-truncates to `v[:147] + "..."` via `field_validator(mode="before")` — eliminates retry loops from machine-generated content exceeding the 150-char limit
- Field descriptions for `description` (max 300) and `output` (max 150) now state the char limit explicitly, making constraints visible in the LLM's JSON schema view
- `update_planning` docstring updated with a "Field constraints" section
- Add `TestFieldLengthConstraints` (10 tests) in `test_planning_actor.py`

## Files changed

| File | Change |
|---|---|
| `src/akgentic/tool/planning/planning_actor.py` | Field descriptions + `truncate_output` validator |
| `src/akgentic/tool/planning/planning.py` | `update_planning` docstring constraint summary |
| `tests/test_planning_actor.py` | Add `TestFieldLengthConstraints` |

## Related

- Closes #88
- ADR: `_bmad-output/akgentic-tool/decisions/adr-016-planning-tool-field-length-awareness.md`
- Story: `_bmad-output/akgentic-tool/stories/4-5-planning-field-length-awareness.md`
- See also: #89 (workspace glob normalization fix, independent)