### PR TITLE
Workspace Persistence and Integration Tests (Story 10.5)

### DIFF
--- a/src/akgentic/tool/vector_store/actor.py
+++ b/src/akgentic/tool/vector_store/actor.py
@@ -70,6 +70,10 @@ class VectorStoreState(BaseState):
         default_factory=dict,
         description="Count of entries pending embedding per collection",
     )
+    collection_configs: dict[str, dict[str, Any]] = Field(
+        default_factory=dict,
+        description="Serialised CollectionConfig per collection (for persistence lookups)",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -156,6 +160,30 @@ class VectorStoreActor(Akgent[VectorStoreConfig, VectorStoreState]):
         if self._backend is not None:
             self.state.backend_state = self._backend.get_state()
 
+    def _save_workspace_collection(self, collection: str) -> None:
+        """Persist a workspace collection to disk if applicable.
+
+        Checks the stored ``CollectionConfig`` for the collection. If
+        ``persistence == "workspace"`` and a ``workspace_path`` is set,
+        delegates to ``InMemoryBackend.save_collection()``.
+
+        Args:
+            collection: Collection name to potentially persist.
+        """
+        cfg_data = self.state.collection_configs.get(collection, {})
+        persistence = cfg_data.get("persistence", "actor_state")
+        workspace_path = cfg_data.get("workspace_path")
+        if persistence == "workspace" and workspace_path and self._backend is not None:
+            try:
+                self._backend.save_collection(collection, workspace_path)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "[%s] _save_workspace_collection failed for '%s': %s",
+                    self.config.name,
+                    collection,
+                    exc,
+                )
+
     # ------------------------------------------------------------------
     # Proxy methods
     # ------------------------------------------------------------------
@@ -163,8 +191,9 @@ class VectorStoreActor(Akgent[VectorStoreConfig, VectorStoreState]):
     def create_collection(self, name: str, config: CollectionConfig) -> None:
         """Create or reconfigure a named collection.
 
-        Delegates to ``InMemoryBackend.create_collection()``, marks the
-        collection as ``READY``, and notifies the orchestrator.
+        For ``persistence="workspace"`` collections, delegates to
+        ``InMemoryBackend.load_collection()`` which restores from disk
+        or starts empty. Otherwise delegates to ``create_collection()``.
 
         Args:
             name: Unique collection identifier.
@@ -178,7 +207,16 @@ class VectorStoreActor(Akgent[VectorStoreConfig, VectorStoreState]):
             )
             return
         try:
-            backend.create_collection(name, config)
+            if config.persistence == "workspace" and config.workspace_path:
+                backend.load_collection(name, config, config.workspace_path)
+            else:
+                backend.create_collection(name, config)
+            self.state.collection_configs[name] = {
+                "dimension": config.dimension,
+                "backend": config.backend,
+                "persistence": config.persistence,
+                "workspace_path": config.workspace_path,
+            }
             self.state.collection_statuses[name] = CollectionStatus.READY
             self._sync_backend_state()
             self.state.notify_state_change()
@@ -226,6 +264,7 @@ class VectorStoreActor(Akgent[VectorStoreConfig, VectorStoreState]):
         try:
             backend.add(collection, entries)
             self._sync_backend_state()
+            self._save_workspace_collection(collection)
             self.state.notify_state_change()
         except ValueError as exc:
             raise RetriableError(str(exc)) from exc
@@ -296,6 +335,7 @@ class VectorStoreActor(Akgent[VectorStoreConfig, VectorStoreState]):
         try:
             backend.remove(collection, ref_ids)
             self._sync_backend_state()
+            self._save_workspace_collection(collection)
             self.state.notify_state_change()
         except ValueError as exc:
             raise RetriableError(str(exc)) from exc
@@ -361,6 +401,7 @@ class VectorStoreActor(Akgent[VectorStoreConfig, VectorStoreState]):
             backend.add(msg.collection, msg.entries)
             self._remove_pending(msg.collection, len(msg.entries))
             self._sync_backend_state()
+            self._save_workspace_collection(msg.collection)
             self.state.notify_state_change()
         except Exception as exc:  # noqa: BLE001
             logger.warning(

--- a/tests/vector_store/test_actor.py
+++ b/tests/vector_store/test_actor.py
@@ -101,6 +101,28 @@ class TestVectorStoreState:
         assert restored.backend_state == state.backend_state
         assert restored.collection_statuses == state.collection_statuses
 
+    def test_collection_configs_round_trip(self) -> None:
+        """collection_configs survives Pydantic serialisation."""
+        state = VectorStoreState(
+            collection_configs={
+                "c1": {
+                    "dimension": 128,
+                    "backend": "inmemory",
+                    "persistence": "workspace",
+                    "workspace_path": "/tmp/ws",
+                }
+            },
+        )
+        data = state.model_dump()
+        restored = VectorStoreState.model_validate(data)
+        assert restored.collection_configs == state.collection_configs
+        assert restored.collection_configs["c1"]["persistence"] == "workspace"
+
+    def test_collection_configs_defaults_empty(self) -> None:
+        """collection_configs defaults to empty dict."""
+        state = VectorStoreState()
+        assert state.collection_configs == {}
+
 
 # ---------------------------------------------------------------------------
 # Actor lifecycle (AC1, AC2, AC3, AC10)
@@ -160,6 +182,21 @@ class TestCreateCollection:
 
         actor.create_collection("test_col", CollectionConfig())
         assert actor.state.collection_statuses["test_col"] == CollectionStatus.READY
+
+    def test_populates_collection_configs(self) -> None:
+        """create_collection stores config dict in state.collection_configs."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        actor._backend = backend
+
+        config = CollectionConfig(dimension=128, persistence="workspace", workspace_path="/ws")
+        actor.create_collection("test_col", config)
+        assert "test_col" in actor.state.collection_configs
+        cfg = actor.state.collection_configs["test_col"]
+        assert cfg["dimension"] == 128
+        assert cfg["persistence"] == "workspace"
+        assert cfg["workspace_path"] == "/ws"
+        assert cfg["backend"] == "inmemory"
 
     def test_notifies_state_change(self) -> None:
         """AC12: state.notify_state_change() called after creation."""
@@ -892,6 +929,54 @@ class TestLazyBackend:
             assert result is None
         finally:
             vector_mod.EmbeddingService = original_cls  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# _save_workspace_collection error handling
+# ---------------------------------------------------------------------------
+
+
+class TestSaveWorkspaceCollection:
+    """Workspace save error handling: logs warning and does not raise."""
+
+    def test_save_logs_warning_on_backend_error(self) -> None:
+        """_save_workspace_collection catches and logs backend save failure."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        backend.save_collection.side_effect = OSError("disk full")
+        actor._backend = backend
+        actor.state.collection_configs["col1"] = {
+            "dimension": 3,
+            "backend": "inmemory",
+            "persistence": "workspace",
+            "workspace_path": "/tmp/ws",
+        }
+        # Should not raise
+        actor._save_workspace_collection("col1")
+        backend.save_collection.assert_called_once_with("col1", "/tmp/ws")
+
+    def test_save_skipped_for_actor_state_persistence(self) -> None:
+        """_save_workspace_collection is a no-op for actor_state persistence."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        actor._backend = backend
+        actor.state.collection_configs["col1"] = {
+            "dimension": 3,
+            "backend": "inmemory",
+            "persistence": "actor_state",
+            "workspace_path": None,
+        }
+        actor._save_workspace_collection("col1")
+        backend.save_collection.assert_not_called()
+
+    def test_save_skipped_for_unknown_collection(self) -> None:
+        """_save_workspace_collection is a no-op for unknown collection."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        actor._backend = backend
+        # No collection_configs entry
+        actor._save_workspace_collection("unknown_col")
+        backend.save_collection.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/vector_store/test_integration.py
+++ b/tests/vector_store/test_integration.py
@@ -1,0 +1,403 @@
+"""Integration tests for VectorStoreActor — end-to-end lifecycle validation.
+
+Covers: full lifecycle (create/add/search/remove), INDEXING-to-READY transition,
+multiple collection independence, embed delegation, idempotent create_collection,
+remove verification, and workspace npz save/load round-trip.
+
+Pattern: Direct instantiation of VectorStoreActor (no Pykka actor system),
+same approach as test_actor.py.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from akgentic.tool.vector import VectorEntry
+from akgentic.tool.vector_store.actor import (
+    VS_ACTOR_NAME,
+    VS_ACTOR_ROLE,
+    VectorStoreActor,
+)
+from akgentic.tool.vector_store.embedding_actor import EmbeddingResult
+from akgentic.tool.vector_store.protocol import (
+    CollectionConfig,
+    CollectionStatus,
+    VectorStoreConfig,
+)
+
+# Resolve forward reference for VectorEntry in EmbeddingResult
+EmbeddingResult.model_rebuild()
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_actor() -> VectorStoreActor:
+    """Instantiate a VectorStoreActor directly — no Pykka actor system."""
+    actor = VectorStoreActor()
+    actor.config = VectorStoreConfig(name=VS_ACTOR_NAME, role=VS_ACTOR_ROLE)
+    actor.on_start()
+    actor.createActor = MagicMock()  # type: ignore[assignment]
+    actor.proxy_tell = MagicMock()  # type: ignore[assignment]
+    return actor
+
+
+@pytest.fixture()
+def actor() -> VectorStoreActor:
+    """Provide a fresh VectorStoreActor for each test."""
+    return _make_actor()
+
+
+def _entry(
+    ref_id: str,
+    ref_type: str = "entity",
+    text: str = "sample",
+    vector: list[float] | None = None,
+) -> VectorEntry:
+    """Create a VectorEntry with an optional pre-populated vector."""
+    return VectorEntry(
+        ref_type=ref_type,
+        ref_id=ref_id,
+        text=text,
+        vector=vector or [],
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC3: Integration Test — Full Lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestFullLifecycle:
+    """AC3: create -> add pre-embedded -> search -> remove -> search."""
+
+    def test_full_lifecycle_create_add_search_remove(
+        self, actor: VectorStoreActor
+    ) -> None:
+        """End-to-end: create collection, add, search, remove, verify."""
+        config = CollectionConfig(dimension=3)
+        actor.create_collection("test_col", config)
+        assert actor.state.collection_statuses["test_col"] == CollectionStatus.READY
+
+        # Add pre-embedded entries
+        entries = [
+            _entry("e1", text="hello", vector=[1.0, 0.0, 0.0]),
+            _entry("e2", text="world", vector=[0.0, 1.0, 0.0]),
+            _entry("e3", text="foo", vector=[0.0, 0.0, 1.0]),
+        ]
+        actor.add("test_col", entries)
+
+        # Search — query close to e1
+        result = actor.search("test_col", [0.9, 0.1, 0.0], top_k=3)
+        assert result.status == CollectionStatus.READY
+        assert len(result.hits) == 3
+        assert result.hits[0].ref_id == "e1"
+        assert result.hits[0].ref_type == "entity"
+        assert result.hits[0].text == "hello"
+        assert result.hits[0].score > 0.0
+
+        # Remove e1
+        actor.remove("test_col", ["e1"])
+
+        # Search again — e1 should be gone
+        result2 = actor.search("test_col", [0.9, 0.1, 0.0], top_k=3)
+        ref_ids = [h.ref_id for h in result2.hits]
+        assert "e1" not in ref_ids
+        assert len(result2.hits) == 2
+
+
+# ---------------------------------------------------------------------------
+# AC4: Integration Test — INDEXING to READY
+# ---------------------------------------------------------------------------
+
+
+class TestIndexingToReady:
+    """AC4: add without vectors -> INDEXING -> deliver EmbeddingResult -> READY."""
+
+    def test_indexing_to_ready_lifecycle(self, actor: VectorStoreActor) -> None:
+        """Async lifecycle: add needs-embedding -> INDEXING -> result -> READY."""
+        config = CollectionConfig(dimension=3)
+        actor.create_collection("async_col", config)
+
+        # Add entries without vectors (triggers embedding path)
+        entries = [
+            _entry("e1", text="hello"),
+            _entry("e2", text="world"),
+        ]
+        actor.add("async_col", entries)
+
+        # Verify INDEXING status
+        assert (
+            actor.state.collection_statuses["async_col"] == CollectionStatus.INDEXING
+        )
+        assert actor.state.indexing_pending["async_col"] == 2
+
+        # Deliver EmbeddingResult manually
+        embedded_entries = [
+            VectorEntry(
+                ref_type="entity", ref_id="e1", text="hello", vector=[1.0, 0.0, 0.0]
+            ),
+            VectorEntry(
+                ref_type="entity", ref_id="e2", text="world", vector=[0.0, 1.0, 0.0]
+            ),
+        ]
+        result_msg = EmbeddingResult(
+            collection="async_col", entries=embedded_entries, request_id="req-1"
+        )
+        actor.receiveMsg_EmbeddingResult(result_msg)
+
+        # Verify READY status
+        assert actor.state.collection_statuses["async_col"] == CollectionStatus.READY
+
+        # Search returns the newly-embedded entries
+        search_result = actor.search("async_col", [0.9, 0.1, 0.0], top_k=2)
+        assert len(search_result.hits) == 2
+        assert search_result.hits[0].ref_id == "e1"
+
+
+# ---------------------------------------------------------------------------
+# AC5: Integration Test — Multiple Collections
+# ---------------------------------------------------------------------------
+
+
+class TestMultipleCollections:
+    """AC5: Multiple collections with different configs are independent."""
+
+    def test_multiple_collections_independence(
+        self, actor: VectorStoreActor
+    ) -> None:
+        """Two collections with different dimensions stay independent."""
+        config_kg = CollectionConfig(dimension=3)
+        config_plan = CollectionConfig(dimension=4)
+
+        actor.create_collection("kg", config_kg)
+        actor.create_collection("planning", config_plan)
+
+        # Add entries to each
+        actor.add("kg", [_entry("kg1", text="knowledge", vector=[1.0, 0.0, 0.0])])
+        actor.add(
+            "planning",
+            [_entry("p1", text="plan", vector=[1.0, 0.0, 0.0, 0.0])],
+        )
+
+        # Search kg — should only find kg entries
+        kg_result = actor.search("kg", [1.0, 0.0, 0.0], top_k=5)
+        assert len(kg_result.hits) == 1
+        assert kg_result.hits[0].ref_id == "kg1"
+
+        # Search planning — should only find planning entries
+        plan_result = actor.search("planning", [1.0, 0.0, 0.0, 0.0], top_k=5)
+        assert len(plan_result.hits) == 1
+        assert plan_result.hits[0].ref_id == "p1"
+
+
+# ---------------------------------------------------------------------------
+# AC6: Integration Test — embed()
+# ---------------------------------------------------------------------------
+
+
+class TestEmbedReturnsVectors:
+    """AC6: embed() delegates to EmbeddingService and returns vectors."""
+
+    def test_embed_returns_vectors(self, actor: VectorStoreActor) -> None:
+        """Mock EmbeddingService.embed -> verify correct dimension vectors."""
+        mock_svc = MagicMock()
+        mock_svc.embed.return_value = [[0.1, 0.2, 0.3]]
+        actor._embedding_svc = mock_svc
+
+        result = actor.embed(["hello"])
+
+        mock_svc.embed.assert_called_once_with(["hello"])
+        assert len(result) == 1
+        assert len(result[0]) == 3
+        assert result[0] == [0.1, 0.2, 0.3]
+
+
+# ---------------------------------------------------------------------------
+# AC7: Integration Test — Idempotent create_collection
+# ---------------------------------------------------------------------------
+
+
+class TestIdempotentCreateCollection:
+    """AC7: Second create_collection is a no-op (data preserved)."""
+
+    def test_idempotent_create_collection(self, actor: VectorStoreActor) -> None:
+        """create_collection twice -> entries from first call preserved."""
+        config = CollectionConfig(dimension=3)
+        actor.create_collection("idem_col", config)
+
+        # Add entries
+        actor.add(
+            "idem_col", [_entry("e1", text="hello", vector=[1.0, 0.0, 0.0])]
+        )
+
+        # Call create_collection again with same name
+        actor.create_collection("idem_col", config)
+
+        # Entries should still be present
+        result = actor.search("idem_col", [1.0, 0.0, 0.0], top_k=5)
+        assert len(result.hits) == 1
+        assert result.hits[0].ref_id == "e1"
+
+
+# ---------------------------------------------------------------------------
+# AC8: Integration Test — remove
+# ---------------------------------------------------------------------------
+
+
+class TestRemoveEntries:
+    """AC8: Add entries, remove subset, verify only remaining returned."""
+
+    def test_remove_entries(self, actor: VectorStoreActor) -> None:
+        """Remove subset of entries and verify search results."""
+        config = CollectionConfig(dimension=3)
+        actor.create_collection("rm_col", config)
+
+        entries = [
+            _entry("e1", text="alpha", vector=[1.0, 0.0, 0.0]),
+            _entry("e2", text="beta", vector=[0.0, 1.0, 0.0]),
+            _entry("e3", text="gamma", vector=[0.0, 0.0, 1.0]),
+        ]
+        actor.add("rm_col", entries)
+
+        # Remove e1 and e3
+        actor.remove("rm_col", ["e1", "e3"])
+
+        # Search — only e2 should remain
+        result = actor.search("rm_col", [0.0, 1.0, 0.0], top_k=5)
+        assert len(result.hits) == 1
+        assert result.hits[0].ref_id == "e2"
+        assert result.hits[0].text == "beta"
+
+
+# ---------------------------------------------------------------------------
+# AC9: Integration Test — Workspace npz Save/Load
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspacePersistenceSaveLoad:
+    """AC9: Workspace persistence round-trip via npz/json on disk."""
+
+    def test_workspace_persistence_save_load(
+        self, tmp_path: Path
+    ) -> None:
+        """Create workspace collection, add entries, verify disk files, reload."""
+        actor = _make_actor()
+        config = CollectionConfig(
+            dimension=3,
+            persistence="workspace",
+            workspace_path=str(tmp_path),
+        )
+        actor.create_collection("ws_col", config)
+
+        # Add pre-embedded entries
+        entries = [
+            _entry("e1", text="hello", vector=[1.0, 0.0, 0.0]),
+            _entry("e2", text="world", vector=[0.0, 1.0, 0.0]),
+        ]
+        actor.add("ws_col", entries)
+
+        # Verify files on disk
+        vs_dir = tmp_path / ".vector_store"
+        assert (vs_dir / "ws_col.npz").exists()
+        assert (vs_dir / "ws_col.json").exists()
+
+        # Search original actor to confirm data
+        result1 = actor.search("ws_col", [1.0, 0.0, 0.0], top_k=5)
+        assert len(result1.hits) == 2
+        assert result1.hits[0].ref_id == "e1"
+
+        # Create a new actor and load from disk
+        actor2 = _make_actor()
+        config2 = CollectionConfig(
+            dimension=3,
+            persistence="workspace",
+            workspace_path=str(tmp_path),
+        )
+        actor2.create_collection("ws_col", config2)
+
+        # Search restored actor — all entries should be present
+        result2 = actor2.search("ws_col", [1.0, 0.0, 0.0], top_k=5)
+        assert len(result2.hits) == 2
+        assert result2.hits[0].ref_id == "e1"
+        assert result2.hits[0].text == "hello"
+        assert result2.hits[0].score > 0.0
+
+        # Verify scores match
+        assert abs(result1.hits[0].score - result2.hits[0].score) < 1e-6
+
+    def test_workspace_save_triggered_on_remove(
+        self, tmp_path: Path
+    ) -> None:
+        """Remove triggers save — verify updated files on disk."""
+        actor = _make_actor()
+        config = CollectionConfig(
+            dimension=3,
+            persistence="workspace",
+            workspace_path=str(tmp_path),
+        )
+        actor.create_collection("ws_rm", config)
+
+        entries = [
+            _entry("e1", text="hello", vector=[1.0, 0.0, 0.0]),
+            _entry("e2", text="world", vector=[0.0, 1.0, 0.0]),
+        ]
+        actor.add("ws_rm", entries)
+
+        # Remove one entry
+        actor.remove("ws_rm", ["e1"])
+
+        # Load from disk in new actor — only e2 should be present
+        actor2 = _make_actor()
+        config2 = CollectionConfig(
+            dimension=3,
+            persistence="workspace",
+            workspace_path=str(tmp_path),
+        )
+        actor2.create_collection("ws_rm", config2)
+
+        result = actor2.search("ws_rm", [0.0, 1.0, 0.0], top_k=5)
+        assert len(result.hits) == 1
+        assert result.hits[0].ref_id == "e2"
+
+    def test_workspace_save_on_embedding_result(
+        self, tmp_path: Path
+    ) -> None:
+        """EmbeddingResult delivery triggers workspace save."""
+        actor = _make_actor()
+        config = CollectionConfig(
+            dimension=3,
+            persistence="workspace",
+            workspace_path=str(tmp_path),
+        )
+        actor.create_collection("ws_embed", config)
+
+        # Simulate async add (needs embedding)
+        entries = [_entry("e1", text="hello")]
+        actor.add("ws_embed", entries)
+
+        # Deliver embedding result
+        embedded = [
+            VectorEntry(
+                ref_type="entity", ref_id="e1", text="hello", vector=[1.0, 0.0, 0.0]
+            ),
+        ]
+        result_msg = EmbeddingResult(
+            collection="ws_embed", entries=embedded, request_id="req-1"
+        )
+        actor.receiveMsg_EmbeddingResult(result_msg)
+
+        # Verify files exist
+        vs_dir = tmp_path / ".vector_store"
+        assert (vs_dir / "ws_embed.npz").exists()
+
+        # Load in new actor
+        actor2 = _make_actor()
+        actor2.create_collection("ws_embed", config)
+        result = actor2.search("ws_embed", [1.0, 0.0, 0.0], top_k=5)
+        assert len(result.hits) == 1
+        assert result.hits[0].ref_id == "e1"


### PR DESCRIPTION
## Summary

- Wire workspace persistence into VectorStoreActor: create_collection uses load_collection for workspace mode, _save_workspace_collection called after every mutation (add, remove, EmbeddingResult)
- Add collection_configs field to VectorStoreState for persistence mode lookups
- 9 integration tests covering full lifecycle, INDEXING-to-READY, multiple collections, embed delegation, idempotent create, remove, and workspace npz save/load round-trip
- Code review: added 6 unit tests for collection_configs serialisation, create_collection config population, and _save_workspace_collection error handling

## Test Results

- 1066/1066 tests pass
- 93.85% coverage on vector_store package (>= 80% required)
- mypy strict: 0 errors
- ruff: all checks passed

Closes #120