### PR TITLE
feat: harden LocalSandboxActor with resource limits and env stripping (#94)

### DIFF
--- a/src/akgentic/tool/sandbox/local.py
+++ b/src/akgentic/tool/sandbox/local.py
@@ -3,10 +3,33 @@
 from __future__ import annotations
 
 import os
+import resource
 import subprocess
 from pathlib import Path
+from typing import Callable
 
 from akgentic.tool.sandbox.actor import ExecResult, SandboxActor
+
+
+def _make_preexec(cpu_s: int = 30, mem_mb: int = 512, fsize_mb: int = 100) -> Callable[[], None]:
+    """Return a preexec_fn callable that sets resource limits and new process group.
+
+    Sets hard caps for:
+    - ``RLIMIT_CPU``: CPU time in seconds
+    - ``RLIMIT_AS``: Virtual address space in bytes
+    - ``RLIMIT_FSIZE``: Maximum file size in bytes
+
+    Also calls ``os.setpgrp()`` to put the child process into a new process group,
+    so that a timeout can kill the entire subtree.
+    """
+
+    def preexec() -> None:
+        resource.setrlimit(resource.RLIMIT_CPU, (cpu_s, cpu_s))
+        resource.setrlimit(resource.RLIMIT_AS, (mem_mb * 1024**2, mem_mb * 1024**2))
+        resource.setrlimit(resource.RLIMIT_FSIZE, (fsize_mb * 1024**2, fsize_mb * 1024**2))
+        os.setpgrp()  # new process group → timeout kills entire subtree
+
+    return preexec
 
 
 class LocalSandboxActor(SandboxActor):
@@ -17,6 +40,10 @@ class LocalSandboxActor(SandboxActor):
     ``./workspaces``). When ``SandboxConfig.workspace_id`` is set, that value is
     used as the directory name instead of ``team_id``, enabling directory sharing
     with ``WorkspaceTool(workspace_id=...)``. No Docker daemon required.
+
+    This actor does NOT provide filesystem isolation — an allowed command can still
+    read files outside the workspace. It is a development convenience only, not a
+    production security boundary.
     """
 
     def _start_sandbox(self) -> None:
@@ -39,6 +66,8 @@ class LocalSandboxActor(SandboxActor):
             capture_output=True,
             text=True,
             timeout=30,
+            preexec_fn=_make_preexec(),
+            env={"PATH": "/usr/bin:/bin:/usr/local/bin"},
         )
         return ExecResult(
             stdout=result.stdout,

--- a/tests/sandbox/test_local_sandbox.py
+++ b/tests/sandbox/test_local_sandbox.py
@@ -10,6 +10,11 @@ Covers AC1 through AC7 for Story 6.2 (updated for Story 6.5):
 - _exec() returns ExecResult with correct stdout, stderr, exit_code
 - subprocess.TimeoutExpired propagates from _exec()
 - exec() public method works end-to-end through _exec()
+
+Story 8.1: Resource limits and environment stripping:
+- preexec_fn is passed to subprocess.run (mock assert)
+- env is stripped to minimal PATH (mock assert)
+- docstring contains isolation disclaimer
 """
 
 from __future__ import annotations
@@ -176,13 +181,16 @@ def test_exec_no_cwd_uses_workspace_path(
 
     actor._exec("pytest tests/", "")
 
-    mock_run.assert_called_once_with(
-        ["pytest", "tests/"],
-        cwd=str(actor.state.workspace_path),
-        capture_output=True,
-        text=True,
-        timeout=30,
-    )
+    call_kwargs = mock_run.call_args
+    assert call_kwargs is not None
+    assert call_kwargs.args[0] == ["pytest", "tests/"]
+    assert call_kwargs.kwargs["cwd"] == str(actor.state.workspace_path)
+    assert call_kwargs.kwargs["capture_output"] is True
+    assert call_kwargs.kwargs["text"] is True
+    assert call_kwargs.kwargs["timeout"] == 30
+    assert call_kwargs.kwargs["preexec_fn"] is not None
+    assert callable(call_kwargs.kwargs["preexec_fn"])
+    assert call_kwargs.kwargs["env"] == {"PATH": "/usr/bin:/bin:/usr/local/bin"}
 
 
 # ---------------------------------------------------------------------------
@@ -205,13 +213,16 @@ def test_exec_with_cwd_appends_to_workspace_path(
     actor._exec("pytest tests/", "src")
 
     expected_cwd = str(actor.state.workspace_path / "src")
-    mock_run.assert_called_once_with(
-        ["pytest", "tests/"],
-        cwd=expected_cwd,
-        capture_output=True,
-        text=True,
-        timeout=30,
-    )
+    call_kwargs = mock_run.call_args
+    assert call_kwargs is not None
+    assert call_kwargs.args[0] == ["pytest", "tests/"]
+    assert call_kwargs.kwargs["cwd"] == expected_cwd
+    assert call_kwargs.kwargs["capture_output"] is True
+    assert call_kwargs.kwargs["text"] is True
+    assert call_kwargs.kwargs["timeout"] == 30
+    assert call_kwargs.kwargs["preexec_fn"] is not None
+    assert callable(call_kwargs.kwargs["preexec_fn"])
+    assert call_kwargs.kwargs["env"] == {"PATH": "/usr/bin:/bin:/usr/local/bin"}
 
 
 # ---------------------------------------------------------------------------
@@ -424,3 +435,77 @@ def test_exec_tool_and_workspace_tool_resolve_same_path_via_workspace_id(
         f"WorkspaceTool root ({workspace_tool_root}) != "
         f"LocalSandboxActor root ({sandbox_root})"
     )
+
+
+# ---------------------------------------------------------------------------
+# Story 8.1: Resource limits and environment stripping (AC: 1, 2, 5)
+# ---------------------------------------------------------------------------
+
+
+@patch("akgentic.tool.sandbox.local.subprocess.run")
+def test_exec_passes_preexec_fn_to_subprocess(
+    mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """AC5 (Story 8.1): _exec() passes a non-None callable preexec_fn to subprocess.run."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("AKGENTIC_WORKSPACES_ROOT", raising=False)
+    actor = make_actor(team_id="team-1")
+    actor._start_sandbox()
+
+    mock_run.return_value = MagicMock(stdout="output", stderr="", returncode=0)
+
+    actor._exec("echo hello", "")
+
+    call_kwargs = mock_run.call_args
+    assert call_kwargs is not None
+    preexec_fn = call_kwargs.kwargs.get("preexec_fn")
+    assert preexec_fn is not None
+    assert callable(preexec_fn)
+
+
+@patch("akgentic.tool.sandbox.local.subprocess.run")
+def test_exec_strips_env_to_minimal_path(
+    mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """AC5 (Story 8.1): _exec() passes env={'PATH': '/usr/bin:/bin:/usr/local/bin'} to subprocess.run."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("AKGENTIC_WORKSPACES_ROOT", raising=False)
+    actor = make_actor(team_id="team-1")
+    actor._start_sandbox()
+
+    mock_run.return_value = MagicMock(stdout="output", stderr="", returncode=0)
+
+    actor._exec("echo hello", "")
+
+    call_kwargs = mock_run.call_args
+    assert call_kwargs is not None
+    env = call_kwargs.kwargs.get("env")
+    assert env == {"PATH": "/usr/bin:/bin:/usr/local/bin"}
+
+
+@patch("akgentic.tool.sandbox.local.subprocess.run")
+def test_exec_no_env_kwargs_other_than_path(
+    mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """AC5 (Story 8.1): env dict passed to subprocess.run has exactly one key ('PATH')."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("AKGENTIC_WORKSPACES_ROOT", raising=False)
+    actor = make_actor(team_id="team-1")
+    actor._start_sandbox()
+
+    mock_run.return_value = MagicMock(stdout="output", stderr="", returncode=0)
+
+    actor._exec("echo hello", "")
+
+    call_kwargs = mock_run.call_args
+    assert call_kwargs is not None
+    env = call_kwargs.kwargs.get("env")
+    assert isinstance(env, dict)
+    assert len(env) == 1
+    assert "PATH" in env
+
+
+def test_docstring_contains_isolation_disclaimer() -> None:
+    """AC5 (Story 8.1): LocalSandboxActor docstring contains isolation disclaimer."""
+    assert LocalSandboxActor.__doc__ is not None
+    assert "does NOT provide filesystem isolation" in LocalSandboxActor.__doc__

--- a/tests/sandbox/test_local_sandbox.py
+++ b/tests/sandbox/test_local_sandbox.py
@@ -11,10 +11,12 @@ Covers AC1 through AC7 for Story 6.2 (updated for Story 6.5):
 - subprocess.TimeoutExpired propagates from _exec()
 - exec() public method works end-to-end through _exec()
 
-Story 8.1: Resource limits and environment stripping:
-- preexec_fn is passed to subprocess.run (mock assert)
-- env is stripped to minimal PATH (mock assert)
-- docstring contains isolation disclaimer
+Story 8.1: Resource limits and environment stripping (AC: 1, 2, 3, 4, 5):
+- preexec_fn is passed to subprocess.run (mock assert) — AC5
+- env is stripped to minimal PATH (mock assert) — AC5
+- env dict has exactly one key — AC5
+- docstring contains isolation disclaimer — AC4 / AC5
+- _make_preexec() callable sets RLIMIT_CPU, RLIMIT_AS, RLIMIT_FSIZE and calls setpgrp — AC1 / AC3
 """
 
 from __future__ import annotations
@@ -467,7 +469,7 @@ def test_exec_passes_preexec_fn_to_subprocess(
 def test_exec_strips_env_to_minimal_path(
     mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """AC5 (Story 8.1): _exec() passes env={'PATH': '/usr/bin:/bin:/usr/local/bin'} to subprocess.run."""
+    """AC5 (Story 8.1): _exec() passes minimal PATH-only env dict to subprocess.run."""
     monkeypatch.chdir(tmp_path)
     monkeypatch.delenv("AKGENTIC_WORKSPACES_ROOT", raising=False)
     actor = make_actor(team_id="team-1")
@@ -506,6 +508,57 @@ def test_exec_no_env_kwargs_other_than_path(
 
 
 def test_docstring_contains_isolation_disclaimer() -> None:
-    """AC5 (Story 8.1): LocalSandboxActor docstring contains isolation disclaimer."""
+    """AC4 / AC5 (Story 8.1): LocalSandboxActor docstring contains isolation disclaimer."""
     assert LocalSandboxActor.__doc__ is not None
     assert "does NOT provide filesystem isolation" in LocalSandboxActor.__doc__
+
+
+# ---------------------------------------------------------------------------
+# Story 8.1: _make_preexec() unit tests — verify actual resource-limit logic
+# ---------------------------------------------------------------------------
+
+
+def test_make_preexec_returns_callable() -> None:
+    """AC1 (Story 8.1): _make_preexec() returns a callable (not None)."""
+    from akgentic.tool.sandbox.local import _make_preexec
+
+    fn = _make_preexec()
+    assert callable(fn)
+
+
+def test_make_preexec_custom_defaults_returns_callable() -> None:
+    """AC1 (Story 8.1): _make_preexec() with custom args returns a callable."""
+    from akgentic.tool.sandbox.local import _make_preexec
+
+    fn = _make_preexec(cpu_s=10, mem_mb=256, fsize_mb=50)
+    assert callable(fn)
+
+
+def test_make_preexec_fn_sets_resource_limits() -> None:
+    """AC1 / AC3 (Story 8.1): The callable returned by _make_preexec() sets RLIMIT_CPU,
+    RLIMIT_AS, and RLIMIT_FSIZE to the expected values, and calls os.setpgrp().
+
+    We mock resource.setrlimit and os.setpgrp to avoid altering the test process's
+    resource limits.
+    """
+    import resource as resource_module
+    from unittest.mock import call, patch
+
+    from akgentic.tool.sandbox.local import _make_preexec
+
+    fn = _make_preexec(cpu_s=30, mem_mb=512, fsize_mb=100)
+
+    with (
+        patch.object(resource_module, "setrlimit") as mock_setrlimit,
+        patch("os.setpgrp") as mock_setpgrp,
+    ):
+        fn()
+
+    mb = 1024**2
+    expected_calls = [
+        call(resource_module.RLIMIT_CPU, (30, 30)),
+        call(resource_module.RLIMIT_AS, (512 * mb, 512 * mb)),
+        call(resource_module.RLIMIT_FSIZE, (100 * mb, 100 * mb)),
+    ]
+    mock_setrlimit.assert_has_calls(expected_calls, any_order=False)
+    mock_setpgrp.assert_called_once()


### PR DESCRIPTION
## Summary

- Add module-level `_make_preexec()` helper that sets `RLIMIT_CPU=30s`, `RLIMIT_AS=512MB`, `RLIMIT_FSIZE=100MB` hard caps and calls `os.setpgrp()` to isolate the child process group
- Update `_exec()` to pass `preexec_fn=_make_preexec()` and `env={"PATH": "/usr/bin:/bin:/usr/local/bin"}` to `subprocess.run()`, preventing inheritance of secrets like `OPENAI_API_KEY`
- Add isolation disclaimer to `LocalSandboxActor` docstring (FR-NI-3): actor does NOT provide filesystem isolation and is a development convenience only
- Add 7 new tests (4 from story + 3 from code review): mock-asserts for `preexec_fn`/`env`, unit tests that verify `_make_preexec()` callable sets correct resource limits via `resource.setrlimit`
- Update 2 existing tests to include new `preexec_fn` and `env` kwargs in assertions

## Code Review Fixes Applied

| Severity | Issue | Fix |
|----------|-------|-----|
| MEDIUM | Tests only mock-asserted `preexec_fn` callable but never verified resource-limit logic | Added `test_make_preexec_fn_sets_resource_limits` and 2 companion tests |
| MEDIUM | Test module docstring incomplete — missing Story 8.1 AC coverage summary | Updated module docstring |
| LOW | `test_docstring_contains_isolation_disclaimer` mislabelled as AC5 | Corrected to AC4/AC5 |

Closes #94