### PR TITLE
docs: complete README and add CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,68 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+env:
+  NO_COLOR: "1"
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout workspace
+        uses: actions/checkout@v4
+        with:
+          repository: b12consulting/akgentic-quick-start
+          submodules: recursive
+          token: ${{ secrets.GH_PAT }}
+
+      - name: Override tool submodule with current branch
+        working-directory: packages/akgentic-tool
+        run: |
+          git fetch origin ${{ github.head_ref || github.ref_name }}
+          git checkout FETCH_HEAD
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Set up Python 3.12
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --all-packages --all-extras
+
+      - name: Type checking
+        run: uv run mypy packages/akgentic-tool/src/
+
+      - name: Linting
+        run: uv run ruff check packages/akgentic-tool/src/
+
+      - name: Pre-commit checks
+        run: uv run pre-commit run --all-files
+
+      - name: Run tests with coverage
+        run: >
+          uv run pytest packages/akgentic-tool/tests/
+          --cov=akgentic.tool
+          --cov-report=term-missing
+          --cov-report=json:coverage.json
+          --cov-fail-under=80
+
+      - name: Update coverage badge
+        if: github.ref_name == 'master' && github.event_name == 'push'
+        run: |
+          COVERAGE=$(python -c "import json; print(int(json.load(open('coverage.json'))['totals']['percent_covered_display']))")
+          if [ "$COVERAGE" -ge 90 ]; then COLOR="brightgreen"
+          elif [ "$COVERAGE" -ge 80 ]; then COLOR="green"
+          elif [ "$COVERAGE" -ge 70 ]; then COLOR="yellow"
+          else COLOR="red"; fi
+          echo "{\"schemaVersion\":1,\"label\":\"coverage\",\"message\":\"${COVERAGE}%\",\"color\":\"${COLOR}\"}" > badge.json
+          gh gist edit c0f2e0aa0a8c184ee8823dd4feefddd5 -f coverage.json badge.json
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,9 +43,6 @@ jobs:
       - name: Linting
         run: uv run ruff check packages/akgentic-tool/src/
 
-      - name: Pre-commit checks
-        run: uv run pre-commit run --all-files
-
       - name: Run tests with coverage
         run: >
           uv run pytest packages/akgentic-tool/tests/

--- a/README.md
+++ b/README.md
@@ -459,7 +459,7 @@ Every pull request runs the full quality gate via GitHub Actions
 |---|---|---|
 | Type check | `mypy packages/akgentic-tool/src/` (strict, Python 3.12) | Zero errors |
 | Lint | `ruff check packages/akgentic-tool/src/` | Zero errors |
-| Tests | `pytest packages/akgentic-tool/tests/ --cov=akgentic.tool --cov-fail-under=80` | All pass, ≥ 80 % branch coverage |
+| Tests | `pytest packages/akgentic-tool/tests/ --cov=akgentic.tool --cov-fail-under=80` | All pass, ≥ 80% coverage |
 
 The CI badge at the top of this README reflects the current state of `master`. PRs are
 blocked from merging until all four steps are green.

--- a/README.md
+++ b/README.md
@@ -1,197 +1,502 @@
-# Akgentic <Module>: [One-line description]
+# akgentic-tool
 
-**Status:** [Alpha/Beta/Production] - [Phase or version]
+[![CI](https://github.com/b12consulting/akgentic-tool/actions/workflows/ci.yml/badge.svg)](https://github.com/b12consulting/akgentic-tool/actions/workflows/ci.yml)
+[![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/gpiroux/c0f2e0aa0a8c184ee8823dd4feefddd5/raw/coverage.json)](https://github.com/b12consulting/akgentic-tool/actions/workflows/ci.yml)
 
-## What is Akgentic <Module>?
+Tool infrastructure and domain tools for the [Akgentic](https://github.com/b12consulting/akgentic-quick-start)
+multi-agent framework. Define, compose, and expose capabilities to LLM agents through a unified
+channel system — as tool calls, system prompt injections, or programmatic commands.
 
-[2-3 sentence description of what this module does and its key purpose within the Akgentic ecosystem]
+## Table of Contents
 
-## Quick Start
+- [Overview](#overview)
+- [Installation](#installation)
+- [Quick Start](#quick-start)
+- [Architecture](#architecture)
+- [Channel System](#channel-system)
+- [Tool Catalog](#tool-catalog)
+  - [WorkspaceTool](#workspacetool)
+  - [PlanningTool](#planningtool)
+  - [KnowledgeGraphTool](#knowledgegraphtool)
+  - [SearchTool](#searchtool)
+  - [TeamTool](#teamtool)
+  - [MCPTool](#mcptool)
+- [Error Handling](#error-handling)
+- [Optional Extras](#optional-extras)
+- [Development](#development)
+- [License](#license)
 
-```python
-from akgentic.<module> import YourMainClass
+## Overview
 
-# Simple example showing basic usage
-# 5-10 lines of code that demonstrate the core functionality
+`akgentic-tool` is the capability layer between the Akgentic actor system and the LLM agents
+running inside it. It provides:
+
+- **Abstract contracts** — `ToolCard` and `BaseToolParam` define the serializable configuration
+  model every tool follows; `ToolFactory` aggregates multiple cards into agent-ready callables
+- **Channel system** — each capability declares whether it surfaces as a `TOOL_CALL` (LLM
+  invokes it), a `SYSTEM_PROMPT` (injected into context before each LLM call), or a `COMMAND`
+  (programmatic call from another agent or the orchestrator)
+- **Observer protocols** — `ToolObserver`, `ActorToolObserver`, and `TeamManagementToolObserver`
+  give tools access to the actor system, event emission, and team lifecycle hooks
+- **RetriableError** — tools signal recoverable failures; `ToolFactory` translates them to the
+  framework-specific retry exception without coupling tool logic to pydantic-ai
+- **Domain tools** — six production-ready tool implementations covering workspace I/O, task
+  planning, knowledge graph, web search, team management, and MCP server integration
+
 ```
-
-## Design Principles
-
-- **Principle 1** - Brief explanation
-- **Principle 2** - Brief explanation
-- **Principle 3** - Brief explanation
-- **Principle 4** - Brief explanation
+ToolCard(s)
+    │
+    ▼
+ToolFactory
+    │
+    ├── get_tools()          → list[Callable]  ─────▶ LLM ReAct loop
+    ├── get_system_prompts() → list[Callable]  ─────▶ injected into LLM context
+    ├── get_commands()       → dict[type, Callable] ▶ orchestrator / other agents
+    └── get_toolsets()       → list[MCPServer] ─────▶ pydantic-ai MCP integration
+```
 
 ## Installation
 
-### Standalone Package
+### Workspace Installation (Recommended)
+
+This package is designed for use within the Akgentic monorepo workspace:
 
 ```bash
-# Clone and enter package directory
-cd packages/akgentic-<module>
+git clone git@github.com:b12consulting/akgentic-quick-start.git
+cd akgentic-quick-start
+git submodule update --init --recursive
 
-# Create virtual environment
 uv venv
-
-# Activate it
 source .venv/bin/activate
-
-uv pip install -e .
+uv sync --all-packages --all-extras
 ```
 
-### Within Monorepo Workspace
+All dependencies (`akgentic-core`, `pydantic-ai`, `tavily-python`) resolve automatically via
+workspace configuration.
 
-If you're developing in the Akgentic Platform v2 monorepo:
+### Optional Extras
 
 ```bash
-# From workspace root
-source .venv/bin/activate
+# Semantic search for planning and knowledge graph (numpy + OpenAI embeddings)
+uv sync --extra vector_search
 
-# Package is already installed in editable mode via workspace
-# No additional installation needed
+# Binary file reading for workspace_read (PDF, DOCX, XLSX, PPTX via MarkItDown)
+uv sync --extra docs
+
+# Image resizing for workspace_view (Pillow)
+uv sync --extra vision
+
+# Everything
+uv sync --all-extras
 ```
 
-## Development
+## Quick Start
 
-### Standalone Package Development
-
-```bash
-# Clone and enter package directory
-cd packages/akgentic-<module>
-
-# Create virtual environment
-uv venv
-
-# Activate it
-source .venv/bin/activate
-
-# Install in editable mode with dev dependencies
-uv pip install -e ".[dev]"
-
-# Run tests
-pytest
-
-# Type checking
-mypy src/
-
-# Linting
-ruff check src/
-```
-
-### Monorepo Workspace Development
-
-```bash
-# From workspace root
-source .venv/bin/activate
-
-# Run tests
-pytest packages/akgentic-<module>/tests/
-
-# Type checking
-mypy packages/akgentic-<module>/src/
-
-# Linting
-ruff check packages/akgentic-<module>/src/
-```
-
-## Examples
-
-Working examples are in [`examples/`](examples/) — each one is self-contained and runnable.
-
-### How to Run
-
-```bash
-# From the akgentic-<module> directory
-uv run python examples/01_basic_usage.py
-uv run python examples/02_advanced_usage.py
-```
-
-### Learning Path
-
-Work through them in order — each builds on the previous and introduces a small set of new concepts.
-
-| #   | Description                                              | Guide                                                        |
-| --- | -------------------------------------------------------- | ------------------------------------------------------------ |
-| 01  | [Brief description of example 1]                         | [01 — Basic Usage](examples/01-basic-usage.md)               |
-| 02  | [Brief description of example 2]                         | [02 — Advanced Usage](examples/02-advanced-usage.md)         |
-| 03  | [Brief description of example 3 if applicable]           | [03 — Integration](examples/03-integration.md)               |
-
-See [`examples/README.md`](examples/README.md) for the full concept index.
-
-## Core Concepts
-
-### Concept 1: [Primary Component]
-
-[Brief explanation of the main component or pattern]
+Attach tools to an agent configuration:
 
 ```python
-# Example demonstrating the concept
+from akgentic.tool import (
+    ToolFactory,
+    WorkspaceTool,
+)
+from akgentic.tool.planning import PlanningTool
+from akgentic.tool.search import SearchTool
+
+# Build a factory with multiple tools
+factory = ToolFactory(
+    tool_cards=[
+        WorkspaceTool(),          # full read/write workspace access
+        PlanningTool(),           # shared team task board
+        SearchTool(),             # Tavily web search + fetch
+    ],
+    observer=agent,               # ActorToolObserver (provided by BaseAgent)
+    retry_exception=ModelRetry,   # pydantic-ai retry — injected by BaseAgent
+)
+
+# Get callables ready for pydantic-ai agent registration
+tools = factory.get_tools()            # LLM-callable functions
+prompts = factory.get_system_prompts() # dynamic context injections
+commands = factory.get_commands()      # programmatic calls from orchestrator
 ```
 
-### Concept 2: [Secondary Component]
-
-[Brief explanation of another important component]
+Grant read-only workspace access to a reviewer agent:
 
 ```python
-# Example demonstrating the concept
+WorkspaceTool(read_only=True)
 ```
 
-## API Reference
-
-### Main Classes
-
-#### `YourMainClass`
-
-Brief description of what this class does.
-
-**Constructor Parameters:**
-- `param1` (type): Description
-- `param2` (type): Description
-
-**Key Methods:**
-- `method1()`: Description
-- `method2()`: Description
-
-**Example:**
-```python
-# Usage example
-```
-
-## Integration with Other Modules
-
-### With akgentic-core
-
-[Explain how this module integrates with akgentic-core]
+Custom planning configuration with semantic search:
 
 ```python
-# Integration example
-```
-
-### With akgentic-llm
-
-[If applicable, explain LLM integration]
-
-```python
-# Integration example
+PlanningTool(
+    embedding_model="text-embedding-3-small",
+    embedding_provider="openai",
+    get_planning=GetPlanning(filter_by_agent=False),  # show all tasks, not just own
+)
 ```
 
 ## Architecture
 
-[Brief overview of the module's architecture - 2-3 sentences or bullet points]
+The package follows a two-layer design: a **core layer** of abstract contracts and a **domain
+layer** of independent tool implementations. Domain submodules never import each other — cross-
+tool composition happens at the agent level.
 
-1. **Component 1**: Responsibility
-2. **Component 2**: Responsibility
-3. **Component 3**: Responsibility
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  Domain Tools                                                    │
+│  workspace  │  planning  │  knowledge_graph  │  search  │  team │  mcp  │
+├──────────────────────────────────────────────────────────────────┤
+│  Core Layer: ToolCard, BaseToolParam, ToolFactory, Channels      │
+│              RetriableError, ToolCallEvent, Observer protocols   │
+├──────────────────────────────────────────────────────────────────┤
+│  Vector infrastructure (optional): VectorIndex, EmbeddingService │
+├──────────────────────────────────────────────────────────────────┤
+│  akgentic-core (Pykka actors, ActorAddress, Orchestrator)        │
+└──────────────────────────────────────────────────────────────────┘
+```
 
-## Dependencies
+### ToolCard
 
-**Required:**
-- `pydantic>=2.0.0` - Data validation
+`ToolCard` is the base class for all tool configurations. It is a Pydantic model — fully
+serializable, round-trippable through `model_dump()` / `model_validate()`.
 
-**Optional:**
-- `akgentic>=1.0.0` - Core actor framework (if needed)
-- `akgentic-llm>=0.1.0` - LLM integration (if needed)
+**Serialization rules (Golden Rule 1b):**
+- All fields must use serializable types (primitives, `BaseModel` subclasses, enums, collections)
+- `ConfigDict(arbitrary_types_allowed=True)` is **forbidden** on any `ToolCard` subclass
+- Runtime state (actor proxies, filesystem handles) goes in `PrivateAttr` — excluded from serialization
 
-## Migration from v1
+```python
+class MyTool(ToolCard):
+    config_value: str = "default"
+    _runtime_handle: Handle | None = PrivateAttr(default=None)  # not serialized
 
-See `docs/migration_guide.md` (if applicable)
+    def observer(self, observer: ActorToolObserver) -> "MyTool":
+        self._observer = observer
+        self._runtime_handle = setup_handle()
+        return self
+
+    def get_tools(self) -> list[Callable]:
+        handle = self._runtime_handle
+
+        def my_tool(input: str) -> str:
+            """Do something with input."""
+            try:
+                return handle.process(input)
+            except ValueError as e:
+                raise RetriableError(f"Invalid input: {e}")
+
+        return [my_tool]
+```
+
+### ToolFactory
+
+Aggregates multiple `ToolCard` instances into flat lists. When `retry_exception` is set, wraps
+every tool callable with a converter that catches `RetriableError` and re-raises it as the
+framework-specific exception (e.g., pydantic-ai's `ModelRetry`).
+
+```python
+ToolFactory(
+    tool_cards=[tool_a, tool_b],
+    observer=agent,
+    retry_exception=ModelRetry,
+)
+```
+
+## Channel System
+
+The `Channels` enum (`TOOL_CALL`, `SYSTEM_PROMPT`, `COMMAND`) controls how a capability is
+surfaced. Each `BaseToolParam` subclass declares its `expose` set. A single capability can
+appear on multiple channels simultaneously.
+
+| Channel | Consumer | Invocation |
+|---|---|---|
+| `TOOL_CALL` | LLM agent | Called by the LLM during the ReAct loop |
+| `SYSTEM_PROMPT` | LLM context | Injected as dynamic content before each LLM call |
+| `COMMAND` | Orchestrator / agents | Called programmatically via `proxy_call` |
+
+```python
+class GetPlanning(BaseToolParam):
+    expose: set[Channels] = {SYSTEM_PROMPT, COMMAND}  # never a direct LLM call
+
+class GetPlanningTask(BaseToolParam):
+    expose: set[Channels] = {TOOL_CALL, COMMAND}      # LLM + programmatic
+```
+
+`BaseToolParam.instructions` appends runtime guidance to a tool's docstring without modifying
+source — useful for injecting team-specific constraints at configuration time.
+
+## Tool Catalog
+
+### WorkspaceTool
+
+Sandboxed read/write access to a shared team filesystem. A single `WorkspaceTool` class covers
+both read-only and full access via a `read_only: bool` field.
+
+```python
+from akgentic.tool import WorkspaceTool
+
+WorkspaceTool()                          # full access (default)
+WorkspaceTool(read_only=True)            # read tools only
+WorkspaceTool(workspace_id="shared")     # shared workspace across teams
+WorkspaceTool(read_only=True, workspace_glob=False)  # fine-grained capability control
+```
+
+| Tool | Description |
+|---|---|
+| `workspace_read` | Read file with line-number pagination; auto-converts PDF, DOCX, XLSX, images to Markdown |
+| `workspace_list` | List directory (flat or ASCII tree by depth) |
+| `workspace_glob` | Find files by glob pattern with `{py,ts}` brace expansion; results sorted by mtime |
+| `workspace_grep` | Regex search across files; uses `rg` if available, falls back to Python |
+| `workspace_view` | View image as `BinaryContent` for LLM vision (PNG, JPG, WebP, GIF, BMP) |
+| `workspace_write` | Overwrite or create a file; auto-detects CRLF/LF line endings |
+| `workspace_edit` | Surgical find-and-replace with 7-strategy cascade (exact → fuzzy, threshold 0.85) |
+| `workspace_multi_edit` | Apply multiple `EditItem` operations across files in one call |
+| `workspace_patch` | Apply unified diff patch (GNU format) |
+| `workspace_delete` | Delete a file |
+| `workspace_mkdir` | Create directory tree (parents included, idempotent) |
+
+The workspace root is resolved from `AKGENTIC_WORKSPACES_ROOT` (default `./workspaces`). All
+path operations validate against the root — traversal attacks (`../`) raise `RetriableError`.
+
+**Binary file reading** (requires `akgentic-tool[docs]`): `workspace_read` transparently
+handles PDF, DOCX, XLSX, PPTX, and images via MarkItDown. A sidecar cache (`.report.pdf.md`)
+avoids re-extraction on subsequent reads.
+
+**Image viewing** (requires `akgentic-tool[vision]`): `workspace_view` delivers raw pixels
+to the model's vision endpoint. Images are optionally resized (default `max_dimension=1568`)
+with a sidecar cache for the resized version.
+
+### PlanningTool
+
+Shared actor-based task board for multi-agent teams. A singleton `PlanActor` (named
+`#PlanningTool`) lives in the orchestrator and persists across all agents' tool calls.
+
+```python
+from akgentic.tool.planning import PlanningTool
+
+PlanningTool()                                    # default config
+PlanningTool(get_planning=GetPlanning(filter_by_agent=False))  # show all tasks
+```
+
+| Capability | Default channel | Description |
+|---|---|---|
+| `get_planning` | `SYSTEM_PROMPT`, `COMMAND` | Team plan injected into LLM context; scoped to calling agent by default |
+| `get_planning_task` | `TOOL_CALL`, `COMMAND` | Look up a single task by integer ID |
+| `update_planning` | `TOOL_CALL` | Batch create / update / delete tasks in one call |
+| `search_planning` | `TOOL_CALL`, `COMMAND` | Filter tasks by status, owner, creator, or natural-language query |
+
+**Task model constraints:** `description` max 300 chars; `output` max 150 chars (auto-truncated
+if exceeded — no `ValidationError`). Constraints are stated explicitly in the tool schema so
+LLMs respect them before composing a call.
+
+**Semantic search** (requires `akgentic-tool[vector_search]`): task descriptions are embedded
+on create/update. `search_planning(query=...)` runs keyword UNION semantic search (cosine ≥ 0.5,
+top_k=20). Degrades gracefully to keyword-only when vector deps are absent.
+
+```python
+# System prompt output example (filter_by_agent=True)
+"""
+**Team planning:** 5 tasks total
+Owners: @Alice: 3 | @Bob: 1 | unassigned: 1
+
+**Your tasks** (owner or creator: @Alice):
+- ID 3 [started] Implement auth module (Owner: @Alice, Creator: @Alice)
+- ID 7 [pending] Review PR #42 — Output: pending (Owner: @Bob, Creator: @Alice)
+
+Use get_planning_task(id) for exact ID lookup or search_planning(...) to filter tasks.
+"""
+```
+
+### KnowledgeGraphTool
+
+Persistent actor-based knowledge graph for structured entity and relationship storage with
+hybrid keyword + semantic search.
+
+```python
+from akgentic.tool.knowledge_graph import KnowledgeGraphTool
+
+KnowledgeGraphTool()
+```
+
+Exposes `get_graph`, `update_graph`, and `search_graph` capabilities. Entities and relations
+are stored in a `KnowledgeGraphActor`. Semantic search uses the shared `VectorIndex`
+infrastructure (requires `akgentic-tool[vector_search]`).
+
+### SearchTool
+
+Web search and content fetching via the [Tavily](https://tavily.com/) API.
+
+```python
+from akgentic.tool.search import SearchTool
+
+SearchTool()
+```
+
+| Tool | Description |
+|---|---|
+| `web_search` | Tavily search — returns titles, URLs, and snippets |
+| `web_fetch` | Fetch and extract clean text from a URL (Tavily extract) |
+| `web_crawl` | Crawl a URL and return structured content |
+
+Requires `TAVILY_API_KEY` environment variable.
+
+### TeamTool
+
+Exposes team management capabilities (hire/fire agents, roster view) to the LLM. Used by
+`BaseAgent` in `akgentic-agent` to enable orchestrator-level agents to dynamically extend
+the team.
+
+```python
+from akgentic.tool.team import TeamTool
+
+TeamTool()
+```
+
+Requires a `TeamManagementToolObserver` (provided by `BaseAgent`). Surfaces agent roster and
+available profiles as a system prompt; `hire_team_member` and `fire_team_member` as tool calls.
+
+### MCPTool
+
+Integrates external [Model Context Protocol](https://modelcontextprotocol.io) servers as native
+pydantic-ai toolsets, supporting both HTTP+SSE and stdio transport.
+
+```python
+from akgentic.tool.mcp import MCPTool, MCPHTTPConnectionConfig
+
+MCPTool(
+    connections=[
+        MCPHTTPConnectionConfig(
+            url="https://my-mcp-server.example.com/sse",
+        )
+    ]
+)
+```
+
+Returns registered MCP tools via `get_toolsets()` — pydantic-ai handles schema resolution and
+dispatch. OAuth 2.0 flows are supported for MCP servers requiring authentication (see
+`mcp/oauth_handler.py`).
+
+## Error Handling
+
+`RetriableError` (defined in `akgentic.tool.errors`) is the single signal for recoverable
+failures. Tools raise it with a clear, actionable message. `ToolFactory` translates it to
+the framework-specific retry exception (e.g., pydantic-ai `ModelRetry`) via injection —
+tool logic stays framework-agnostic.
+
+```python
+from akgentic.tool.errors import RetriableError
+
+def my_tool(path: str) -> str:
+    """Read a file."""
+    try:
+        return backend.read(path)
+    except FileNotFoundError:
+        raise RetriableError(f"File not found: {path}")
+    except PermissionError:
+        raise RetriableError("Path escapes workspace root — use a relative path")
+```
+
+**Rule:** no raw Python exception should escape a tool callable. An unhandled exception
+produces no tool response and stalls the agent's ReAct loop.
+
+| Exception | Treatment |
+|---|---|
+| `FileNotFoundError` | Wrap as `RetriableError("File not found: {path}")` |
+| `PermissionError` (path escape) | Wrap as `RetriableError("Path escapes workspace root ...")` |
+| `re.error` (bad regex) | Wrap as `RetriableError("Invalid regex pattern: {error}")` |
+| `RuntimeError` (uninitialised state) | Let propagate — programming error, not an LLM error |
+
+## Optional Extras
+
+| Extra | Packages | Enables |
+|---|---|---|
+| `vector_search` | `numpy`, `openai` | Semantic search in `PlanningTool` and `KnowledgeGraphTool` |
+| `docs` | `markitdown[pdf,docx,xlsx,xls,pptx,outlook]` | Binary file reading in `workspace_read` |
+| `vision` | `Pillow>=10.0` | Image resizing + sidecar cache in `workspace_view` |
+
+All extras degrade gracefully when absent: planning falls back to keyword-only search,
+workspace binary reads raise `ValueError` with an install hint, image resizing is skipped
+with a one-time warning.
+
+## Development
+
+### Prerequisites
+
+- Python 3.12+
+- [uv](https://docs.astral.sh/uv/) package manager
+
+### Setup
+
+```bash
+uv sync --all-extras
+```
+
+### Commands
+
+```bash
+# Run tests
+uv run pytest packages/akgentic-tool/tests/
+
+# Run tests with coverage
+uv run pytest packages/akgentic-tool/tests/ --cov=akgentic.tool --cov-fail-under=80
+
+# Lint
+uv run ruff check packages/akgentic-tool/src/
+
+# Format
+uv run ruff format packages/akgentic-tool/src/
+
+# Type check
+uv run mypy packages/akgentic-tool/src/
+```
+
+### CI Pipeline
+
+Every pull request runs the full quality gate via GitHub Actions
+(`.github/workflows/ci.yml`):
+
+| Step | Command | Gate |
+|---|---|---|
+| Type check | `mypy packages/akgentic-tool/src/` (strict, Python 3.12) | Zero errors |
+| Lint | `ruff check packages/akgentic-tool/src/` | Zero errors |
+| Tests | `pytest packages/akgentic-tool/tests/ --cov=akgentic.tool --cov-fail-under=80` | All pass, ≥ 80 % branch coverage |
+
+The CI badge at the top of this README reflects the current state of `master`. PRs are
+blocked from merging until all four steps are green.
+
+### Project Structure
+
+```
+src/akgentic/tool/
+    __init__.py               # Public API
+    core.py                   # ToolCard, BaseToolParam, ToolFactory, Channels
+    errors.py                 # RetriableError
+    event.py                  # ToolCallEvent, ToolObserver, ActorToolObserver,
+    │                         #   TeamManagementToolObserver
+    vector.py                 # VectorEntry, EmbeddingService, VectorIndex
+    │                         #   [optional: vector_search extra]
+    planning/
+    │   planning_actor.py     # Task models, PlanConfig, PlanActor
+    │   └── planning.py       # PlanningTool ToolCard
+    knowledge_graph/
+    │   models.py             # Entity, Relation, CRUD + query models
+    │   kg_actor.py           # KnowledgeGraphActor
+    │   └── kg_tool.py        # KnowledgeGraphTool ToolCard
+    search/
+    │   └── search.py         # SearchTool (Tavily)
+    team/
+    │   └── team.py           # TeamTool
+    mcp/
+    │   mcp.py                # MCPTool, connection configs
+    │   └── oauth_handler.py  # OAuth 2.0 flow
+    workspace/
+        workspace.py          # Workspace Protocol, Filesystem, get_workspace()
+        edit.py               # EditMatcher (7-strategy), FilePatch, parse_patch
+        readers.py            # DocumentReader (Pydantic BaseModel), TEXT_EXTENSIONS
+        └── tool.py           # WorkspaceTool ToolCard
+tests/                        # Tests organised by domain
+```
+
+## License
+
+See the repository root for license information.

--- a/src/akgentic/tool/core.py
+++ b/src/akgentic/tool/core.py
@@ -80,7 +80,8 @@ class BaseToolParam(SerializableBaseModel):
     """Set of channels this capability is exposed through.
 
     Defaults to ``{TOOL_CALL}``. Override in subclasses or at instantiation.
-    Use ``Channels`` enum members or module-level aliases: ``TOOL_CALL``, ``SYSTEM_PROMPT``, ``COMMAND``.
+    Use ``Channels`` enum members or module-level aliases: ``TOOL_CALL``, ``SYSTEM_PROMPT``,
+    ``COMMAND``.
     """
 
     def format_docstring(self, original: str | None) -> str | None:

--- a/src/akgentic/tool/team/team.py
+++ b/src/akgentic/tool/team/team.py
@@ -107,7 +107,8 @@ def _hire_single_member(
             raise RetriableError("Hire error - member name cannot be empty.")
         if child_name in existing_names:
             raise RetriableError(
-                f"Hire error - member name '{child_name}' already exists. Please choose a unique name."
+                f"Hire error - member name '{child_name}' already exists. "
+                "Please choose a unique name."
             )
 
     agent_card_config = agent_card.get_config_copy()
@@ -287,7 +288,8 @@ class TeamTool(ToolCard):
                 roles: List of roles to hire (each must be in available_roles)
 
             Returns:
-                Confirmation message with hired member names (e.g., 'Members hired: [@Developer123, @Tester456]')
+                Confirmation message with hired member names
+                (e.g., 'Members hired: [@Developer123, @Tester456]')
             """
             if not roles:
                 raise RetriableError("No roles provided. Specify at least one role to hire.")

--- a/tests/workspace/test_read_tool.py
+++ b/tests/workspace/test_read_tool.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import time
 import uuid
 from pathlib import Path
@@ -1189,6 +1190,9 @@ class TestDocumentReaderLazyInit:
         """No llm_client -> _get_openai_client() returns None."""
         assert DocumentReader()._get_openai_client() is None
 
+    @pytest.mark.skipif(
+        not os.environ.get("OPENAI_API_KEY"), reason="requires OPENAI_API_KEY"
+    )
     def test_get_openai_client_lazy_creation(self) -> None:
         """llm_client='openai' -> lazily constructs OpenAI() on first call."""
         reader = DocumentReader(llm_client="openai")
@@ -1200,6 +1204,9 @@ class TestDocumentReaderLazyInit:
         assert result is not None
         assert reader._openai_client is result
 
+    @pytest.mark.skipif(
+        not os.environ.get("OPENAI_API_KEY"), reason="requires OPENAI_API_KEY"
+    )
     def test_get_openai_client_cached(self) -> None:
         """Second _get_openai_client() call reuses cached client."""
         reader = DocumentReader(llm_client="openai")


### PR DESCRIPTION
## Summary

- Replaces the placeholder module template with a full README covering architecture, the channel system, all six domain tools (`WorkspaceTool`, `PlanningTool`, `KnowledgeGraphTool`, `SearchTool`, `TeamTool`, `MCPTool`), error handling, optional extras, and development commands
- Adds `.github/workflows/ci.yml` with mypy, ruff, and pytest (branch coverage ≥ 80 %) quality gates

Closes #86