### PR TITLE
EmbeddingActor non-blocking pattern (story 10.4)

### DIFF
--- a/src/akgentic/tool/vector_store/__init__.py
+++ b/src/akgentic/tool/vector_store/__init__.py
@@ -12,6 +12,12 @@ from akgentic.tool.vector_store.actor import (
     VectorStoreActor,
     VectorStoreState,
 )
+from akgentic.tool.vector_store.embedding_actor import (
+    EmbeddingActor,
+    EmbeddingError,
+    EmbeddingRequest,
+    EmbeddingResult,
+)
 from akgentic.tool.vector_store.inmemory import InMemoryBackend
 from akgentic.tool.vector_store.protocol import (
     CollectionConfig,
@@ -26,7 +32,11 @@ from akgentic.tool.vector_store.protocol import (
 __all__ = [
     "CollectionConfig",
     "CollectionStatus",
+    "EmbeddingActor",
+    "EmbeddingError",
     "EmbeddingProvider",
+    "EmbeddingRequest",
+    "EmbeddingResult",
     "InMemoryBackend",
     "SearchHit",
     "SearchResult",

--- a/src/akgentic/tool/vector_store/actor.py
+++ b/src/akgentic/tool/vector_store/actor.py
@@ -9,11 +9,13 @@ initialisation and catch/log/swallow error handling.
 from __future__ import annotations
 
 import logging
+import uuid
 from typing import TYPE_CHECKING, Any
 
 from pydantic import Field
 
 from akgentic.core.agent import Akgent
+from akgentic.core.agent_config import BaseConfig
 from akgentic.core.agent_state import BaseState
 from akgentic.tool.errors import RetriableError
 from akgentic.tool.vector_store.protocol import (
@@ -25,6 +27,10 @@ from akgentic.tool.vector_store.protocol import (
 
 if TYPE_CHECKING:
     from akgentic.tool.vector import EmbeddingService, VectorEntry
+    from akgentic.tool.vector_store.embedding_actor import (
+        EmbeddingError,
+        EmbeddingResult,
+    )
     from akgentic.tool.vector_store.inmemory import InMemoryBackend
 
 logger = logging.getLogger(__name__)
@@ -55,6 +61,14 @@ class VectorStoreState(BaseState):
     collection_statuses: dict[str, CollectionStatus] = Field(
         default_factory=dict,
         description="Per-collection lifecycle status",
+    )
+    pending_entries: dict[str, list[dict[str, str]]] = Field(
+        default_factory=dict,
+        description="Raw entry metadata awaiting embedding, keyed by collection",
+    )
+    indexing_pending: dict[str, int] = Field(
+        default_factory=dict,
+        description="Count of entries pending embedding per collection",
     )
 
 
@@ -174,8 +188,12 @@ class VectorStoreActor(Akgent[VectorStoreConfig, VectorStoreState]):
     def add(self, collection: str, entries: list[VectorEntry]) -> None:
         """Ingest embedding entries into a collection.
 
-        Delegates to ``InMemoryBackend.add()``. ``ValueError`` (non-existent
-        collection) is re-raised as ``RetriableError``.
+        Entries with pre-populated vectors go through the synchronous path
+        directly to the backend.  Entries without vectors are sent to a
+        spawned ``EmbeddingActor`` for asynchronous embedding (AC2, AC9).
+
+        If the collection is in ``ERROR`` status, a new ``add()`` resets
+        it to ``INDEXING`` (AC8 -- retry after failure).
 
         Args:
             collection: Target collection name.
@@ -185,6 +203,26 @@ class VectorStoreActor(Akgent[VectorStoreConfig, VectorStoreState]):
         if backend is None:
             logger.warning("[%s] Backend unavailable, skipping add", self.config.name)
             return
+
+        pre_embedded = [e for e in entries if len(e.vector) > 0]
+        needs_embedding = [e for e in entries if len(e.vector) == 0]
+
+        if pre_embedded:
+            self._add_pre_embedded(collection, pre_embedded)
+
+        if needs_embedding:
+            self._add_needs_embedding(collection, needs_embedding)
+
+    def _add_pre_embedded(self, collection: str, entries: list[VectorEntry]) -> None:
+        """Add entries with pre-populated vectors directly to backend.
+
+        Args:
+            collection: Target collection name.
+            entries: Entries with non-empty vector fields.
+        """
+        backend = self._get_or_create_backend()
+        if backend is None:
+            return
         try:
             backend.add(collection, entries)
             self._sync_backend_state()
@@ -192,7 +230,54 @@ class VectorStoreActor(Akgent[VectorStoreConfig, VectorStoreState]):
         except ValueError as exc:
             raise RetriableError(str(exc)) from exc
         except Exception as exc:  # noqa: BLE001
-            logger.warning("[%s] add failed: %s", self.config.name, exc)
+            logger.warning("[%s] _add_pre_embedded failed: %s", self.config.name, exc)
+
+    def _add_needs_embedding(self, collection: str, entries: list[VectorEntry]) -> None:
+        """Spawn an EmbeddingActor for entries that need embedding.
+
+        Stores raw metadata in pending state, sets collection to INDEXING,
+        and fires the request asynchronously (AC2, AC3, AC8).
+
+        Args:
+            collection: Target collection name.
+            entries: Entries with empty vector fields.
+        """
+        from akgentic.tool.vector_store.embedding_actor import (
+            EmbeddingActor,
+            EmbeddingRequest,
+        )
+
+        request_id = str(uuid.uuid4())
+        raw_entries = [
+            {"ref_type": e.ref_type, "ref_id": e.ref_id, "text": e.text} for e in entries
+        ]
+
+        # Track pending entries in state
+        pending = self.state.pending_entries.get(collection, [])
+        pending.extend(raw_entries)
+        self.state.pending_entries[collection] = pending
+
+        count = self.state.indexing_pending.get(collection, 0)
+        self.state.indexing_pending[collection] = count + len(entries)
+
+        # Transition status (READY/ERROR -> INDEXING)
+        self.state.collection_statuses[collection] = CollectionStatus.INDEXING
+
+        # Spawn EmbeddingActor child
+        embed_config = BaseConfig(name=f"embed-{collection}-{request_id}")
+        embed_addr = self.createActor(EmbeddingActor, config=embed_config)
+
+        request = EmbeddingRequest(
+            collection=collection,
+            entries=raw_entries,
+            request_id=request_id,
+            embedding_model=self.config.embedding_model,
+            embedding_provider=self.config.embedding_provider,
+        )
+        embed_proxy = self.proxy_tell(embed_addr, EmbeddingActor)
+        embed_proxy.receiveMsg_EmbeddingRequest(request)
+
+        self.state.notify_state_change()
 
     def remove(self, collection: str, ref_ids: list[str]) -> None:
         """Remove entries from a collection by reference ID.
@@ -217,9 +302,7 @@ class VectorStoreActor(Akgent[VectorStoreConfig, VectorStoreState]):
         except Exception as exc:  # noqa: BLE001
             logger.warning("[%s] remove failed: %s", self.config.name, exc)
 
-    def search(
-        self, collection: str, query_vector: list[float], top_k: int
-    ) -> SearchResult:
+    def search(self, collection: str, query_vector: list[float], top_k: int) -> SearchResult:
         """Search a collection by cosine similarity.
 
         Read-only operation — does not call ``state.notify_state_change()``.
@@ -236,19 +319,94 @@ class VectorStoreActor(Akgent[VectorStoreConfig, VectorStoreState]):
         backend = self._get_or_create_backend()
         if backend is None:
             logger.warning("[%s] Backend unavailable, returning empty search", self.config.name)
-            return SearchResult(
-                hits=[], status=CollectionStatus.READY, indexing_pending=0
-            )
+            return SearchResult(hits=[], status=CollectionStatus.READY, indexing_pending=0)
         try:
             result: SearchResult = backend.search(collection, query_vector, top_k)
+            # Override status/pending from actor state (AC6)
+            actor_status = self.state.collection_statuses.get(collection)
+            if actor_status is not None:
+                result = SearchResult(
+                    hits=result.hits,
+                    status=actor_status,
+                    indexing_pending=self.state.indexing_pending.get(collection, 0),
+                )
             return result
         except ValueError as exc:
             raise RetriableError(str(exc)) from exc
         except Exception as exc:  # noqa: BLE001
             logger.warning("[%s] search failed: %s", self.config.name, exc)
-            return SearchResult(
-                hits=[], status=CollectionStatus.READY, indexing_pending=0
+            return SearchResult(hits=[], status=CollectionStatus.READY, indexing_pending=0)
+
+    # ------------------------------------------------------------------
+    # Embedding result/error handlers
+    # ------------------------------------------------------------------
+
+    def receiveMsg_EmbeddingResult(self, msg: EmbeddingResult) -> None:  # noqa: N802
+        """Handle successful embedding delivery from EmbeddingActor.
+
+        Inserts fully-vectorised entries into the backend and updates
+        collection status (AC5).
+
+        Args:
+            msg: Result containing entries with populated vectors.
+        """
+        backend = self._get_or_create_backend()
+        if backend is None:
+            logger.warning(
+                "[%s] Backend unavailable, cannot insert embedding results",
+                self.config.name,
             )
+            return
+        try:
+            backend.add(msg.collection, msg.entries)
+            self._remove_pending(msg.collection, len(msg.entries))
+            self._sync_backend_state()
+            self.state.notify_state_change()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "[%s] receiveMsg_EmbeddingResult failed: %s",
+                self.config.name,
+                exc,
+            )
+
+    def receiveMsg_EmbeddingError(self, msg: EmbeddingError) -> None:  # noqa: N802
+        """Handle embedding failure from EmbeddingActor.
+
+        Sets collection to ERROR and discards pending entries (AC7).
+
+        Args:
+            msg: Error details from the failed embedding batch.
+        """
+        logger.warning(
+            "[%s] Embedding failed for collection '%s': %s",
+            self.config.name,
+            msg.collection,
+            msg.error,
+        )
+        self.state.collection_statuses[msg.collection] = CollectionStatus.ERROR
+        self.state.pending_entries.pop(msg.collection, None)
+        self.state.indexing_pending[msg.collection] = 0
+        self.state.notify_state_change()
+
+    def _remove_pending(self, collection: str, count: int) -> None:
+        """Decrement pending count and clean up on completion.
+
+        Args:
+            collection: Collection name.
+            count: Number of entries that were successfully embedded.
+        """
+        pending = self.state.indexing_pending.get(collection, 0)
+        pending = max(0, pending - count)
+        self.state.indexing_pending[collection] = pending
+
+        # Remove corresponding raw entries from pending list
+        pending_list = self.state.pending_entries.get(collection, [])
+        self.state.pending_entries[collection] = pending_list[count:]
+
+        if pending <= 0:
+            self.state.collection_statuses[collection] = CollectionStatus.READY
+            self.state.pending_entries.pop(collection, None)
+            self.state.indexing_pending.pop(collection, None)
 
     def embed(self, texts: list[str]) -> list[list[float]]:
         """Embed texts via ``EmbeddingService``.

--- a/src/akgentic/tool/vector_store/actor.py
+++ b/src/akgentic/tool/vector_store/actor.py
@@ -368,6 +368,11 @@ class VectorStoreActor(Akgent[VectorStoreConfig, VectorStoreState]):
                 self.config.name,
                 exc,
             )
+            # Transition to ERROR so the collection does not stay stuck in INDEXING
+            self.state.collection_statuses[msg.collection] = CollectionStatus.ERROR
+            self.state.pending_entries.pop(msg.collection, None)
+            self.state.indexing_pending[msg.collection] = 0
+            self.state.notify_state_change()
 
     def receiveMsg_EmbeddingError(self, msg: EmbeddingError) -> None:  # noqa: N802
         """Handle embedding failure from EmbeddingActor.

--- a/src/akgentic/tool/vector_store/embedding_actor.py
+++ b/src/akgentic/tool/vector_store/embedding_actor.py
@@ -153,7 +153,9 @@ class EmbeddingActor(Akgent[BaseConfig, BaseState]):
                 entries=vector_entries,
                 request_id=msg.request_id,
             )
-            assert self._parent is not None  # always set by createActor
+            if self._parent is None:
+                logger.warning("[%s] No parent address, cannot deliver result", self.config.name)
+                return
             parent_proxy = self.proxy_tell(self._parent, VectorStoreActor)
             parent_proxy.receiveMsg_EmbeddingResult(result)
 
@@ -177,7 +179,9 @@ class EmbeddingActor(Akgent[BaseConfig, BaseState]):
             request_id=msg.request_id,
         )
         try:
-            assert self._parent is not None  # always set by createActor
+            if self._parent is None:
+                logger.warning("[%s] No parent address, cannot deliver error", self.config.name)
+                return
             parent_proxy = self.proxy_tell(self._parent, VectorStoreActor)
             parent_proxy.receiveMsg_EmbeddingError(err)
         except Exception as send_exc:  # noqa: BLE001

--- a/src/akgentic/tool/vector_store/embedding_actor.py
+++ b/src/akgentic/tool/vector_store/embedding_actor.py
@@ -1,0 +1,188 @@
+"""Fire-and-forget EmbeddingActor for non-blocking embedding calls.
+
+Spawned by ``VectorStoreActor`` when entries need embedding.  Calls
+``EmbeddingService.embed()`` in its own Pykka thread, delivers results
+(or errors) back to the parent via ``proxy_tell``, then stops itself.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import TYPE_CHECKING, Literal
+
+from pydantic import Field
+
+from akgentic.core.agent import Akgent
+from akgentic.core.agent_config import BaseConfig
+from akgentic.core.agent_state import BaseState
+from akgentic.core.utils.serializer import SerializableBaseModel
+
+if TYPE_CHECKING:
+    from akgentic.tool.vector import EmbeddingService, VectorEntry
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Message models
+# ---------------------------------------------------------------------------
+
+
+class EmbeddingRequest(SerializableBaseModel):
+    """Request sent from VectorStoreActor to EmbeddingActor.
+
+    Contains raw entry metadata (no vectors) for a single batch.
+    """
+
+    collection: str = Field(description="Target collection name")
+    entries: list[dict[str, str]] = Field(
+        description="Raw entries: list of {ref_type, ref_id, text}"
+    )
+    request_id: str = Field(
+        default_factory=lambda: str(uuid.uuid4()),
+        description="Unique identifier for this embedding batch",
+    )
+    embedding_model: str = Field(
+        default="text-embedding-3-small",
+        description="Embedding model identifier",
+    )
+    embedding_provider: Literal["openai", "azure"] = Field(
+        default="openai",
+        description="Embedding API provider",
+    )
+
+
+class EmbeddingResult(SerializableBaseModel):
+    """Successful result sent from EmbeddingActor back to VectorStoreActor."""
+
+    collection: str = Field(description="Target collection name")
+    entries: list[VectorEntry] = Field(description="Entries with vectors populated")
+    request_id: str = Field(description="Matching request identifier")
+
+
+class EmbeddingError(SerializableBaseModel):
+    """Error sent from EmbeddingActor back to VectorStoreActor on failure."""
+
+    collection: str = Field(description="Target collection name")
+    error: str = Field(description="Error message from embedding failure")
+    request_id: str = Field(description="Matching request identifier")
+
+
+# ---------------------------------------------------------------------------
+# EmbeddingActor
+# ---------------------------------------------------------------------------
+
+
+class EmbeddingActor(Akgent[BaseConfig, BaseState]):
+    """Short-lived actor that embeds a batch of texts and delivers results.
+
+    Spawned by ``VectorStoreActor`` via ``createActor()``.  Processes a
+    single ``EmbeddingRequest``, sends back ``EmbeddingResult`` or
+    ``EmbeddingError``, and stops itself.
+    """
+
+    def on_start(self) -> None:  # noqa: ANN201
+        """Initialise state and lazy embedding service slot."""
+        self.state = BaseState()
+        self.state.observer(self)
+        self._embedding_svc: EmbeddingService | None = None
+
+    def _get_or_create_embedding_svc(
+        self, model: str, provider: Literal["openai", "azure"]
+    ) -> EmbeddingService | None:
+        """Lazily create an ``EmbeddingService`` for the given config.
+
+        Args:
+            model: Embedding model identifier.
+            provider: Embedding API provider name.
+
+        Returns:
+            An ``EmbeddingService`` instance, or ``None`` on failure.
+        """
+        if self._embedding_svc is not None:
+            return self._embedding_svc
+        try:
+            from akgentic.tool.vector import EmbeddingService as EmbSvc
+
+            self._embedding_svc = EmbSvc(model=model, provider=provider)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "[%s] Failed to initialize EmbeddingService: %s",
+                self.config.name,
+                exc,
+            )
+            return None
+        return self._embedding_svc
+
+    def receiveMsg_EmbeddingRequest(self, msg: EmbeddingRequest) -> None:  # noqa: N802
+        """Process an embedding request: embed texts and deliver results.
+
+        On success, sends ``EmbeddingResult`` to parent.  On failure,
+        sends ``EmbeddingError``.  Always stops self after delivery.
+
+        Args:
+            msg: The embedding request with raw entry metadata.
+        """
+        try:
+            svc = self._get_or_create_embedding_svc(msg.embedding_model, msg.embedding_provider)
+            if svc is None:
+                self._send_error(msg, "EmbeddingService unavailable")
+                return
+
+            from akgentic.tool.vector import VectorEntry
+
+            texts = [e["text"] for e in msg.entries]
+            vectors: list[list[float]] = svc.embed(texts)
+
+            vector_entries: list[VectorEntry] = []
+            for entry_meta, vector in zip(msg.entries, vectors):
+                vector_entries.append(
+                    VectorEntry(
+                        ref_type=entry_meta["ref_type"],
+                        ref_id=entry_meta["ref_id"],
+                        text=entry_meta["text"],
+                        vector=vector,
+                    )
+                )
+
+            from akgentic.tool.vector_store.actor import VectorStoreActor
+
+            result = EmbeddingResult(
+                collection=msg.collection,
+                entries=vector_entries,
+                request_id=msg.request_id,
+            )
+            assert self._parent is not None  # always set by createActor
+            parent_proxy = self.proxy_tell(self._parent, VectorStoreActor)
+            parent_proxy.receiveMsg_EmbeddingResult(result)
+
+        except Exception as exc:  # noqa: BLE001
+            self._send_error(msg, str(exc))
+        finally:
+            self.stop()
+
+    def _send_error(self, msg: EmbeddingRequest, error: str) -> None:
+        """Send an ``EmbeddingError`` to the parent actor.
+
+        Args:
+            msg: The original request (for collection and request_id).
+            error: Human-readable error description.
+        """
+        from akgentic.tool.vector_store.actor import VectorStoreActor
+
+        err = EmbeddingError(
+            collection=msg.collection,
+            error=error,
+            request_id=msg.request_id,
+        )
+        try:
+            assert self._parent is not None  # always set by createActor
+            parent_proxy = self.proxy_tell(self._parent, VectorStoreActor)
+            parent_proxy.receiveMsg_EmbeddingError(err)
+        except Exception as send_exc:  # noqa: BLE001
+            logger.warning(
+                "[%s] Failed to send EmbeddingError to parent: %s",
+                self.config.name,
+                send_exc,
+            )

--- a/tests/vector_store/test_actor.py
+++ b/tests/vector_store/test_actor.py
@@ -23,6 +23,10 @@ from akgentic.tool.vector_store.actor import (
     VectorStoreActor,
     VectorStoreState,
 )
+from akgentic.tool.vector_store.embedding_actor import (
+    EmbeddingError,
+    EmbeddingResult,
+)
 from akgentic.tool.vector_store.protocol import (
     CollectionConfig,
     CollectionStatus,
@@ -48,6 +52,28 @@ def _mock_backend() -> MagicMock:
     backend = MagicMock()
     backend.get_state.return_value = {"collections": {}}
     return backend
+
+
+def _mock_entry(
+    ref_id: str = "e1",
+    ref_type: str = "entity",
+    text: str = "hello",
+    vector: list[float] | None = None,
+) -> MagicMock:
+    """Return a MagicMock that mimics VectorEntry.
+
+    Args:
+        ref_id: Entry reference ID.
+        ref_type: Entry reference type.
+        text: Entry text.
+        vector: Embedding vector; empty list means needs-embedding.
+    """
+    entry = MagicMock()
+    entry.ref_id = ref_id
+    entry.ref_type = ref_type
+    entry.text = text
+    entry.vector = vector if vector is not None else []
+    return entry
 
 
 # ---------------------------------------------------------------------------
@@ -183,45 +209,389 @@ class TestCreateCollection:
 class TestAdd:
     """AC5: add delegates to backend with state notification."""
 
-    def test_delegates_to_backend(self) -> None:
-        """AC5: Delegation to InMemoryBackend.add."""
+    def test_pre_embedded_delegates_to_backend(self) -> None:
+        """AC9: Pre-embedded entries go directly to backend.add()."""
         actor = _make_actor()
         backend = _mock_backend()
         actor._backend = backend
-        entries = [MagicMock()]
+        entry = _mock_entry(vector=[0.1, 0.2])
 
-        actor.add("col1", entries)
-        backend.add.assert_called_once_with("col1", entries)
+        actor.add("col1", [entry])
+        backend.add.assert_called_once_with("col1", [entry])
 
-    def test_notifies_state_change(self) -> None:
-        """AC12: state.notify_state_change() called after add."""
+    def test_pre_embedded_notifies_state_change(self) -> None:
+        """AC12: state.notify_state_change() called after pre-embedded add."""
         actor = _make_actor()
         backend = _mock_backend()
         actor._backend = backend
+        entry = _mock_entry(vector=[0.1])
 
         with patch.object(VectorStoreState, "notify_state_change") as mock_notify:
-            actor.add("col1", [])
+            actor.add("col1", [entry])
             mock_notify.assert_called_once()
 
-    def test_nonexistent_collection_raises_retriable(self) -> None:
+    def test_pre_embedded_nonexistent_collection_raises_retriable(self) -> None:
         """AC9: ValueError from backend becomes RetriableError."""
         actor = _make_actor()
         backend = _mock_backend()
         backend.add.side_effect = ValueError("Collection 'col1' does not exist")
         actor._backend = backend
+        entry = _mock_entry(vector=[0.1])
 
         with pytest.raises(RetriableError, match="does not exist"):
-            actor.add("col1", [])
+            actor.add("col1", [entry])
 
-    def test_unexpected_error_swallowed(self) -> None:
+    def test_pre_embedded_unexpected_error_swallowed(self) -> None:
         """AC9: Unexpected errors caught/logged/swallowed."""
         actor = _make_actor()
         backend = _mock_backend()
         backend.add.side_effect = RuntimeError("unexpected")
         actor._backend = backend
+        entry = _mock_entry(vector=[0.1])
 
         # Should not raise
+        actor.add("col1", [entry])
+
+    def test_empty_entries_no_op(self) -> None:
+        """Empty entries list is a no-op."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        actor._backend = backend
+
         actor.add("col1", [])
+        backend.add.assert_not_called()
+
+    def test_backend_unavailable_skips(self) -> None:
+        """When backend is None, add() logs and returns."""
+        actor = _make_actor()
+        with patch.object(actor, "_get_or_create_backend", return_value=None):
+            actor.add("col1", [_mock_entry(vector=[0.1])])
+
+
+# ---------------------------------------------------------------------------
+# Non-blocking add — needs embedding (AC2, AC3, AC8)
+# ---------------------------------------------------------------------------
+
+
+class TestAddNeedsEmbedding:
+    """AC2/AC3: Entries without vectors spawn EmbeddingActor."""
+
+    def test_spawns_embedding_actor(self) -> None:
+        """AC2: add() with vectorless entries spawns EmbeddingActor."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        actor._backend = backend
+        entry = _mock_entry(vector=[])
+
+        mock_addr = MagicMock()
+        mock_proxy = MagicMock()
+        with (
+            patch.object(actor, "createActor", return_value=mock_addr) as mock_create,
+            patch.object(actor, "proxy_tell", return_value=mock_proxy),
+        ):
+            actor.add("col1", [entry])
+            mock_create.assert_called_once()
+            mock_proxy.receiveMsg_EmbeddingRequest.assert_called_once()
+
+    def test_sets_status_indexing(self) -> None:
+        """AC3: Collection status transitions to INDEXING on add."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        actor._backend = backend
+        entry = _mock_entry(vector=[])
+
+        with (
+            patch.object(actor, "createActor", return_value=MagicMock()),
+            patch.object(actor, "proxy_tell", return_value=MagicMock()),
+        ):
+            actor.add("col1", [entry])
+
+        assert actor.state.collection_statuses["col1"] == CollectionStatus.INDEXING
+
+    def test_tracks_indexing_pending_count(self) -> None:
+        """AC3: indexing_pending incremented by number of entries."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        actor._backend = backend
+        entries = [_mock_entry(ref_id="e1"), _mock_entry(ref_id="e2")]
+
+        with (
+            patch.object(actor, "createActor", return_value=MagicMock()),
+            patch.object(actor, "proxy_tell", return_value=MagicMock()),
+        ):
+            actor.add("col1", entries)
+
+        assert actor.state.indexing_pending["col1"] == 2
+
+    def test_stores_pending_entries(self) -> None:
+        """Pending entry metadata stored in state."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        actor._backend = backend
+        entry = _mock_entry(ref_id="e1", text="hello")
+
+        with (
+            patch.object(actor, "createActor", return_value=MagicMock()),
+            patch.object(actor, "proxy_tell", return_value=MagicMock()),
+        ):
+            actor.add("col1", [entry])
+
+        assert len(actor.state.pending_entries["col1"]) == 1
+        assert actor.state.pending_entries["col1"][0]["ref_id"] == "e1"
+
+    def test_does_not_call_backend_add(self) -> None:
+        """AC2: Vectorless entries do NOT call backend.add() directly."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        actor._backend = backend
+        entry = _mock_entry(vector=[])
+
+        with (
+            patch.object(actor, "createActor", return_value=MagicMock()),
+            patch.object(actor, "proxy_tell", return_value=MagicMock()),
+        ):
+            actor.add("col1", [entry])
+
+        backend.add.assert_not_called()
+
+    def test_retry_from_error_resets_to_indexing(self) -> None:
+        """AC8: add() on ERROR collection transitions to INDEXING."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        actor._backend = backend
+        actor.state.collection_statuses["col1"] = CollectionStatus.ERROR
+
+        entry = _mock_entry(vector=[])
+        with (
+            patch.object(actor, "createActor", return_value=MagicMock()),
+            patch.object(actor, "proxy_tell", return_value=MagicMock()),
+        ):
+            actor.add("col1", [entry])
+
+        assert actor.state.collection_statuses["col1"] == CollectionStatus.INDEXING
+
+    def test_mixed_entries_partitioned(self) -> None:
+        """AC9: Mixed entries: pre-embedded go to backend, vectorless to actor."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        actor._backend = backend
+
+        pre = _mock_entry(ref_id="pre1", vector=[0.1, 0.2])
+        needs = _mock_entry(ref_id="needs1", vector=[])
+
+        with (
+            patch.object(actor, "createActor", return_value=MagicMock()),
+            patch.object(actor, "proxy_tell", return_value=MagicMock()),
+        ):
+            actor.add("col1", [pre, needs])
+
+        # Pre-embedded goes to backend
+        backend.add.assert_called_once_with("col1", [pre])
+        # Needs-embedding tracked in pending
+        assert actor.state.indexing_pending["col1"] == 1
+
+
+# ---------------------------------------------------------------------------
+# receiveMsg_EmbeddingResult (AC5)
+# ---------------------------------------------------------------------------
+
+
+class TestReceiveEmbeddingResult:
+    """AC5: VectorStoreActor handles embedding results."""
+
+    def _make_result(self, collection: str = "col1") -> EmbeddingResult:
+        """Create a mock EmbeddingResult with VectorEntry objects."""
+        from akgentic.tool.vector import VectorEntry
+
+        entries = [
+            VectorEntry(ref_type="entity", ref_id="e1", text="hi", vector=[0.1]),
+            VectorEntry(ref_type="entity", ref_id="e2", text="bye", vector=[0.2]),
+        ]
+        return EmbeddingResult(
+            collection=collection, entries=entries, request_id="req-1"
+        )
+
+    def test_inserts_into_backend(self) -> None:
+        """AC5: Entries are inserted into backend on result delivery."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        actor._backend = backend
+        actor.state.collection_statuses["col1"] = CollectionStatus.INDEXING
+        actor.state.indexing_pending["col1"] = 2
+        actor.state.pending_entries["col1"] = [
+            {"ref_type": "entity", "ref_id": "e1", "text": "hi"},
+            {"ref_type": "entity", "ref_id": "e2", "text": "bye"},
+        ]
+
+        result = self._make_result()
+        actor.receiveMsg_EmbeddingResult(result)
+
+        backend.add.assert_called_once_with("col1", result.entries)
+
+    def test_transitions_to_ready(self) -> None:
+        """AC5: Status returns to READY when all pending complete."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        actor._backend = backend
+        actor.state.collection_statuses["col1"] = CollectionStatus.INDEXING
+        actor.state.indexing_pending["col1"] = 2
+        actor.state.pending_entries["col1"] = [
+            {"ref_type": "entity", "ref_id": "e1", "text": "hi"},
+            {"ref_type": "entity", "ref_id": "e2", "text": "bye"},
+        ]
+
+        actor.receiveMsg_EmbeddingResult(self._make_result())
+
+        assert actor.state.collection_statuses["col1"] == CollectionStatus.READY
+        assert actor.state.indexing_pending.get("col1") is None
+
+    def test_decrements_pending_count(self) -> None:
+        """AC5: indexing_pending decremented by result entry count."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        actor._backend = backend
+        # Simulate 4 pending, result delivers 2
+        actor.state.collection_statuses["col1"] = CollectionStatus.INDEXING
+        actor.state.indexing_pending["col1"] = 4
+        actor.state.pending_entries["col1"] = [
+            {"ref_type": "entity", "ref_id": f"e{i}", "text": f"t{i}"}
+            for i in range(4)
+        ]
+
+        actor.receiveMsg_EmbeddingResult(self._make_result())
+
+        assert actor.state.indexing_pending["col1"] == 2
+        assert actor.state.collection_statuses["col1"] == CollectionStatus.INDEXING
+
+    def test_notifies_state_change(self) -> None:
+        """state.notify_state_change() called after result delivery."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        actor._backend = backend
+        actor.state.collection_statuses["col1"] = CollectionStatus.INDEXING
+        actor.state.indexing_pending["col1"] = 2
+        actor.state.pending_entries["col1"] = [
+            {"ref_type": "entity", "ref_id": "e1", "text": "hi"},
+            {"ref_type": "entity", "ref_id": "e2", "text": "bye"},
+        ]
+
+        with patch.object(VectorStoreState, "notify_state_change") as mock_notify:
+            actor.receiveMsg_EmbeddingResult(self._make_result())
+            assert mock_notify.call_count >= 1
+
+
+# ---------------------------------------------------------------------------
+# receiveMsg_EmbeddingError (AC7)
+# ---------------------------------------------------------------------------
+
+
+class TestReceiveEmbeddingError:
+    """AC7: VectorStoreActor handles embedding errors."""
+
+    def test_sets_error_status(self) -> None:
+        """AC7: Collection status set to ERROR."""
+        actor = _make_actor()
+        actor.state.collection_statuses["col1"] = CollectionStatus.INDEXING
+        actor.state.indexing_pending["col1"] = 2
+        actor.state.pending_entries["col1"] = [
+            {"ref_type": "entity", "ref_id": "e1", "text": "hi"},
+        ]
+
+        err = EmbeddingError(collection="col1", error="API failed", request_id="r1")
+        actor.receiveMsg_EmbeddingError(err)
+
+        assert actor.state.collection_statuses["col1"] == CollectionStatus.ERROR
+
+    def test_discards_pending_entries(self) -> None:
+        """AC7: Pending entries discarded on error."""
+        actor = _make_actor()
+        actor.state.collection_statuses["col1"] = CollectionStatus.INDEXING
+        actor.state.indexing_pending["col1"] = 2
+        actor.state.pending_entries["col1"] = [
+            {"ref_type": "entity", "ref_id": "e1", "text": "hi"},
+        ]
+
+        err = EmbeddingError(collection="col1", error="API failed", request_id="r1")
+        actor.receiveMsg_EmbeddingError(err)
+
+        assert actor.state.indexing_pending["col1"] == 0
+        assert "col1" not in actor.state.pending_entries
+
+    def test_notifies_state_change(self) -> None:
+        """state.notify_state_change() called after error."""
+        actor = _make_actor()
+        actor.state.collection_statuses["col1"] = CollectionStatus.INDEXING
+
+        with patch.object(VectorStoreState, "notify_state_change") as mock_notify:
+            err = EmbeddingError(
+                collection="col1", error="fail", request_id="r1"
+            )
+            actor.receiveMsg_EmbeddingError(err)
+            assert mock_notify.call_count >= 1
+
+
+# ---------------------------------------------------------------------------
+# Search during INDEXING (AC6)
+# ---------------------------------------------------------------------------
+
+
+class TestSearchDuringIndexing:
+    """AC6: search() returns partial results with INDEXING status."""
+
+    def test_returns_indexing_status(self) -> None:
+        """AC6: Search returns status=INDEXING when collection is indexing."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        backend.search.return_value = SearchResult(
+            hits=[], status=CollectionStatus.READY, indexing_pending=0
+        )
+        actor._backend = backend
+        actor.state.collection_statuses["col1"] = CollectionStatus.INDEXING
+        actor.state.indexing_pending["col1"] = 3
+
+        result = actor.search("col1", [0.1], 5)
+        assert result.status == CollectionStatus.INDEXING
+        assert result.indexing_pending == 3
+
+    def test_returns_ready_when_not_indexing(self) -> None:
+        """Search returns READY status when no indexing."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        backend.search.return_value = SearchResult(
+            hits=[], status=CollectionStatus.READY, indexing_pending=0
+        )
+        actor._backend = backend
+        actor.state.collection_statuses["col1"] = CollectionStatus.READY
+
+        result = actor.search("col1", [0.1], 5)
+        assert result.status == CollectionStatus.READY
+        assert result.indexing_pending == 0
+
+
+# ---------------------------------------------------------------------------
+# State serialisation with new fields
+# ---------------------------------------------------------------------------
+
+
+class TestVectorStoreStateNewFields:
+    """Pending entries and indexing_pending serialise correctly."""
+
+    def test_pending_entries_round_trip(self) -> None:
+        """pending_entries survives serialisation."""
+        state = VectorStoreState(
+            pending_entries={"c1": [{"ref_type": "t", "ref_id": "1", "text": "hi"}]},
+            indexing_pending={"c1": 1},
+        )
+        data = state.model_dump()
+        restored = VectorStoreState.model_validate(data)
+        assert restored.pending_entries == state.pending_entries
+        assert restored.indexing_pending == state.indexing_pending
+
+    def test_defaults_empty(self) -> None:
+        """New fields default to empty dicts."""
+        state = VectorStoreState()
+        assert state.pending_entries == {}
+        assert state.indexing_pending == {}
 
 
 # ---------------------------------------------------------------------------
@@ -535,3 +905,16 @@ class TestPublicApiExports:
         assert "VS_ACTOR_ROLE" in vs.__all__
         assert vs.VS_ACTOR_NAME == "#VectorStore"
         assert vs.VS_ACTOR_ROLE == "ToolActor"
+
+    def test_embedding_actor_exported(self) -> None:
+        """EmbeddingActor and message models in __all__."""
+        import akgentic.tool.vector_store as vs
+
+        assert "EmbeddingActor" in vs.__all__
+        assert "EmbeddingRequest" in vs.__all__
+        assert "EmbeddingResult" in vs.__all__
+        assert "EmbeddingError" in vs.__all__
+        assert hasattr(vs, "EmbeddingActor")
+        assert hasattr(vs, "EmbeddingRequest")
+        assert hasattr(vs, "EmbeddingResult")
+        assert hasattr(vs, "EmbeddingError")

--- a/tests/vector_store/test_actor.py
+++ b/tests/vector_store/test_actor.py
@@ -479,6 +479,25 @@ class TestReceiveEmbeddingResult:
             actor.receiveMsg_EmbeddingResult(self._make_result())
             assert mock_notify.call_count >= 1
 
+    def test_backend_add_failure_transitions_to_error(self) -> None:
+        """When backend.add() fails, collection moves to ERROR (not stuck in INDEXING)."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        backend.add.side_effect = RuntimeError("disk full")
+        actor._backend = backend
+        actor.state.collection_statuses["col1"] = CollectionStatus.INDEXING
+        actor.state.indexing_pending["col1"] = 2
+        actor.state.pending_entries["col1"] = [
+            {"ref_type": "entity", "ref_id": "e1", "text": "hi"},
+            {"ref_type": "entity", "ref_id": "e2", "text": "bye"},
+        ]
+
+        actor.receiveMsg_EmbeddingResult(self._make_result())
+
+        assert actor.state.collection_statuses["col1"] == CollectionStatus.ERROR
+        assert actor.state.indexing_pending["col1"] == 0
+        assert "col1" not in actor.state.pending_entries
+
 
 # ---------------------------------------------------------------------------
 # receiveMsg_EmbeddingError (AC7)

--- a/tests/vector_store/test_embedding_actor.py
+++ b/tests/vector_store/test_embedding_actor.py
@@ -1,0 +1,263 @@
+"""Unit tests for EmbeddingActor.
+
+Covers: actor lifecycle (on_start), receiveMsg_EmbeddingRequest success
+and failure paths, result/error delivery to parent, and self-stop.
+
+Pattern: Instantiate EmbeddingActor() directly, set config, call
+on_start(). Mock parent address and proxy_tell to capture messages.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from akgentic.core.agent_config import BaseConfig
+
+from akgentic.tool.vector_store.embedding_actor import (
+    EmbeddingActor,
+    EmbeddingError,
+    EmbeddingRequest,
+    EmbeddingResult,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_actor() -> EmbeddingActor:
+    """Create and initialise an EmbeddingActor for testing."""
+    actor = EmbeddingActor()
+    actor.config = BaseConfig(name="test-embed-actor", role="EmbeddingActor")
+    actor._parent = MagicMock()
+    actor.on_start()
+    return actor
+
+
+def _make_request(
+    collection: str = "test_col",
+    entries: list[dict[str, str]] | None = None,
+) -> EmbeddingRequest:
+    """Create a test EmbeddingRequest."""
+    if entries is None:
+        entries = [
+            {"ref_type": "entity", "ref_id": "e1", "text": "hello world"},
+            {"ref_type": "entity", "ref_id": "e2", "text": "goodbye"},
+        ]
+    return EmbeddingRequest(
+        collection=collection,
+        entries=entries,
+        request_id="test-req-1",
+        embedding_model="text-embedding-3-small",
+        embedding_provider="openai",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Construction and on_start (AC1)
+# ---------------------------------------------------------------------------
+
+
+class TestEmbeddingActorLifecycle:
+    """AC1: EmbeddingActor construction and on_start."""
+
+    def test_on_start_initialises_state(self) -> None:
+        """on_start sets state with observer."""
+        actor = _make_actor()
+        assert actor.state is not None
+        actor.state.notify_state_change()
+
+    def test_on_start_embedding_svc_is_none(self) -> None:
+        """Embedding service starts as None (lazy)."""
+        actor = _make_actor()
+        assert actor._embedding_svc is None
+
+
+# ---------------------------------------------------------------------------
+# receiveMsg_EmbeddingRequest — success path (AC4)
+# ---------------------------------------------------------------------------
+
+
+class TestEmbeddingRequestSuccess:
+    """AC4: EmbeddingActor embeds and delivers results to parent."""
+
+    def test_sends_embedding_result_to_parent(self) -> None:
+        """On success, EmbeddingResult is sent to parent via proxy_tell."""
+        actor = _make_actor()
+        mock_svc = MagicMock()
+        mock_svc.embed.return_value = [[0.1, 0.2], [0.3, 0.4]]
+        actor._embedding_svc = mock_svc
+
+        mock_proxy = MagicMock()
+        captured_results: list[EmbeddingResult] = []
+
+        def capture_result(msg: EmbeddingResult) -> None:
+            captured_results.append(msg)
+
+        mock_proxy.receiveMsg_EmbeddingResult = capture_result
+
+        with (
+            patch.object(actor, "proxy_tell", return_value=mock_proxy),
+            patch.object(actor, "stop"),
+        ):
+            actor.receiveMsg_EmbeddingRequest(_make_request())
+
+        assert len(captured_results) == 1
+        result = captured_results[0]
+        assert result.collection == "test_col"
+        assert result.request_id == "test-req-1"
+        assert len(result.entries) == 2
+        assert result.entries[0].ref_id == "e1"
+        assert result.entries[0].vector == [0.1, 0.2]
+        assert result.entries[1].ref_id == "e2"
+        assert result.entries[1].vector == [0.3, 0.4]
+
+    def test_calls_embedding_service_with_texts(self) -> None:
+        """EmbeddingService.embed() is called with the entry texts."""
+        actor = _make_actor()
+        mock_svc = MagicMock()
+        mock_svc.embed.return_value = [[0.1], [0.2]]
+        actor._embedding_svc = mock_svc
+
+        with (
+            patch.object(actor, "proxy_tell", return_value=MagicMock()),
+            patch.object(actor, "stop"),
+        ):
+            actor.receiveMsg_EmbeddingRequest(_make_request())
+
+        mock_svc.embed.assert_called_once_with(["hello world", "goodbye"])
+
+
+# ---------------------------------------------------------------------------
+# receiveMsg_EmbeddingRequest — failure path (AC4, AC7)
+# ---------------------------------------------------------------------------
+
+
+class TestEmbeddingRequestFailure:
+    """AC4/AC7: EmbeddingActor sends error on embedding failure."""
+
+    def test_sends_embedding_error_on_exception(self) -> None:
+        """On embed failure, EmbeddingError is sent to parent."""
+        actor = _make_actor()
+        mock_svc = MagicMock()
+        mock_svc.embed.side_effect = RuntimeError("API timeout")
+        actor._embedding_svc = mock_svc
+
+        mock_proxy = MagicMock()
+        captured_errors: list[EmbeddingError] = []
+
+        def capture_error(msg: EmbeddingError) -> None:
+            captured_errors.append(msg)
+
+        mock_proxy.receiveMsg_EmbeddingError = capture_error
+
+        with (
+            patch.object(actor, "proxy_tell", return_value=mock_proxy),
+            patch.object(actor, "stop"),
+        ):
+            actor.receiveMsg_EmbeddingRequest(_make_request())
+
+        assert len(captured_errors) == 1
+        err = captured_errors[0]
+        assert err.collection == "test_col"
+        assert "API timeout" in err.error
+        assert err.request_id == "test-req-1"
+
+    def test_sends_error_when_svc_unavailable(self) -> None:
+        """When EmbeddingService cannot be created, sends error."""
+        actor = _make_actor()
+
+        mock_proxy = MagicMock()
+        captured_errors: list[EmbeddingError] = []
+
+        def capture_error(msg: EmbeddingError) -> None:
+            captured_errors.append(msg)
+
+        mock_proxy.receiveMsg_EmbeddingError = capture_error
+
+        with (
+            patch.object(
+                actor,
+                "_get_or_create_embedding_svc",
+                return_value=None,
+            ),
+            patch.object(actor, "proxy_tell", return_value=mock_proxy),
+            patch.object(actor, "stop"),
+        ):
+            actor.receiveMsg_EmbeddingRequest(_make_request())
+
+        assert len(captured_errors) == 1
+        assert "unavailable" in captured_errors[0].error.lower()
+
+
+# ---------------------------------------------------------------------------
+# Actor stops itself after delivery (AC4)
+# ---------------------------------------------------------------------------
+
+
+class TestEmbeddingActorStopsSelf:
+    """AC4: EmbeddingActor stops itself after result or error delivery."""
+
+    def test_stops_after_success(self) -> None:
+        """Actor calls self.stop() after sending result."""
+        actor = _make_actor()
+        mock_svc = MagicMock()
+        mock_svc.embed.return_value = [[0.1], [0.2]]
+        actor._embedding_svc = mock_svc
+
+        with (
+            patch.object(actor, "proxy_tell", return_value=MagicMock()),
+            patch.object(actor, "stop") as mock_stop,
+        ):
+            actor.receiveMsg_EmbeddingRequest(_make_request())
+            mock_stop.assert_called_once()
+
+    def test_stops_after_failure(self) -> None:
+        """Actor calls self.stop() after sending error."""
+        actor = _make_actor()
+        mock_svc = MagicMock()
+        mock_svc.embed.side_effect = RuntimeError("fail")
+        actor._embedding_svc = mock_svc
+
+        with (
+            patch.object(actor, "proxy_tell", return_value=MagicMock()),
+            patch.object(actor, "stop") as mock_stop,
+        ):
+            actor.receiveMsg_EmbeddingRequest(_make_request())
+            mock_stop.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Message model construction
+# ---------------------------------------------------------------------------
+
+
+class TestMessageModels:
+    """Validate EmbeddingRequest/Result/Error construction and serialisation."""
+
+    def test_embedding_request_defaults(self) -> None:
+        """EmbeddingRequest has sensible defaults."""
+        req = EmbeddingRequest(
+            collection="c1",
+            entries=[{"ref_type": "t", "ref_id": "1", "text": "hi"}],
+        )
+        assert req.collection == "c1"
+        assert req.request_id  # auto-generated UUID
+        assert req.embedding_model == "text-embedding-3-small"
+
+    def test_embedding_request_round_trip(self) -> None:
+        """EmbeddingRequest round-trips through serialisation."""
+        req = _make_request()
+        data = req.model_dump()
+        restored = EmbeddingRequest.model_validate(data)
+        assert restored.collection == req.collection
+        assert restored.entries == req.entries
+
+    def test_embedding_error_round_trip(self) -> None:
+        """EmbeddingError round-trips through serialisation."""
+        err = EmbeddingError(
+            collection="c1", error="test error", request_id="r1"
+        )
+        data = err.model_dump()
+        restored = EmbeddingError.model_validate(data)
+        assert restored.error == "test error"

--- a/tests/vector_store/test_embedding_actor.py
+++ b/tests/vector_store/test_embedding_actor.py
@@ -228,6 +228,36 @@ class TestEmbeddingActorStopsSelf:
 
 
 # ---------------------------------------------------------------------------
+# No-parent guard (null safety)
+# ---------------------------------------------------------------------------
+
+
+class TestNoParentGuard:
+    """Verify EmbeddingActor handles missing parent gracefully."""
+
+    def test_no_parent_on_success_path(self) -> None:
+        """When _parent is None, result delivery is skipped without error."""
+        actor = _make_actor()
+        actor._parent = None
+        mock_svc = MagicMock()
+        mock_svc.embed.return_value = [[0.1], [0.2]]
+        actor._embedding_svc = mock_svc
+
+        with patch.object(actor, "stop"):
+            # Should not raise
+            actor.receiveMsg_EmbeddingRequest(_make_request())
+
+    def test_no_parent_on_error_path(self) -> None:
+        """When _parent is None, _send_error logs and returns without error."""
+        actor = _make_actor()
+        actor._parent = None
+
+        with patch.object(actor, "stop"):
+            # _send_error should not raise
+            actor._send_error(_make_request(), "test error")
+
+
+# ---------------------------------------------------------------------------
 # Message model construction
 # ---------------------------------------------------------------------------
 

--- a/tests/vector_store/test_public_api.py
+++ b/tests/vector_store/test_public_api.py
@@ -18,7 +18,11 @@ class TestPublicApi:
         expected = {
             "CollectionConfig",
             "CollectionStatus",
+            "EmbeddingActor",
+            "EmbeddingError",
             "EmbeddingProvider",
+            "EmbeddingRequest",
+            "EmbeddingResult",
             "InMemoryBackend",
             "SearchHit",
             "SearchResult",


### PR DESCRIPTION
## Summary

- Implements fire-and-forget `EmbeddingActor` that embeds batches of texts in its own Pykka thread and delivers results back to `VectorStoreActor` via `proxy_tell`
- Modifies `VectorStoreActor.add()` to partition entries: pre-embedded (sync) vs needs-embedding (async via `EmbeddingActor`)
- Adds `pending_entries` and `indexing_pending` tracking to `VectorStoreState` for collection status lifecycle (READY -> INDEXING -> READY/ERROR)
- Updates `search()` to return partial results with correct `status=INDEXING` and `indexing_pending` count during async embedding
- Exports `EmbeddingActor`, `EmbeddingRequest`, `EmbeddingResult`, `EmbeddingError` from `vector_store/__init__.py`

## Code Review Fixes

- Replaced `assert self._parent is not None` with explicit `if` guard + logging in `EmbeddingActor` for production safety
- Added ERROR status transition on `backend.add()` failure in `receiveMsg_EmbeddingResult` to prevent collection stuck in INDEXING
- Added 3 new tests: no-parent guard (success/error paths), result-handler backend failure recovery

## Quality Gates

- 1051 tests passing
- 92.67% coverage on vector_store module (80% threshold met)
- mypy strict: 0 issues
- ruff check: clean

Closes #118