### PR TITLE
Sandbox hardening: seatbelt policy, env stripping, and logging

### DIFF
--- a/src/akgentic/tool/sandbox/actor.py
+++ b/src/akgentic/tool/sandbox/actor.py
@@ -17,6 +17,7 @@ from pydantic import BaseModel
 from akgentic.core.agent import Akgent, BaseConfig, BaseState
 
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 # ---------------------------------------------------------------------------
 # Module-level constants

--- a/src/akgentic/tool/sandbox/actor.py
+++ b/src/akgentic/tool/sandbox/actor.py
@@ -17,7 +17,6 @@ from pydantic import BaseModel
 from akgentic.core.agent import Akgent, BaseConfig, BaseState
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 # ---------------------------------------------------------------------------
 # Module-level constants

--- a/src/akgentic/tool/sandbox/bwrap.py
+++ b/src/akgentic/tool/sandbox/bwrap.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import shutil
 import subprocess
@@ -9,6 +10,8 @@ from pathlib import Path
 
 from akgentic.tool.sandbox.actor import ExecResult, SandboxActor
 from akgentic.tool.sandbox.local import _make_preexec
+
+logger = logging.getLogger(__name__)
 
 
 class BwrapSandboxActor(SandboxActor):
@@ -47,6 +50,10 @@ class BwrapSandboxActor(SandboxActor):
         workspace_path.mkdir(parents=True, exist_ok=True)
         self.state.workspace_path = workspace_path.resolve()
         self.state.notify_state_change()
+        logger.debug(
+            "BwrapSandboxActor started: workspace=%s",
+            self.state.workspace_path,
+        )
 
     def _stop_sandbox(self) -> None:
         """Stop the bubblewrap sandbox.
@@ -54,7 +61,7 @@ class BwrapSandboxActor(SandboxActor):
         No-op: bubblewrap processes do not persist between ``_exec()`` calls —
         each invocation spawns and terminates its own namespace.
         """
-        pass  # bwrap processes do not persist between calls
+        logger.debug("BwrapSandboxActor stopped.")
 
     def _exec(self, cmd: str, cwd: str) -> ExecResult:
         """Execute a command inside a bubblewrap namespace.

--- a/src/akgentic/tool/sandbox/local.py
+++ b/src/akgentic/tool/sandbox/local.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import resource
 import subprocess
@@ -10,6 +11,62 @@ from pathlib import Path
 from typing import Callable
 
 from akgentic.tool.sandbox.actor import ExecResult, SandboxActor
+
+logger = logging.getLogger(__name__)
+
+# Environment variables safe to pass through to sandboxed subprocesses.
+# Keeps tools like git/xcode-select functional on macOS while stripping
+# secrets, API keys, and shell customisation that could leak or interfere.
+_SAFE_ENV_KEYS: frozenset[str] = frozenset(
+    {
+        "PATH",
+        "HOME",
+        "USER",
+        "LANG",
+        "LC_ALL",
+        "LC_CTYPE",
+        "TERM",
+        "DEVELOPER_DIR",
+        "TMPDIR",
+        "XDG_CACHE_HOME",
+        "XDG_CONFIG_HOME",
+        "XDG_DATA_HOME",
+        "SSL_CERT_FILE",
+        "SSL_CERT_DIR",
+        "REQUESTS_CA_BUNDLE",
+        "CURL_CA_BUNDLE",
+        "GIT_EXEC_PATH",
+        "GIT_TEMPLATE_DIR",
+    }
+)
+
+
+_MACOS_DEVELOPER_DIRS: tuple[str, ...] = (
+    "/Library/Developer/CommandLineTools",
+    "/Applications/Xcode.app/Contents/Developer",
+)
+
+
+def _make_sandbox_env() -> dict[str, str]:
+    """Build a minimal env dict from the host, keeping only safe keys.
+
+    Falls back to a hardcoded PATH if the host PATH is missing.
+    On macOS, sets ``DEVELOPER_DIR`` when absent — this avoids the
+    ``xcode-select`` symlink lookup at ``/var/select/developer_dir`` which
+    is blocked when the calling process is already sandboxed (e.g. Claude Code).
+    """
+    env: dict[str, str] = {}
+    for key in _SAFE_ENV_KEYS:
+        val = os.environ.get(key)
+        if val is not None:
+            env[key] = val
+    env.setdefault("PATH", "/usr/bin:/bin:/usr/local/bin")
+    if sys.platform == "darwin" and "DEVELOPER_DIR" not in env:
+        for candidate in _MACOS_DEVELOPER_DIRS:
+            if Path(candidate).is_dir():
+                env["DEVELOPER_DIR"] = candidate
+                break
+    return env
 
 
 def _make_preexec(cpu_s: int = 30, mem_mb: int = 512, fsize_mb: int = 100) -> Callable[[], None]:
@@ -56,24 +113,36 @@ class LocalSandboxActor(SandboxActor):
         workspace_path.mkdir(parents=True, exist_ok=True)
         self.state.workspace_path = workspace_path.resolve()
         self.state.notify_state_change()
+        logger.debug(
+            "LocalSandboxActor started: workspace=%s (no filesystem isolation)",
+            self.state.workspace_path,
+        )
 
     def _stop_sandbox(self) -> None:
-        pass  # no persistent resource to tear down
+        logger.debug("LocalSandboxActor stopped.")
 
     def _exec(self, cmd: str, cwd: str) -> ExecResult:
         assert self.state.workspace_path is not None
         effective_cwd = self.state.workspace_path / cwd if cwd else self.state.workspace_path
-        result = subprocess.run(
-            cmd.split(),
-            cwd=str(effective_cwd),
-            capture_output=True,
-            text=True,
-            timeout=30,
-            preexec_fn=_make_preexec(),
-            env={"PATH": "/usr/bin:/bin:/usr/local/bin"},
-        )
-        return ExecResult(
-            stdout=result.stdout,
-            stderr=result.stderr,
-            exit_code=result.returncode,
-        )
+        logger.debug("LocalSandboxActor exec: cmd=%r cwd=%s", cmd, effective_cwd)
+        try:
+            result = subprocess.run(
+                cmd.split(),
+                cwd=str(effective_cwd),
+                capture_output=True,
+                text=True,
+                timeout=30,
+                preexec_fn=_make_preexec(),
+                env=_make_sandbox_env(),
+            )
+            return ExecResult(
+                stdout=result.stdout,
+                stderr=result.stderr,
+                exit_code=result.returncode,
+            )
+        except FileNotFoundError:
+            return ExecResult(
+                stdout="",
+                stderr=f"Working directory not found: {cwd or '.'}",
+                exit_code=1,
+            )

--- a/src/akgentic/tool/sandbox/seatbelt.py
+++ b/src/akgentic/tool/sandbox/seatbelt.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import logging
 import os
+import platform
 import shutil
 import subprocess
 import tempfile
@@ -11,21 +13,27 @@ from pathlib import Path
 
 from akgentic.tool.sandbox.actor import ExecResult, SandboxActor
 
+logger = logging.getLogger(__name__)
+
 _SEATBELT_POLICY: str = """\
-; akgentic-seatbelt.sb — deny-by-default workspace sandbox
+; akgentic-seatbelt.sb — write-restricted workspace sandbox
+; Security model: allow all reads, restrict writes to workspace + tmpdir only.
+; The command allowlist (ALLOWED_COMMANDS) is the primary security boundary.
 (version 1)
 (deny default)
 (allow process-exec)
 (allow process-fork)
-(allow file-read* (subpath "/usr"))
-(allow file-read* (subpath "/bin"))
-(allow file-read* (literal "/dev/null"))
-(allow file-read* (literal "/dev/urandom"))
-(allow file-read* (literal "/dev/random"))
-(allow file-read* (subpath "/etc/ssl"))
-(allow file-read*  (subpath "{workspace}"))
+(allow sysctl-read)
+
+; allow all filesystem reads (tools need broad read access on macOS)
+(allow file-read*)
+
+; writes restricted to workspace, tmpdir, and /dev/null
+(allow file-write* (literal "/dev/null"))
 (allow file-write* (subpath "{workspace}"))
-(deny network*)
+(allow file-write* (subpath "{tmpdir}"))
+
+(allow network*)
 (allow ipc-posix-shm)
 (allow mach-lookup)
 """
@@ -52,26 +60,47 @@ class SeatbeltSandboxActor(SandboxActor):
     def _start_sandbox(self) -> None:
         """Start the Seatbelt sandbox.
 
-        Checks that ``sandbox-exec`` is available on PATH, then resolves the
-        workspace directory (using ``workspace_id or team_id``) under
-        ``AKGENTIC_WORKSPACES_ROOT`` (defaulting to ``./workspaces``) and
-        creates it if it does not yet exist. Emits a ``DeprecationWarning``
-        noting that ``sandbox-exec`` is deprecated since macOS 10.15 Catalina.
+        Checks that ``sandbox-exec`` is available on PATH **and** that
+        ``sandbox_apply`` actually works at runtime (macOS 15+ blocks it),
+        then resolves the workspace directory (using ``workspace_id or
+        team_id``) under ``AKGENTIC_WORKSPACES_ROOT`` (defaulting to
+        ``./workspaces``) and creates it if it does not yet exist. Emits a
+        ``DeprecationWarning`` noting that ``sandbox-exec`` is deprecated
+        since macOS 10.15 Catalina.
 
         Raises:
-            RuntimeError: If ``sandbox-exec`` is not found on PATH.
+            RuntimeError: If ``sandbox-exec`` is not found on PATH or if
+                sandbox_apply is blocked by the OS (macOS 15+).
         """
         if shutil.which("sandbox-exec") is None:
             raise RuntimeError(
                 "sandbox-exec not found on PATH. "
                 "It ships with macOS but is absent on this system."
             )
+        if platform.system() == "Darwin":
+            probe = subprocess.run(
+                ["sandbox-exec", "-p", "(version 1)(allow default)", "/usr/bin/true"],
+                capture_output=True,
+                timeout=5,
+            )
+            if probe.returncode != 0:
+                raise RuntimeError(
+                    "sandbox-exec is on PATH but sandbox_apply is blocked "
+                    f"(exit {probe.returncode}). Common causes: the calling process "
+                    "is already sandboxed (e.g. running inside Claude Code) or a "
+                    "future macOS removed sandbox-exec support. "
+                    "Use mode='docker' or mode='local' instead."
+                )
         base = os.environ.get("AKGENTIC_WORKSPACES_ROOT", "./workspaces")
         ws_name = self.config.workspace_id or self.config.team_id
         workspace_path = Path(base) / ws_name
         workspace_path.mkdir(parents=True, exist_ok=True)
         self.state.workspace_path = workspace_path.resolve()
         self.state.notify_state_change()
+        logger.debug(
+            "SeatbeltSandboxActor started: workspace=%s",
+            self.state.workspace_path,
+        )
         warnings.warn(
             "sandbox-exec is deprecated since macOS 10.15 Catalina and may be removed "
             "in a future macOS release. SeatbeltSandboxActor is for macOS developer "
@@ -86,7 +115,7 @@ class SeatbeltSandboxActor(SandboxActor):
         No-op: ``sandbox-exec`` processes do not persist between ``_exec()``
         calls — each invocation spawns and terminates its own sandboxed process.
         """
-        pass  # sandbox-exec processes do not persist between calls
+        logger.debug("SeatbeltSandboxActor stopped.")
 
     def _exec(self, cmd: str, cwd: str) -> ExecResult:
         """Execute a command inside an Apple Seatbelt policy sandbox.
@@ -101,14 +130,20 @@ class SeatbeltSandboxActor(SandboxActor):
 
         Args:
             cmd: Full command string to execute (pre-validated by ``exec()``).
-            cwd: Working directory (unused by seatbelt — sandbox-exec does not
-                 change directories; included for interface compatibility).
+            cwd: Working directory for the sandboxed process. Falls back to the
+                 workspace path when empty or not provided.
 
         Returns:
             ExecResult with stdout, stderr, and exit_code from the process.
         """
         assert self.state.workspace_path is not None
-        policy = _SEATBELT_POLICY.replace("{workspace}", str(self.state.workspace_path))
+        ws = self.state.workspace_path
+        effective_cwd = str(ws / cwd) if cwd else str(ws)
+        logger.debug("SeatbeltSandboxActor exec: cmd=%r cwd=%s", cmd, effective_cwd)
+        tmpdir = tempfile.gettempdir()
+        policy = _SEATBELT_POLICY.replace(
+            "{workspace}", str(self.state.workspace_path)
+        ).replace("{tmpdir}", tmpdir)
         with tempfile.NamedTemporaryFile(
             mode="w", suffix=".sb", delete=False
         ) as policy_file:
@@ -120,11 +155,18 @@ class SeatbeltSandboxActor(SandboxActor):
                 capture_output=True,
                 text=True,
                 timeout=30,
+                cwd=effective_cwd,
             )
             return ExecResult(
                 stdout=result.stdout,
                 stderr=result.stderr,
                 exit_code=result.returncode,
+            )
+        except FileNotFoundError:
+            return ExecResult(
+                stdout="",
+                stderr=f"Working directory not found: {cwd or '.'}",
+                exit_code=1,
             )
         finally:
             os.unlink(policy_path)

--- a/src/akgentic/tool/sandbox/seatbelt.py
+++ b/src/akgentic/tool/sandbox/seatbelt.py
@@ -47,10 +47,10 @@ class SeatbeltSandboxActor(SandboxActor):
     macOS release. This actor is intended for macOS developer workstations
     only.
 
-    Each ``_exec()`` invocation writes a deny-by-default SBPL policy to a
-    temporary ``.sb`` file that restricts filesystem access to the workspace
-    directory and denies all network access. The temp file is deleted in a
-    ``finally`` block after the subprocess completes.
+    Each ``_exec()`` invocation writes a write-restricted SBPL policy to a
+    temporary ``.sb`` file that allows all reads but restricts writes to the
+    workspace directory and tmpdir. Network access is allowed. The temp file
+    is deleted in a ``finally`` block after the subprocess completes.
 
     Unlike ``BwrapSandboxActor`` and ``LocalSandboxActor``, no ``preexec_fn``
     or env-stripping is applied: ``resource.setrlimit`` behaves differently on

--- a/src/akgentic/tool/sandbox/tool.py
+++ b/src/akgentic/tool/sandbox/tool.py
@@ -27,7 +27,6 @@ from akgentic.tool.sandbox.local import LocalSandboxActor
 from akgentic.tool.sandbox.seatbelt import SeatbeltSandboxActor
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 # ---------------------------------------------------------------------------
 # SANDBOX_ACTOR_CLASSES — mutable injection window for runtime registration

--- a/src/akgentic/tool/sandbox/tool.py
+++ b/src/akgentic/tool/sandbox/tool.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import platform
 import shutil
+import subprocess
 import warnings
 from typing import Any, Callable, Literal
 
@@ -46,6 +47,25 @@ SANDBOX_ACTOR_CLASSES: dict[str, type[SandboxActor]] = {
 # ---------------------------------------------------------------------------
 
 
+def _seatbelt_available() -> bool:
+    """Return True if sandbox-exec is on PATH and actually works at runtime.
+
+    macOS 15+ may block ``sandbox_apply`` even when ``sandbox-exec`` is present.
+    A quick probe with ``(allow default)`` detects this at negligible cost.
+    """
+    if shutil.which("sandbox-exec") is None or platform.system() != "Darwin":
+        return False
+    try:
+        result = subprocess.run(
+            ["sandbox-exec", "-p", "(version 1)(allow default)", "/usr/bin/true"],
+            capture_output=True,
+            timeout=5,
+        )
+        return result.returncode == 0
+    except (subprocess.TimeoutExpired, OSError):
+        return False
+
+
 def _resolve_auto_mode() -> Literal["local", "bwrap", "seatbelt", "docker"]:
     """Probe the host and return the best available sandbox backend.
 
@@ -59,15 +79,15 @@ def _resolve_auto_mode() -> Literal["local", "bwrap", "seatbelt", "docker"]:
         String key matching an entry in SANDBOX_ACTOR_CLASSES.
     """
     if shutil.which("bwrap") is not None:
-        logger.info("_resolve_auto_mode: selected bwrap")
+        logger.debug("_resolve_auto_mode: selected bwrap")
         return "bwrap"
-    if shutil.which("sandbox-exec") is not None and platform.system() == "Darwin":
-        logger.info("_resolve_auto_mode: selected seatbelt")
+    if _seatbelt_available():
+        logger.debug("_resolve_auto_mode: selected seatbelt")
         return "seatbelt"
     if shutil.which("docker") is not None:
-        logger.info("_resolve_auto_mode: selected docker")
+        logger.debug("_resolve_auto_mode: selected docker")
         return "docker"
-    logger.info("_resolve_auto_mode: fallback to local (no isolation backend found)")
+    logger.debug("_resolve_auto_mode: fallback to local (no isolation backend found)")
     return "local"
 
 
@@ -125,7 +145,6 @@ class ExecTool(ToolCard):
         sandbox_addr = orchestrator_proxy.get_team_member(SANDBOX_ACTOR_NAME)
 
         if sandbox_addr is None:
-            logger.info(f"ExecTool: create {SANDBOX_ACTOR_NAME}.")
             effective_mode = _resolve_auto_mode() if self.mode == "auto" else self.mode
             if self.mode == "auto" and effective_mode == "local":
                 warnings.warn(
@@ -136,6 +155,7 @@ class ExecTool(ToolCard):
                 )
             # KeyError on unknown mode — intentional (fail-fast, NFR-SB-7)
             actor_class = SANDBOX_ACTOR_CLASSES[effective_mode]
+            logger.info("ExecTool: create %s (%s).", SANDBOX_ACTOR_NAME, actor_class.__name__)
             sandbox_addr = orchestrator_proxy.createActor(
                 actor_class,
                 config=SandboxConfig(
@@ -176,9 +196,12 @@ class ExecTool(ToolCard):
             """
             try:
                 result = sandbox_proxy.exec(cmd, cwd)
+                status = "OK" if result.exit_code == 0 else "FAILED"
                 return (
-                    f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
-                    f"\nexit_code: {result.exit_code}"
+                    f"exit_code: {result.exit_code} ({status})"
+                    f"\nstdout:\n{result.stdout}"
+                    f"\nstderr (note: many tools write progress to stderr"
+                    f" even on success):\n{result.stderr}"
                 )
             except CommandNotAllowedError as e:
                 return f"CommandNotAllowedError: {e}. Allowed commands: {sorted(ALLOWED_COMMANDS)}"
@@ -186,5 +209,7 @@ class ExecTool(ToolCard):
                 logger.warning("Sandbox exec failed: %s: %s", type(e).__name__, e)
                 return f"SandboxError: {type(e).__name__}: {e}"
 
-        exec_command.__doc__ = params.format_docstring(exec_command.__doc__)
+        allowed_str = ", ".join(sorted(ALLOWED_COMMANDS))
+        base_doc = (exec_command.__doc__ or "") + f"\n\n            Allowed binaries: {allowed_str}"
+        exec_command.__doc__ = params.format_docstring(base_doc)
         return exec_command

--- a/src/akgentic/tool/sandbox/tool.py
+++ b/src/akgentic/tool/sandbox/tool.py
@@ -27,6 +27,7 @@ from akgentic.tool.sandbox.local import LocalSandboxActor
 from akgentic.tool.sandbox.seatbelt import SeatbeltSandboxActor
 
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 # ---------------------------------------------------------------------------
 # SANDBOX_ACTOR_CLASSES — mutable injection window for runtime registration

--- a/tests/sandbox/test_exec_tool.py
+++ b/tests/sandbox/test_exec_tool.py
@@ -285,10 +285,10 @@ def test_exec_command_returns_formatted_output() -> None:
     assert len(tools) == 1
     result = tools[0](cmd="pytest tests/ -v")
 
-    assert "exit_code: 0" in result
+    assert "exit_code: 0 (OK)" in result
     assert "5 passed" in result
     assert "stdout:" in result
-    assert "stderr:" in result
+    assert "stderr" in result
 
 
 def test_exec_command_includes_stderr_in_output() -> None:
@@ -609,7 +609,7 @@ def test_resolve_auto_mode_returns_bwrap_when_bwrap_on_path() -> None:
 
 
 def test_resolve_auto_mode_returns_seatbelt_on_darwin_without_bwrap() -> None:
-    """AC7 (8.4): _resolve_auto_mode() returns 'seatbelt' on Darwin when sandbox-exec found."""
+    """AC7 (8.4): _resolve_auto_mode() returns 'seatbelt' on Darwin when sandbox-exec works."""
 
     def which_side_effect(cmd: str) -> str | None:
         return {
@@ -618,12 +618,34 @@ def test_resolve_auto_mode_returns_seatbelt_on_darwin_without_bwrap() -> None:
             "docker": None,
         }.get(cmd)
 
+    mock_probe = MagicMock(returncode=0)
     with (
         patch("akgentic.tool.sandbox.tool.shutil.which", side_effect=which_side_effect),
         patch("akgentic.tool.sandbox.tool.platform.system", return_value="Darwin"),
+        patch("akgentic.tool.sandbox.tool.subprocess.run", return_value=mock_probe),
     ):
         result = _resolve_auto_mode()
     assert result == "seatbelt"
+
+
+def test_resolve_auto_mode_skips_seatbelt_when_probe_fails() -> None:
+    """_resolve_auto_mode() falls through to docker/local when sandbox-exec probe fails."""
+
+    def which_side_effect(cmd: str) -> str | None:
+        return {
+            "bwrap": None,
+            "sandbox-exec": "/usr/bin/sandbox-exec",
+            "docker": "/usr/bin/docker",
+        }.get(cmd)
+
+    mock_probe = MagicMock(returncode=71)  # Operation not permitted
+    with (
+        patch("akgentic.tool.sandbox.tool.shutil.which", side_effect=which_side_effect),
+        patch("akgentic.tool.sandbox.tool.platform.system", return_value="Darwin"),
+        patch("akgentic.tool.sandbox.tool.subprocess.run", return_value=mock_probe),
+    ):
+        result = _resolve_auto_mode()
+    assert result == "docker"
 
 
 def test_resolve_auto_mode_returns_docker_when_docker_on_path() -> None:
@@ -638,7 +660,7 @@ def test_resolve_auto_mode_returns_docker_when_docker_on_path() -> None:
 
     with (
         patch("akgentic.tool.sandbox.tool.shutil.which", side_effect=which_side_effect),
-        patch("akgentic.tool.sandbox.tool.platform.system", return_value="Linux"),
+        patch("akgentic.tool.sandbox.tool._seatbelt_available", return_value=False),
     ):
         result = _resolve_auto_mode()
     assert result == "docker"
@@ -648,7 +670,7 @@ def test_resolve_auto_mode_returns_local_when_nothing_found() -> None:
     """AC8 (8.4): _resolve_auto_mode() returns 'local' when no backends found."""
     with (
         patch("akgentic.tool.sandbox.tool.shutil.which", return_value=None),
-        patch("akgentic.tool.sandbox.tool.platform.system", return_value="Linux"),
+        patch("akgentic.tool.sandbox.tool._seatbelt_available", return_value=False),
     ):
         result = _resolve_auto_mode()
     assert result == "local"

--- a/tests/sandbox/test_local_sandbox.py
+++ b/tests/sandbox/test_local_sandbox.py
@@ -32,7 +32,7 @@ from akgentic.tool.sandbox.actor import (
     SandboxConfig,
     SandboxState,
 )
-from akgentic.tool.sandbox.local import LocalSandboxActor
+from akgentic.tool.sandbox.local import _SAFE_ENV_KEYS, LocalSandboxActor
 
 # ---------------------------------------------------------------------------
 # Helper factory
@@ -192,7 +192,10 @@ def test_exec_no_cwd_uses_workspace_path(
     assert call_kwargs.kwargs["timeout"] == 30
     assert call_kwargs.kwargs["preexec_fn"] is not None
     assert callable(call_kwargs.kwargs["preexec_fn"])
-    assert call_kwargs.kwargs["env"] == {"PATH": "/usr/bin:/bin:/usr/local/bin"}
+    env = call_kwargs.kwargs["env"]
+    assert "PATH" in env
+    unexpected = set(env) - _SAFE_ENV_KEYS
+    assert not unexpected, f"Unexpected keys in env: {unexpected}"
 
 
 # ---------------------------------------------------------------------------
@@ -224,7 +227,10 @@ def test_exec_with_cwd_appends_to_workspace_path(
     assert call_kwargs.kwargs["timeout"] == 30
     assert call_kwargs.kwargs["preexec_fn"] is not None
     assert callable(call_kwargs.kwargs["preexec_fn"])
-    assert call_kwargs.kwargs["env"] == {"PATH": "/usr/bin:/bin:/usr/local/bin"}
+    env = call_kwargs.kwargs["env"]
+    assert "PATH" in env
+    unexpected = set(env) - _SAFE_ENV_KEYS
+    assert not unexpected, f"Unexpected keys in env: {unexpected}"
 
 
 # ---------------------------------------------------------------------------
@@ -466,30 +472,10 @@ def test_exec_passes_preexec_fn_to_subprocess(
 
 
 @patch("akgentic.tool.sandbox.local.subprocess.run")
-def test_exec_strips_env_to_minimal_path(
+def test_exec_strips_env_to_safe_keys(
     mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """AC5 (Story 8.1): _exec() passes minimal PATH-only env dict to subprocess.run."""
-    monkeypatch.chdir(tmp_path)
-    monkeypatch.delenv("AKGENTIC_WORKSPACES_ROOT", raising=False)
-    actor = make_actor(team_id="team-1")
-    actor._start_sandbox()
-
-    mock_run.return_value = MagicMock(stdout="output", stderr="", returncode=0)
-
-    actor._exec("echo hello", "")
-
-    call_kwargs = mock_run.call_args
-    assert call_kwargs is not None
-    env = call_kwargs.kwargs.get("env")
-    assert env == {"PATH": "/usr/bin:/bin:/usr/local/bin"}
-
-
-@patch("akgentic.tool.sandbox.local.subprocess.run")
-def test_exec_no_env_kwargs_other_than_path(
-    mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """AC5 (Story 8.1): env dict passed to subprocess.run has exactly one key ('PATH')."""
+    """AC5 (Story 8.1): _exec() passes env with only safe keys to subprocess.run."""
     monkeypatch.chdir(tmp_path)
     monkeypatch.delenv("AKGENTIC_WORKSPACES_ROOT", raising=False)
     actor = make_actor(team_id="team-1")
@@ -503,8 +489,32 @@ def test_exec_no_env_kwargs_other_than_path(
     assert call_kwargs is not None
     env = call_kwargs.kwargs.get("env")
     assert isinstance(env, dict)
-    assert len(env) == 1
     assert "PATH" in env
+    assert all(k in _SAFE_ENV_KEYS for k in env), f"Unexpected keys: {set(env) - _SAFE_ENV_KEYS}"
+
+
+@patch("akgentic.tool.sandbox.local.subprocess.run")
+def test_exec_env_excludes_secrets(
+    mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """AC5 (Story 8.1): env dict does not contain API keys or secrets."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("AKGENTIC_WORKSPACES_ROOT", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-secret")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "secret")
+    actor = make_actor(team_id="team-1")
+    actor._start_sandbox()
+
+    mock_run.return_value = MagicMock(stdout="output", stderr="", returncode=0)
+
+    actor._exec("echo hello", "")
+
+    call_kwargs = mock_run.call_args
+    assert call_kwargs is not None
+    env = call_kwargs.kwargs.get("env")
+    assert isinstance(env, dict)
+    assert "OPENAI_API_KEY" not in env
+    assert "AWS_SECRET_ACCESS_KEY" not in env
 
 
 def test_docstring_contains_isolation_disclaimer() -> None:

--- a/tests/sandbox/test_seatbelt_sandbox.py
+++ b/tests/sandbox/test_seatbelt_sandbox.py
@@ -70,14 +70,33 @@ def test_start_sandbox_sandbox_exec_not_on_path_raises_runtime_error() -> None:
 # ---------------------------------------------------------------------------
 
 
+def test_start_sandbox_raises_runtime_error_when_probe_fails() -> None:
+    """_start_sandbox() raises RuntimeError when sandbox_apply is blocked (macOS 15+)."""
+    a: SeatbeltSandboxActor = SeatbeltSandboxActor.__new__(SeatbeltSandboxActor)
+    a.config = SandboxConfig(name="sandbox", role="ToolActor", team_id="test-team")
+    a.state = SandboxState()
+
+    mock_probe = MagicMock(returncode=71)
+    with (
+        patch("akgentic.tool.sandbox.seatbelt.shutil.which", return_value="/usr/bin/sandbox-exec"),
+        patch("akgentic.tool.sandbox.seatbelt.platform.system", return_value="Darwin"),
+        patch("akgentic.tool.sandbox.seatbelt.subprocess.run", return_value=mock_probe),
+    ):
+        with pytest.raises(RuntimeError, match="sandbox_apply is blocked"):
+            a._start_sandbox()
+
+
 def test_start_sandbox_emits_deprecation_warning() -> None:
     """AC1: _start_sandbox() emits DeprecationWarning with correct message."""
     a: SeatbeltSandboxActor = SeatbeltSandboxActor.__new__(SeatbeltSandboxActor)
     a.config = SandboxConfig(name="sandbox", role="ToolActor", team_id="test-team")
     a.state = SandboxState()
 
+    mock_probe = MagicMock(returncode=0)
     with (
         patch("akgentic.tool.sandbox.seatbelt.shutil.which", return_value="/usr/bin/sandbox-exec"),
+        patch("akgentic.tool.sandbox.seatbelt.platform.system", return_value="Darwin"),
+        patch("akgentic.tool.sandbox.seatbelt.subprocess.run", return_value=mock_probe),
         patch("pathlib.Path.mkdir"),
         patch("akgentic.tool.sandbox.actor.SandboxState.notify_state_change"),
         pytest.warns(DeprecationWarning, match="sandbox-exec is deprecated"),
@@ -101,8 +120,11 @@ def test_start_sandbox_creates_workspace_directory(
     a.config = SandboxConfig(name="sandbox", role="ToolActor", team_id="test-team")
     a.state = SandboxState()
 
+    mock_probe = MagicMock(returncode=0)
     with (
         patch("akgentic.tool.sandbox.seatbelt.shutil.which", return_value="/usr/bin/sandbox-exec"),
+        patch("akgentic.tool.sandbox.seatbelt.platform.system", return_value="Darwin"),
+        patch("akgentic.tool.sandbox.seatbelt.subprocess.run", return_value=mock_probe),
         patch("akgentic.tool.sandbox.actor.SandboxState.notify_state_change"),
         warnings.catch_warnings(),
     ):
@@ -130,8 +152,11 @@ def test_start_sandbox_idempotent_existing_workspace(
     a.config = SandboxConfig(name="sandbox", role="ToolActor", team_id="test-team")
     a.state = SandboxState()
 
+    mock_probe = MagicMock(returncode=0)
     with (
         patch("akgentic.tool.sandbox.seatbelt.shutil.which", return_value="/usr/bin/sandbox-exec"),
+        patch("akgentic.tool.sandbox.seatbelt.platform.system", return_value="Darwin"),
+        patch("akgentic.tool.sandbox.seatbelt.subprocess.run", return_value=mock_probe),
         patch("akgentic.tool.sandbox.actor.SandboxState.notify_state_change"),
         warnings.catch_warnings(),
     ):
@@ -173,6 +198,50 @@ def test_exec_writes_policy_and_calls_sandbox_exec(actor: SeatbeltSandboxActor) 
         assert cmd_list[2].endswith(".sb")
         assert "ls" in cmd_list
         assert "." in cmd_list
+
+
+# ---------------------------------------------------------------------------
+# cwd forwarding — empty cwd defaults to workspace, explicit cwd is used
+# ---------------------------------------------------------------------------
+
+
+def test_exec_empty_cwd_defaults_to_workspace(
+    actor: SeatbeltSandboxActor, tmp_path: Path
+) -> None:
+    """_exec() passes workspace_path as cwd when cwd is empty string."""
+    with patch("akgentic.tool.sandbox.seatbelt.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(stdout="", stderr="", returncode=0)
+        with patch("akgentic.tool.sandbox.seatbelt.os.unlink"):
+            actor._exec("ls .", "")
+    assert mock_run.call_args.kwargs["cwd"] == str(tmp_path)
+
+
+def test_exec_explicit_cwd_is_resolved_relative_to_workspace(
+    actor: SeatbeltSandboxActor, tmp_path: Path
+) -> None:
+    """_exec() resolves cwd as a subdirectory of the workspace path."""
+    with patch("akgentic.tool.sandbox.seatbelt.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(stdout="", stderr="", returncode=0)
+        with patch("akgentic.tool.sandbox.seatbelt.os.unlink"):
+            actor._exec("ls .", "subdir")
+    assert mock_run.call_args.kwargs["cwd"] == str(tmp_path / "subdir")
+
+
+def test_exec_missing_cwd_returns_error_result(
+    actor: SeatbeltSandboxActor, tmp_path: Path
+) -> None:
+    """_exec() returns ExecResult with exit_code=1 when cwd does not exist."""
+    with patch("akgentic.tool.sandbox.seatbelt.subprocess.run") as mock_run:
+        mock_run.side_effect = FileNotFoundError(
+            2, "No such file or directory", str(tmp_path / "nope")
+        )
+        with patch("akgentic.tool.sandbox.seatbelt.os.unlink"):
+            result = actor._exec("ls .", "nope")
+    assert result.exit_code == 1
+    assert "not found" in result.stderr.lower()
+    assert "nope" in result.stderr
+    # Must NOT leak the absolute host path
+    assert str(tmp_path) not in result.stderr
 
 
 # ---------------------------------------------------------------------------
@@ -243,24 +312,29 @@ def test_exec_policy_substitutes_workspace_path(
 # ---------------------------------------------------------------------------
 
 
-def test_exec_policy_denies_network(actor: SeatbeltSandboxActor) -> None:
-    """AC5: SBPL policy written by _exec() contains '(deny network*)'."""
+def test_exec_policy_allows_network(actor: SeatbeltSandboxActor) -> None:
+    """SBPL policy allows network access (needed for git clone, curl, wget, pip)."""
     policy = _capture_policy(actor)
-    assert "(deny network*)" in policy
+    assert "(allow network*)" in policy
+
+
+def test_exec_policy_allows_all_reads(actor: SeatbeltSandboxActor) -> None:
+    """Policy uses blanket (allow file-read*) for broad read access on macOS."""
+    policy = _capture_policy(actor)
+    assert "(allow file-read*)" in policy
 
 
 # ---------------------------------------------------------------------------
-# AC5: Policy contains file-read* and file-write* for workspace
+# AC5: Policy contains file-write* for workspace
 # ---------------------------------------------------------------------------
 
 
-def test_exec_policy_allows_workspace_read_write(
+def test_exec_policy_allows_workspace_write(
     actor: SeatbeltSandboxActor, tmp_path: Path
 ) -> None:
-    """AC5: SBPL policy contains file-read* and file-write* subpath entries for workspace."""
+    """AC5: SBPL policy contains file-write* subpath entry for workspace."""
     policy = _capture_policy(actor)
     ws = str(tmp_path)
-    assert f'(allow file-read*  (subpath "{ws}"))' in policy
     assert f'(allow file-write* (subpath "{ws}"))' in policy
 
 


### PR DESCRIPTION
## Summary
- Revise seatbelt SBPL policy to write-restricted model (allow all reads, restrict writes to workspace+tmpdir, allow network)
- Add sandbox_apply runtime probe for macOS 15+ with graceful fallback in auto-mode
- Replace hardcoded env with _make_sandbox_env() using _SAFE_ENV_KEYS frozenset (18 safe keys)
- Add cwd forwarding to SeatbeltSandboxActor._exec()
- Handle FileNotFoundError in local and seatbelt _exec() methods
- Add structured logging to all sandbox actors, downgrade auto-mode logs to DEBUG
- Improve ExecTool output format and add dynamic docstring with allowed binaries

### Code review fixes
- Remove logger.setLevel(logging.INFO) anti-pattern from actor.py and tool.py
- Update stale SeatbeltSandboxActor docstring (was claiming network denied)

Closes #110