### PR TITLE
feat: BwrapSandboxActor — Linux bubblewrap filesystem isolation

### DIFF
--- a/src/akgentic/tool/event.py
+++ b/src/akgentic/tool/event.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from typing import Protocol, runtime_checkable
+import uuid
 
 from akgentic.core.actor_address import ActorAddress
 from akgentic.core.agent import AkgentType
@@ -48,6 +49,11 @@ class ActorToolObserver(ToolObserver, Protocol):
     @property
     def orchestrator(self) -> ActorAddress | None:
         """Get the orchestrator address."""
+        ...
+
+    @property
+    def team_id(self) -> uuid.UUID:
+        """Get the team id."""
         ...
 
     def proxy_ask(

--- a/src/akgentic/tool/event.py
+++ b/src/akgentic/tool/event.py
@@ -1,6 +1,6 @@
+import uuid
 from dataclasses import dataclass
 from typing import Protocol, runtime_checkable
-import uuid
 
 from akgentic.core.actor_address import ActorAddress
 from akgentic.core.agent import AkgentType

--- a/src/akgentic/tool/sandbox/bwrap.py
+++ b/src/akgentic/tool/sandbox/bwrap.py
@@ -1,0 +1,107 @@
+"""BwrapSandboxActor — Linux bubblewrap sandbox for filesystem-isolated command execution."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+from akgentic.tool.sandbox.actor import ExecResult, SandboxActor
+from akgentic.tool.sandbox.local import _make_preexec
+
+
+class BwrapSandboxActor(SandboxActor):
+    """Linux-only sandbox actor that uses bubblewrap (bwrap) for filesystem isolation.
+
+    Requires ``bwrap`` to be installed on PATH (``apt install bubblewrap`` or
+    ``dnf install bubblewrap``). Each ``_exec()`` invocation runs the command inside
+    a fresh bubblewrap namespace where only the workspace directory is writable —
+    ``/usr``, ``/lib*``, ``/tmp``, ``/dev``, and ``/proc`` are bound read-only or as
+    virtual filesystems. Network access is disabled via ``--unshare-net``.
+
+    Unlike ``LocalSandboxActor``, this actor provides genuine filesystem isolation:
+    paths outside the namespace (e.g., ``/etc``, ``/home``, parent directories of the
+    workspace) are invisible to the sandboxed process.
+    """
+
+    def _start_sandbox(self) -> None:
+        """Start the bubblewrap sandbox.
+
+        Checks that ``bwrap`` is available on PATH, then resolves the workspace
+        directory (using ``workspace_id or team_id``) under ``AKGENTIC_WORKSPACES_ROOT``
+        (defaulting to ``./workspaces``) and creates it if it does not yet exist.
+
+        Raises:
+            RuntimeError: If ``bwrap`` is not found on PATH.
+        """
+        if shutil.which("bwrap") is None:
+            raise RuntimeError(
+                "bwrap not found on PATH. Install with:\n"
+                "  apt install bubblewrap   (Debian/Ubuntu)\n"
+                "  dnf install bubblewrap   (Fedora/RHEL)"
+            )
+        base = os.environ.get("AKGENTIC_WORKSPACES_ROOT", "./workspaces")
+        ws_name = self.config.workspace_id or self.config.team_id
+        workspace_path = Path(base) / ws_name
+        workspace_path.mkdir(parents=True, exist_ok=True)
+        self.state.workspace_path = workspace_path.resolve()
+        self.state.notify_state_change()
+
+    def _stop_sandbox(self) -> None:
+        """Stop the bubblewrap sandbox.
+
+        No-op: bubblewrap processes do not persist between ``_exec()`` calls —
+        each invocation spawns and terminates its own namespace.
+        """
+        pass  # bwrap processes do not persist between calls
+
+    def _exec(self, cmd: str, cwd: str) -> ExecResult:
+        """Execute a command inside a bubblewrap namespace.
+
+        Builds a ``bwrap`` command that mounts the workspace at ``/workspace``
+        (read-write), bind-mounts ``/usr`` and ``/lib*`` read-only, provides
+        virtual ``/tmp``, ``/dev``, and ``/proc``, and unshares the network and
+        PID namespaces. The process is also subject to the same resource limits
+        as ``LocalSandboxActor`` (via ``_make_preexec()``) and runs with a
+        minimal PATH-only environment.
+
+        Args:
+            cmd: Full command string to execute (pre-validated by ``exec()``).
+            cwd: Working directory inside the sandbox (relative to ``/workspace``).
+                 Empty string means ``/workspace`` root.
+
+        Returns:
+            ExecResult with stdout, stderr, and exit_code from the process.
+        """
+        assert self.state.workspace_path is not None
+        effective_cwd = f"/workspace/{cwd}" if cwd else "/workspace"
+        bwrap_cmd: list[str] = [
+            "bwrap",
+            "--bind", str(self.state.workspace_path), "/workspace",
+            "--ro-bind", "/usr", "/usr",
+            "--ro-bind-try", "/lib", "/lib",
+            "--ro-bind-try", "/lib64", "/lib64",
+            "--ro-bind-try", "/lib32", "/lib32",
+            "--tmpfs", "/tmp",
+            "--dev", "/dev",
+            "--proc", "/proc",
+            "--unshare-net",
+            "--unshare-pid",
+            "--die-with-parent",
+            "--new-session",
+            "--chdir", effective_cwd,
+        ] + cmd.split()
+        result = subprocess.run(
+            bwrap_cmd,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            preexec_fn=_make_preexec(),
+            env={"PATH": "/usr/bin:/bin:/usr/local/bin"},
+        )
+        return ExecResult(
+            stdout=result.stdout,
+            stderr=result.stderr,
+            exit_code=result.returncode,
+        )

--- a/src/akgentic/tool/sandbox/local.py
+++ b/src/akgentic/tool/sandbox/local.py
@@ -3,10 +3,33 @@
 from __future__ import annotations
 
 import os
+import resource
 import subprocess
 from pathlib import Path
+from typing import Callable
 
 from akgentic.tool.sandbox.actor import ExecResult, SandboxActor
+
+
+def _make_preexec(cpu_s: int = 30, mem_mb: int = 512, fsize_mb: int = 100) -> Callable[[], None]:
+    """Return a preexec_fn callable that sets resource limits and new process group.
+
+    Sets hard caps for:
+    - ``RLIMIT_CPU``: CPU time in seconds
+    - ``RLIMIT_AS``: Virtual address space in bytes
+    - ``RLIMIT_FSIZE``: Maximum file size in bytes
+
+    Also calls ``os.setpgrp()`` to put the child process into a new process group,
+    so that a timeout can kill the entire subtree.
+    """
+
+    def preexec() -> None:
+        resource.setrlimit(resource.RLIMIT_CPU, (cpu_s, cpu_s))
+        resource.setrlimit(resource.RLIMIT_AS, (mem_mb * 1024**2, mem_mb * 1024**2))
+        resource.setrlimit(resource.RLIMIT_FSIZE, (fsize_mb * 1024**2, fsize_mb * 1024**2))
+        os.setpgrp()  # new process group → timeout kills entire subtree
+
+    return preexec
 
 
 class LocalSandboxActor(SandboxActor):
@@ -17,6 +40,10 @@ class LocalSandboxActor(SandboxActor):
     ``./workspaces``). When ``SandboxConfig.workspace_id`` is set, that value is
     used as the directory name instead of ``team_id``, enabling directory sharing
     with ``WorkspaceTool(workspace_id=...)``. No Docker daemon required.
+
+    This actor does NOT provide filesystem isolation — an allowed command can still
+    read files outside the workspace. It is a development convenience only, not a
+    production security boundary.
     """
 
     def _start_sandbox(self) -> None:
@@ -39,6 +66,8 @@ class LocalSandboxActor(SandboxActor):
             capture_output=True,
             text=True,
             timeout=30,
+            preexec_fn=_make_preexec(),
+            env={"PATH": "/usr/bin:/bin:/usr/local/bin"},
         )
         return ExecResult(
             stdout=result.stdout,

--- a/src/akgentic/tool/sandbox/tool.py
+++ b/src/akgentic/tool/sandbox/tool.py
@@ -96,7 +96,7 @@ class ExecTool(ToolCard):
                 config=SandboxConfig(
                     name=SANDBOX_ACTOR_NAME,
                     role="ToolActor",
-                    team_id=str(observer._team_id),  # type: ignore[attr-defined]
+                    team_id=str(observer.team_id),
                     workspace_id=self.workspace_id,
                     mode=self.mode,
                 ),

--- a/src/akgentic/tool/workspace/tool.py
+++ b/src/akgentic/tool/workspace/tool.py
@@ -421,7 +421,7 @@ class WorkspaceTool(ToolCard):
         if observer.orchestrator is None:
             raise ValueError("WorkspaceTool requires access to the orchestrator.")
         self._observer = observer
-        ws_name = self.workspace_id or str(observer._team_id)  # type: ignore[attr-defined]
+        ws_name = self.workspace_id or str(observer.team_id)
         self._workspace = get_workspace(ws_name)
         return self
 

--- a/tests/sandbox/test_bwrap_sandbox.py
+++ b/tests/sandbox/test_bwrap_sandbox.py
@@ -15,7 +15,6 @@ Covers Story 8.2 (AC: 1–8):
 
 from __future__ import annotations
 
-import shutil
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -23,8 +22,6 @@ import pytest
 
 from akgentic.tool.sandbox.actor import ExecResult, SandboxConfig, SandboxState
 from akgentic.tool.sandbox.bwrap import BwrapSandboxActor
-from akgentic.tool.sandbox.local import _make_preexec  # noqa: F401  (imported for availability check)
-
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/tests/sandbox/test_bwrap_sandbox.py
+++ b/tests/sandbox/test_bwrap_sandbox.py
@@ -1,0 +1,288 @@
+"""Tests for BwrapSandboxActor — Linux bubblewrap sandbox execution.
+
+Covers Story 8.2 (AC: 1–8):
+- _start_sandbox() raises RuntimeError when bwrap not on PATH (AC2)
+- _start_sandbox() creates workspace directory (AC1)
+- _start_sandbox() is idempotent (AC1 — mkdir exist_ok=True)
+- _stop_sandbox() is a no-op (AC3)
+- _exec() builds correct bwrap command with all required flags (AC4)
+- _exec() passes preexec_fn callable to subprocess.run (AC5)
+- _exec() passes minimal PATH-only env dict to subprocess.run (AC5)
+- _exec() uses /workspace as cwd when cwd="" (AC4)
+- _exec() appends cwd to /workspace when cwd is non-empty (AC4)
+- _exec() returns ExecResult with correct fields (AC4)
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from akgentic.tool.sandbox.actor import ExecResult, SandboxConfig, SandboxState
+from akgentic.tool.sandbox.bwrap import BwrapSandboxActor
+from akgentic.tool.sandbox.local import _make_preexec  # noqa: F401  (imported for availability check)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def actor(tmp_path: Path) -> BwrapSandboxActor:
+    """Return a BwrapSandboxActor with workspace resolved to a temp directory.
+
+    Uses ``BwrapSandboxActor.__new__`` to bypass Pykka's actor instantiation.
+    Config and state are set directly, mirroring the pattern in test_local_sandbox.py.
+    """
+    a: BwrapSandboxActor = BwrapSandboxActor.__new__(BwrapSandboxActor)
+    a.config = SandboxConfig(name="sandbox", role="ToolActor", team_id="test-team")
+    a.state = SandboxState()
+    a.state.workspace_path = tmp_path
+    return a
+
+
+# ---------------------------------------------------------------------------
+# AC2: _start_sandbox() raises RuntimeError when bwrap not on PATH
+# ---------------------------------------------------------------------------
+
+
+def test_start_sandbox_bwrap_not_on_path_raises_runtime_error() -> None:
+    """AC2: _start_sandbox() raises RuntimeError with install hints when bwrap missing."""
+    a: BwrapSandboxActor = BwrapSandboxActor.__new__(BwrapSandboxActor)
+    a.config = SandboxConfig(name="sandbox", role="ToolActor", team_id="test-team")
+    a.state = SandboxState()
+
+    with patch("akgentic.tool.sandbox.bwrap.shutil.which", return_value=None):
+        with pytest.raises(RuntimeError, match="bwrap not found"):
+            a._start_sandbox()
+
+
+def test_start_sandbox_bwrap_not_on_path_error_contains_apt_hint() -> None:
+    """AC2: RuntimeError message includes 'apt install bubblewrap'."""
+    a: BwrapSandboxActor = BwrapSandboxActor.__new__(BwrapSandboxActor)
+    a.config = SandboxConfig(name="sandbox", role="ToolActor", team_id="test-team")
+    a.state = SandboxState()
+
+    with patch("akgentic.tool.sandbox.bwrap.shutil.which", return_value=None):
+        with pytest.raises(RuntimeError, match="apt install bubblewrap"):
+            a._start_sandbox()
+
+
+def test_start_sandbox_bwrap_not_on_path_error_contains_dnf_hint() -> None:
+    """AC2: RuntimeError message includes 'dnf install bubblewrap'."""
+    a: BwrapSandboxActor = BwrapSandboxActor.__new__(BwrapSandboxActor)
+    a.config = SandboxConfig(name="sandbox", role="ToolActor", team_id="test-team")
+    a.state = SandboxState()
+
+    with patch("akgentic.tool.sandbox.bwrap.shutil.which", return_value=None):
+        with pytest.raises(RuntimeError, match="dnf install bubblewrap"):
+            a._start_sandbox()
+
+
+# ---------------------------------------------------------------------------
+# AC1: _start_sandbox() creates workspace directory
+# ---------------------------------------------------------------------------
+
+
+def test_start_sandbox_creates_workspace_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """AC1: _start_sandbox() creates workspace under AKGENTIC_WORKSPACES_ROOT."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("AKGENTIC_WORKSPACES_ROOT", raising=False)
+
+    a: BwrapSandboxActor = BwrapSandboxActor.__new__(BwrapSandboxActor)
+    a.config = SandboxConfig(name="sandbox", role="ToolActor", team_id="test-team")
+    a.state = SandboxState()
+
+    with (
+        patch("akgentic.tool.sandbox.bwrap.shutil.which", return_value="/usr/bin/bwrap"),
+        patch("akgentic.tool.sandbox.actor.SandboxState.notify_state_change"),
+    ):
+        a._start_sandbox()
+
+    expected = tmp_path / "workspaces" / "test-team"
+    assert expected.exists()
+    assert expected.is_dir()
+
+
+def test_start_sandbox_stores_resolved_absolute_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """AC1: _start_sandbox() stores resolved absolute path in state.workspace_path."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("AKGENTIC_WORKSPACES_ROOT", raising=False)
+
+    a: BwrapSandboxActor = BwrapSandboxActor.__new__(BwrapSandboxActor)
+    a.config = SandboxConfig(name="sandbox", role="ToolActor", team_id="test-team")
+    a.state = SandboxState()
+
+    with (
+        patch("akgentic.tool.sandbox.bwrap.shutil.which", return_value="/usr/bin/bwrap"),
+        patch("akgentic.tool.sandbox.actor.SandboxState.notify_state_change"),
+    ):
+        a._start_sandbox()
+
+    assert a.state.workspace_path is not None
+    assert a.state.workspace_path.is_absolute()
+    assert a.state.workspace_path == (tmp_path / "workspaces" / "test-team").resolve()
+
+
+# ---------------------------------------------------------------------------
+# AC1: _start_sandbox() is idempotent (exist_ok=True)
+# ---------------------------------------------------------------------------
+
+
+def test_start_sandbox_idempotent_existing_workspace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """AC1: Calling _start_sandbox() twice does not raise (idempotent mkdir)."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("AKGENTIC_WORKSPACES_ROOT", raising=False)
+
+    a: BwrapSandboxActor = BwrapSandboxActor.__new__(BwrapSandboxActor)
+    a.config = SandboxConfig(name="sandbox", role="ToolActor", team_id="test-team")
+    a.state = SandboxState()
+
+    with (
+        patch("akgentic.tool.sandbox.bwrap.shutil.which", return_value="/usr/bin/bwrap"),
+        patch("akgentic.tool.sandbox.actor.SandboxState.notify_state_change"),
+    ):
+        a._start_sandbox()
+        a._start_sandbox()  # Must not raise
+
+    expected = tmp_path / "workspaces" / "test-team"
+    assert expected.exists()
+
+
+# ---------------------------------------------------------------------------
+# AC3: _stop_sandbox() is a no-op
+# ---------------------------------------------------------------------------
+
+
+def test_stop_sandbox_is_noop(actor: BwrapSandboxActor) -> None:
+    """AC3: _stop_sandbox() returns None and makes no subprocess calls."""
+    with patch("akgentic.tool.sandbox.bwrap.subprocess.run") as mock_run:
+        result = actor._stop_sandbox()
+
+    assert result is None
+    mock_run.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# AC4: _exec() builds correct bwrap command with all required flags
+# ---------------------------------------------------------------------------
+
+
+def test_exec_builds_correct_bwrap_command(actor: BwrapSandboxActor) -> None:
+    """AC4: _exec() passes a bwrap command list with all required flags to subprocess.run."""
+    with patch("akgentic.tool.sandbox.bwrap.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(stdout="", stderr="", returncode=0)
+        actor._exec("ls .", "")
+
+        cmd_list: list[str] = mock_run.call_args[0][0]  # first positional arg
+
+    assert cmd_list[0] == "bwrap"
+    assert "--bind" in cmd_list
+    assert "--ro-bind" in cmd_list
+    assert "--ro-bind-try" in cmd_list
+    assert "--tmpfs" in cmd_list
+    assert "--dev" in cmd_list
+    assert "--proc" in cmd_list
+    assert "--unshare-net" in cmd_list
+    assert "--unshare-pid" in cmd_list
+    assert "--die-with-parent" in cmd_list
+    assert "--new-session" in cmd_list
+    assert "--chdir" in cmd_list
+    assert "/workspace" in cmd_list
+    assert "ls" in cmd_list
+
+
+# ---------------------------------------------------------------------------
+# AC4: --chdir argument handling for cwd
+# ---------------------------------------------------------------------------
+
+
+def test_exec_cwd_empty_uses_workspace_root(actor: BwrapSandboxActor) -> None:
+    """AC4: When cwd='', --chdir is followed by '/workspace'."""
+    with patch("akgentic.tool.sandbox.bwrap.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(stdout="", stderr="", returncode=0)
+        actor._exec("ls .", "")
+
+        cmd_list: list[str] = mock_run.call_args[0][0]
+
+    chdir_idx = cmd_list.index("--chdir")
+    assert cmd_list[chdir_idx + 1] == "/workspace"
+
+
+def test_exec_cwd_nonempty_appends_to_workspace(actor: BwrapSandboxActor) -> None:
+    """AC4: When cwd='subdir', --chdir is followed by '/workspace/subdir'."""
+    with patch("akgentic.tool.sandbox.bwrap.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(stdout="", stderr="", returncode=0)
+        actor._exec("ls .", "subdir")
+
+        cmd_list: list[str] = mock_run.call_args[0][0]
+
+    chdir_idx = cmd_list.index("--chdir")
+    assert cmd_list[chdir_idx + 1] == "/workspace/subdir"
+
+
+# ---------------------------------------------------------------------------
+# AC5: resource limits and env stripping
+# ---------------------------------------------------------------------------
+
+
+def test_exec_passes_preexec_fn_to_subprocess(actor: BwrapSandboxActor) -> None:
+    """AC5: _exec() passes a non-None callable preexec_fn to subprocess.run."""
+    with patch("akgentic.tool.sandbox.bwrap.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(stdout="", stderr="", returncode=0)
+        actor._exec("ls .", "")
+
+        call_kwargs = mock_run.call_args
+    assert call_kwargs is not None
+    preexec_fn = call_kwargs.kwargs.get("preexec_fn")
+    assert preexec_fn is not None
+    assert callable(preexec_fn)
+
+
+def test_exec_strips_env_to_minimal_path(actor: BwrapSandboxActor) -> None:
+    """AC5: _exec() passes minimal PATH-only env dict to subprocess.run."""
+    with patch("akgentic.tool.sandbox.bwrap.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(stdout="", stderr="", returncode=0)
+        actor._exec("ls .", "")
+
+        call_kwargs = mock_run.call_args
+    assert call_kwargs is not None
+    env = call_kwargs.kwargs.get("env")
+    assert env == {"PATH": "/usr/bin:/bin:/usr/local/bin"}
+
+
+# ---------------------------------------------------------------------------
+# AC4: _exec() returns ExecResult with correct fields
+# ---------------------------------------------------------------------------
+
+
+def test_exec_returns_exec_result(actor: BwrapSandboxActor) -> None:
+    """AC4: _exec() returns ExecResult with stdout, stderr, exit_code from subprocess.run."""
+    with patch("akgentic.tool.sandbox.bwrap.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(stdout="out", stderr="err", returncode=0)
+        result = actor._exec("ls .", "")
+
+    assert isinstance(result, ExecResult)
+    assert result.stdout == "out"
+    assert result.stderr == "err"
+    assert result.exit_code == 0
+
+
+def test_exec_returns_exec_result_nonzero_exit(actor: BwrapSandboxActor) -> None:
+    """AC4: _exec() correctly captures non-zero exit codes."""
+    with patch("akgentic.tool.sandbox.bwrap.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(stdout="", stderr="error output", returncode=1)
+        result = actor._exec("ls .", "")
+
+    assert result.exit_code == 1
+    assert result.stderr == "error output"

--- a/tests/sandbox/test_exec_tool.py
+++ b/tests/sandbox/test_exec_tool.py
@@ -45,7 +45,7 @@ class MockObserver:
         has_orchestrator: bool = True,
         existing_actor: ActorAddress | None = None,
     ) -> None:
-        self._team_id = "team-test"
+        self.team_id = "team-test"
         self.myAddress = MagicMock(spec=ActorAddress)
         self.orchestrator = MagicMock(spec=ActorAddress) if has_orchestrator else None
 
@@ -450,7 +450,7 @@ def test_observer_passes_workspace_id_none_to_sandbox_config() -> None:
 def test_observer_config_has_team_id_and_workspace_id_independently() -> None:
     """FR-SB-32: SandboxConfig gets both team_id and workspace_id, independently set."""
     observer = MockObserver(existing_actor=None)
-    observer._team_id = "t1"
+    observer.team_id = "t1"
     tool = ExecTool(workspace_id="my-ws")
 
     tool.observer(observer)  # type: ignore[arg-type]

--- a/tests/sandbox/test_local_sandbox.py
+++ b/tests/sandbox/test_local_sandbox.py
@@ -10,6 +10,11 @@ Covers AC1 through AC7 for Story 6.2 (updated for Story 6.5):
 - _exec() returns ExecResult with correct stdout, stderr, exit_code
 - subprocess.TimeoutExpired propagates from _exec()
 - exec() public method works end-to-end through _exec()
+
+Story 8.1: Resource limits and environment stripping:
+- preexec_fn is passed to subprocess.run (mock assert)
+- env is stripped to minimal PATH (mock assert)
+- docstring contains isolation disclaimer
 """
 
 from __future__ import annotations
@@ -176,13 +181,16 @@ def test_exec_no_cwd_uses_workspace_path(
 
     actor._exec("pytest tests/", "")
 
-    mock_run.assert_called_once_with(
-        ["pytest", "tests/"],
-        cwd=str(actor.state.workspace_path),
-        capture_output=True,
-        text=True,
-        timeout=30,
-    )
+    call_kwargs = mock_run.call_args
+    assert call_kwargs is not None
+    assert call_kwargs.args[0] == ["pytest", "tests/"]
+    assert call_kwargs.kwargs["cwd"] == str(actor.state.workspace_path)
+    assert call_kwargs.kwargs["capture_output"] is True
+    assert call_kwargs.kwargs["text"] is True
+    assert call_kwargs.kwargs["timeout"] == 30
+    assert call_kwargs.kwargs["preexec_fn"] is not None
+    assert callable(call_kwargs.kwargs["preexec_fn"])
+    assert call_kwargs.kwargs["env"] == {"PATH": "/usr/bin:/bin:/usr/local/bin"}
 
 
 # ---------------------------------------------------------------------------
@@ -205,13 +213,16 @@ def test_exec_with_cwd_appends_to_workspace_path(
     actor._exec("pytest tests/", "src")
 
     expected_cwd = str(actor.state.workspace_path / "src")
-    mock_run.assert_called_once_with(
-        ["pytest", "tests/"],
-        cwd=expected_cwd,
-        capture_output=True,
-        text=True,
-        timeout=30,
-    )
+    call_kwargs = mock_run.call_args
+    assert call_kwargs is not None
+    assert call_kwargs.args[0] == ["pytest", "tests/"]
+    assert call_kwargs.kwargs["cwd"] == expected_cwd
+    assert call_kwargs.kwargs["capture_output"] is True
+    assert call_kwargs.kwargs["text"] is True
+    assert call_kwargs.kwargs["timeout"] == 30
+    assert call_kwargs.kwargs["preexec_fn"] is not None
+    assert callable(call_kwargs.kwargs["preexec_fn"])
+    assert call_kwargs.kwargs["env"] == {"PATH": "/usr/bin:/bin:/usr/local/bin"}
 
 
 # ---------------------------------------------------------------------------
@@ -424,3 +435,77 @@ def test_exec_tool_and_workspace_tool_resolve_same_path_via_workspace_id(
         f"WorkspaceTool root ({workspace_tool_root}) != "
         f"LocalSandboxActor root ({sandbox_root})"
     )
+
+
+# ---------------------------------------------------------------------------
+# Story 8.1: Resource limits and environment stripping (AC: 1, 2, 5)
+# ---------------------------------------------------------------------------
+
+
+@patch("akgentic.tool.sandbox.local.subprocess.run")
+def test_exec_passes_preexec_fn_to_subprocess(
+    mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """AC5 (Story 8.1): _exec() passes a non-None callable preexec_fn to subprocess.run."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("AKGENTIC_WORKSPACES_ROOT", raising=False)
+    actor = make_actor(team_id="team-1")
+    actor._start_sandbox()
+
+    mock_run.return_value = MagicMock(stdout="output", stderr="", returncode=0)
+
+    actor._exec("echo hello", "")
+
+    call_kwargs = mock_run.call_args
+    assert call_kwargs is not None
+    preexec_fn = call_kwargs.kwargs.get("preexec_fn")
+    assert preexec_fn is not None
+    assert callable(preexec_fn)
+
+
+@patch("akgentic.tool.sandbox.local.subprocess.run")
+def test_exec_strips_env_to_minimal_path(
+    mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """AC5 (Story 8.1): _exec() passes env={'PATH': '/usr/bin:/bin:/usr/local/bin'} to subprocess.run."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("AKGENTIC_WORKSPACES_ROOT", raising=False)
+    actor = make_actor(team_id="team-1")
+    actor._start_sandbox()
+
+    mock_run.return_value = MagicMock(stdout="output", stderr="", returncode=0)
+
+    actor._exec("echo hello", "")
+
+    call_kwargs = mock_run.call_args
+    assert call_kwargs is not None
+    env = call_kwargs.kwargs.get("env")
+    assert env == {"PATH": "/usr/bin:/bin:/usr/local/bin"}
+
+
+@patch("akgentic.tool.sandbox.local.subprocess.run")
+def test_exec_no_env_kwargs_other_than_path(
+    mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """AC5 (Story 8.1): env dict passed to subprocess.run has exactly one key ('PATH')."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("AKGENTIC_WORKSPACES_ROOT", raising=False)
+    actor = make_actor(team_id="team-1")
+    actor._start_sandbox()
+
+    mock_run.return_value = MagicMock(stdout="output", stderr="", returncode=0)
+
+    actor._exec("echo hello", "")
+
+    call_kwargs = mock_run.call_args
+    assert call_kwargs is not None
+    env = call_kwargs.kwargs.get("env")
+    assert isinstance(env, dict)
+    assert len(env) == 1
+    assert "PATH" in env
+
+
+def test_docstring_contains_isolation_disclaimer() -> None:
+    """AC5 (Story 8.1): LocalSandboxActor docstring contains isolation disclaimer."""
+    assert LocalSandboxActor.__doc__ is not None
+    assert "does NOT provide filesystem isolation" in LocalSandboxActor.__doc__

--- a/tests/sandbox/test_local_sandbox.py
+++ b/tests/sandbox/test_local_sandbox.py
@@ -11,10 +11,12 @@ Covers AC1 through AC7 for Story 6.2 (updated for Story 6.5):
 - subprocess.TimeoutExpired propagates from _exec()
 - exec() public method works end-to-end through _exec()
 
-Story 8.1: Resource limits and environment stripping:
-- preexec_fn is passed to subprocess.run (mock assert)
-- env is stripped to minimal PATH (mock assert)
-- docstring contains isolation disclaimer
+Story 8.1: Resource limits and environment stripping (AC: 1, 2, 3, 4, 5):
+- preexec_fn is passed to subprocess.run (mock assert) — AC5
+- env is stripped to minimal PATH (mock assert) — AC5
+- env dict has exactly one key — AC5
+- docstring contains isolation disclaimer — AC4 / AC5
+- _make_preexec() callable sets RLIMIT_CPU, RLIMIT_AS, RLIMIT_FSIZE and calls setpgrp — AC1 / AC3
 """
 
 from __future__ import annotations
@@ -467,7 +469,7 @@ def test_exec_passes_preexec_fn_to_subprocess(
 def test_exec_strips_env_to_minimal_path(
     mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """AC5 (Story 8.1): _exec() passes env={'PATH': '/usr/bin:/bin:/usr/local/bin'} to subprocess.run."""
+    """AC5 (Story 8.1): _exec() passes minimal PATH-only env dict to subprocess.run."""
     monkeypatch.chdir(tmp_path)
     monkeypatch.delenv("AKGENTIC_WORKSPACES_ROOT", raising=False)
     actor = make_actor(team_id="team-1")
@@ -506,6 +508,57 @@ def test_exec_no_env_kwargs_other_than_path(
 
 
 def test_docstring_contains_isolation_disclaimer() -> None:
-    """AC5 (Story 8.1): LocalSandboxActor docstring contains isolation disclaimer."""
+    """AC4 / AC5 (Story 8.1): LocalSandboxActor docstring contains isolation disclaimer."""
     assert LocalSandboxActor.__doc__ is not None
     assert "does NOT provide filesystem isolation" in LocalSandboxActor.__doc__
+
+
+# ---------------------------------------------------------------------------
+# Story 8.1: _make_preexec() unit tests — verify actual resource-limit logic
+# ---------------------------------------------------------------------------
+
+
+def test_make_preexec_returns_callable() -> None:
+    """AC1 (Story 8.1): _make_preexec() returns a callable (not None)."""
+    from akgentic.tool.sandbox.local import _make_preexec
+
+    fn = _make_preexec()
+    assert callable(fn)
+
+
+def test_make_preexec_custom_defaults_returns_callable() -> None:
+    """AC1 (Story 8.1): _make_preexec() with custom args returns a callable."""
+    from akgentic.tool.sandbox.local import _make_preexec
+
+    fn = _make_preexec(cpu_s=10, mem_mb=256, fsize_mb=50)
+    assert callable(fn)
+
+
+def test_make_preexec_fn_sets_resource_limits() -> None:
+    """AC1 / AC3 (Story 8.1): The callable returned by _make_preexec() sets RLIMIT_CPU,
+    RLIMIT_AS, and RLIMIT_FSIZE to the expected values, and calls os.setpgrp().
+
+    We mock resource.setrlimit and os.setpgrp to avoid altering the test process's
+    resource limits.
+    """
+    import resource as resource_module
+    from unittest.mock import call, patch
+
+    from akgentic.tool.sandbox.local import _make_preexec
+
+    fn = _make_preexec(cpu_s=30, mem_mb=512, fsize_mb=100)
+
+    with (
+        patch.object(resource_module, "setrlimit") as mock_setrlimit,
+        patch("os.setpgrp") as mock_setpgrp,
+    ):
+        fn()
+
+    mb = 1024**2
+    expected_calls = [
+        call(resource_module.RLIMIT_CPU, (30, 30)),
+        call(resource_module.RLIMIT_AS, (512 * mb, 512 * mb)),
+        call(resource_module.RLIMIT_FSIZE, (100 * mb, 100 * mb)),
+    ]
+    mock_setrlimit.assert_has_calls(expected_calls, any_order=False)
+    mock_setpgrp.assert_called_once()

--- a/tests/workspace/test_read_tool.py
+++ b/tests/workspace/test_read_tool.py
@@ -37,7 +37,7 @@ def make_observer(
     """Build a minimal mock ActorToolObserver."""
     observer = MagicMock()
     observer.orchestrator = None if orchestrator_is_none else MagicMock()
-    observer._team_id = team_id or uuid.uuid4()
+    observer.team_id = team_id or uuid.uuid4()
     return observer
 
 

--- a/tests/workspace/test_view_tool.py
+++ b/tests/workspace/test_view_tool.py
@@ -30,7 +30,7 @@ def make_observer(
     """Build a minimal mock ActorToolObserver."""
     observer = MagicMock()
     observer.orchestrator = None if orchestrator_is_none else MagicMock()
-    observer._team_id = team_id or uuid.uuid4()
+    observer.team_id = team_id or uuid.uuid4()
     return observer
 
 

--- a/tests/workspace/test_workspace_tool.py
+++ b/tests/workspace/test_workspace_tool.py
@@ -26,7 +26,7 @@ def make_observer(
     tid = team_id or uuid.uuid4()
     observer = MagicMock()
     observer.orchestrator = MagicMock()
-    observer._team_id = tid
+    observer.team_id = tid
     fs = Filesystem(str(tmp_path), str(tid))
     return observer, fs
 


### PR DESCRIPTION
## Summary

- Add BwrapSandboxActor in sandbox/bwrap.py: isolates subprocess execution inside a Linux bubblewrap namespace; workspace is the only writable path, /etc, /home, and all other host paths are invisible
- Network access blocked via --unshare-net; PID namespace isolated via --unshare-pid; resource limits and minimal PATH env reused from _make_preexec() in local.py
- 14 unit tests covering all ACs: bwrap-not-on-PATH RuntimeError, workspace creation, idempotency, stop no-op, full bwrap flag assertion, preexec_fn, env stripping, --chdir logic, ExecResult capture
- Add team_id property to ActorToolObserver Protocol; replace private _team_id attribute access with typed property across sandbox/tool.py, workspace/tool.py, and all test mocks

Closes #96