### PR TITLE
KnowledgeGraphActor migration to VectorStoreActor

### DIFF
--- a/src/akgentic/tool/knowledge_graph/__init__.py
+++ b/src/akgentic/tool/knowledge_graph/__init__.py
@@ -55,14 +55,7 @@ from akgentic.tool.knowledge_graph.models import (
     SearchQuery,
     SearchResult,
 )
-from akgentic.tool.vector import (
-    EmbeddingService,
-    VectorEntry,
-    VectorIndex,
-)
-from akgentic.tool.vector import (
-    _check_vector_search_dependencies as _check_kg_dependencies,
-)
+from akgentic.tool.vector import _check_vector_search_dependencies as _check_kg_dependencies
 
 __all__ = [
     # Core domain models
@@ -83,8 +76,6 @@ __all__ = [
     "SearchQuery",
     "SearchHit",
     "SearchResult",
-    # Vector index models (Story 2.1)
-    "VectorEntry",
     # ToolCard (Story 1.3)
     "KnowledgeGraphTool",
     "GetGraph",
@@ -95,9 +86,6 @@ __all__ = [
     "KnowledgeGraphConfig",
     "KG_ACTOR_NAME",
     "KG_ACTOR_ROLE",
-    # Vector index services (Story 2.1)
-    "EmbeddingService",
-    "VectorIndex",
     # Utilities
     "_check_kg_dependencies",
 ]

--- a/src/akgentic/tool/knowledge_graph/kg_actor.py
+++ b/src/akgentic/tool/knowledge_graph/kg_actor.py
@@ -12,12 +12,10 @@ from __future__ import annotations
 import logging
 import uuid
 from collections import deque
-from typing import Literal
-
-from pydantic import Field
 
 from akgentic.core.agent import Akgent
 from akgentic.core.agent_config import BaseConfig
+from akgentic.core.orchestrator import Orchestrator
 from akgentic.tool.errors import RetriableError
 from akgentic.tool.knowledge_graph.models import (
     Entity,
@@ -35,7 +33,10 @@ from akgentic.tool.knowledge_graph.models import (
     SearchQuery,
     SearchResult,
 )
-from akgentic.tool.vector import EmbeddingService, VectorEntry, VectorIndex
+from akgentic.tool.vector import VectorEntry
+from akgentic.tool.vector_store.actor import VS_ACTOR_NAME, VectorStoreActor
+from akgentic.tool.vector_store.protocol import CollectionConfig
+from akgentic.tool.vector_store.protocol import SearchResult as VsSearchResult
 
 logger = logging.getLogger(__name__)
 
@@ -45,22 +46,16 @@ KG_ACTOR_NAME: str = "#KnowledgeGraphTool"
 KG_ACTOR_ROLE: str = "ToolActor"
 """Actor role constant for ToolCard integration."""
 
+KG_COLLECTION: str = "knowledge_graph"
+"""Collection name used in VectorStoreActor."""
+
 
 class KnowledgeGraphConfig(BaseConfig):
-    """Configuration for ``KnowledgeGraphActor`` with embedding provider settings.
+    """Configuration for ``KnowledgeGraphActor``.
 
-    Extends ``BaseConfig`` with the embedding model and provider fields so
-    the actor can initialize ``EmbeddingService`` from its config object.
+    An empty ``BaseConfig`` subclass retained for type stability
+    (the actor generic parameter still references it).
     """
-
-    embedding_model: str = Field(
-        default="text-embedding-3-small",
-        description="OpenAI embedding model identifier",
-    )
-    embedding_provider: Literal["openai", "azure"] = Field(
-        default="openai",
-        description="Which OpenAI SDK variant to use for embeddings",
-    )
 
 
 class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
@@ -81,54 +76,69 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
     # ------------------------------------------------------------------
 
     def on_start(self) -> None:  # noqa: ANN201
-        """Initialize state, attach observer, and set up the vector index."""
+        """Initialize state, attach observer, and acquire VectorStoreActor proxy."""
         self.state = KnowledgeGraphState()
         self.state.observer(self)
-        self._vector_index = VectorIndex()
-        self._embedding_svc: EmbeddingService | None = None
+        self._vs_proxy: VectorStoreActor | None = None
+        self._acquire_vs_proxy()
 
-    # ------------------------------------------------------------------
-    # Embedding helpers
-    # ------------------------------------------------------------------
+    def _acquire_vs_proxy(self) -> None:
+        """Acquire the VectorStoreActor proxy and create the KG collection.
 
-    def _get_or_create_embedding_svc(self) -> EmbeddingService | None:
-        """Return the ``EmbeddingService``, creating it lazily on first call.
-
-        Returns:
-            The service instance, or ``None`` if creation fails (e.g. missing deps).
+        Operates in degraded mode (no vector search) if the proxy cannot
+        be acquired.
         """
-        if self._embedding_svc is None:
-            try:
-                self._embedding_svc = EmbeddingService(
-                    model=self.config.embedding_model,
-                    provider=self.config.embedding_provider,
-                )
-            except Exception as exc:  # noqa: BLE001
+        try:
+            if self.orchestrator is None:
                 logger.warning(
-                    "[%s] Failed to initialize EmbeddingService: %s", self.config.name, exc
+                    "[%s] No orchestrator; operating in degraded mode",
+                    self.config.name,
                 )
-                return None
-        return self._embedding_svc
+                return
+            orch_proxy = self.proxy_ask(self.orchestrator, Orchestrator)
+            vs_addr = orch_proxy.get_team_member(VS_ACTOR_NAME)
+            if vs_addr is None:
+                logger.warning(
+                    "[%s] VectorStoreActor not found; operating in degraded mode",
+                    self.config.name,
+                )
+                return
+            self._vs_proxy = self.proxy_ask(vs_addr, VectorStoreActor)
+            self._vs_proxy.create_collection(KG_COLLECTION, CollectionConfig())
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "[%s] Failed to acquire VectorStoreActor proxy: %s",
+                self.config.name,
+                exc,
+            )
+
+    # ------------------------------------------------------------------
+    # Embedding helpers (via VectorStoreActor proxy)
+    # ------------------------------------------------------------------
 
     def _embed_entity(self, entity: Entity) -> None:
-        """Embed an entity and store the result in the vector index.
+        """Embed an entity and store the result via VectorStoreActor proxy.
 
-        Silently logs a WARNING and returns if the embedding service is
-        unavailable or if the API call fails (AC-7).
+        Silently logs a WARNING and returns if the proxy is unavailable
+        or if the embedding call fails.
         """
-        svc = self._get_or_create_embedding_svc()
-        if svc is None:
+        if self._vs_proxy is None:
             return
         try:
             text = f"{entity.name}: {entity.description}"
-            vectors = svc.embed([text])
-            self._vector_index.add(
-                VectorEntry(
-                    ref_type="entity",
-                    ref_id=str(entity.id),
-                    text=text,
-                    vector=vectors[0],
-                )
+            vectors = self._vs_proxy.embed([text])
+            if not vectors:
+                return
+            self._vs_proxy.add(
+                KG_COLLECTION,
+                [
+                    VectorEntry(
+                        ref_type="entity",
+                        ref_id=str(entity.id),
+                        text=text,
+                        vector=vectors[0],
+                    )
+                ],
             )
         except Exception as exc:  # noqa: BLE001
             logger.warning(
@@ -139,30 +149,34 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
         """Embed a relation if it has a non-empty description.
 
         Relations without descriptions are not embedded (no meaningful text).
-        Silently logs WARNING on embedding failure (AC-7).
+        Silently logs WARNING on embedding failure.
         """
         if not relation.description:
             return
-        svc = self._get_or_create_embedding_svc()
-        if svc is None:
+        if self._vs_proxy is None:
             return
         try:
             text = (
                 f"{relation.from_entity} {relation.relation_type} "
                 f"{relation.to_entity}: {relation.description}"
             )
-            vectors = svc.embed([text])
-            self._vector_index.add(
-                VectorEntry(
-                    ref_type="relation",
-                    ref_id=str(relation.id),
-                    text=text,
-                    vector=vectors[0],
-                )
+            vectors = self._vs_proxy.embed([text])
+            if not vectors:
+                return
+            self._vs_proxy.add(
+                KG_COLLECTION,
+                [
+                    VectorEntry(
+                        ref_type="relation",
+                        ref_id=str(relation.id),
+                        text=text,
+                        vector=vectors[0],
+                    )
+                ],
             )
         except Exception as exc:  # noqa: BLE001
             logger.warning(
-                "[%s] Failed to embed relation '%s→%s': %s",
+                "[%s] Failed to embed relation '%s->%s': %s",
                 self.config.name,
                 relation.from_entity,
                 relation.to_entity,
@@ -273,7 +287,8 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
                 continue
 
             if eu.description is not None and eu.description != entity.description:
-                self._vector_index.remove({str(entity.id)})
+                if self._vs_proxy is not None:
+                    self._vs_proxy.remove(KG_COLLECTION, [str(entity.id)])
                 entity.description = eu.description
                 self._embed_entity(entity)
             elif eu.description is not None:
@@ -335,9 +350,11 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
                 if r.from_entity not in names_set and r.to_entity not in names_set
             ]
 
-            self._vector_index.remove(
-                {str(eid) for eid in _deleted_ids} | {str(rid) for rid in _deleted_rel_ids}
-            )
+            if self._vs_proxy is not None:
+                ref_ids = [str(eid) for eid in _deleted_ids] + [
+                    str(rid) for rid in _deleted_rel_ids
+                ]
+                self._vs_proxy.remove(KG_COLLECTION, ref_ids)
 
         return errors
 
@@ -379,7 +396,8 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
                 if (r.from_entity, r.to_entity, r.relation_type) not in triples_to_delete
             ]
 
-            self._vector_index.remove({str(rid) for rid in _deleted_rel_ids})
+            if self._vs_proxy is not None:
+                self._vs_proxy.remove(KG_COLLECTION, [str(rid) for rid in _deleted_rel_ids])
 
         return errors
 
@@ -684,8 +702,8 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
     def _vector_search(self, query_text: str, top_k: int) -> SearchResult:
         """Embed ``query_text`` and return top-k results by cosine similarity.
 
-        Returns an empty ``SearchResult`` when the embedding service is
-        unavailable, the index is empty, or the embedding call fails.
+        Returns an empty ``SearchResult`` when the VectorStoreActor proxy is
+        unavailable or the embedding call fails.
 
         Args:
             query_text: The natural-language query to embed and search.
@@ -694,17 +712,26 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
         Returns:
             ``SearchResult`` with hits ranked by cosine similarity score.
         """
-        svc = self._get_or_create_embedding_svc()
-        if svc is None or len(self._vector_index) == 0:
+        if self._vs_proxy is None:
             return SearchResult(hits=[])
         try:
-            vectors = svc.embed([query_text])
+            vectors = self._vs_proxy.embed([query_text])
+            if not vectors:
+                return SearchResult(hits=[])
             query_vector = vectors[0]
         except Exception as exc:  # noqa: BLE001
             logger.warning("[%s] Vector search embedding failed: %s", self.config.name, exc)
             return SearchResult(hits=[])
 
-        pairs = self._vector_index.search_cosine(query_vector, top_k)
+        try:
+            vs_result: VsSearchResult = self._vs_proxy.search(
+                KG_COLLECTION, query_vector, top_k
+            )
+            pairs = [(hit.ref_id, hit.score) for hit in vs_result.hits]
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[%s] Vector search failed: %s", self.config.name, exc)
+            return SearchResult(hits=[])
+
         hits: list[SearchHit] = []
         for ref_id, score in pairs:
             obj = self._resolve_ref(ref_id)

--- a/src/akgentic/tool/knowledge_graph/kg_actor.py
+++ b/src/akgentic/tool/knowledge_graph/kg_actor.py
@@ -291,8 +291,6 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
                     self._vs_proxy.remove(KG_COLLECTION, [str(entity.id)])
                 entity.description = eu.description
                 self._embed_entity(entity)
-            elif eu.description is not None:
-                entity.description = eu.description
             if eu.entity_type is not None:
                 entity.entity_type = eu.entity_type
             if eu.is_root is not None:
@@ -311,7 +309,7 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
     def _delete_entities(self, names: list[str]) -> list[str]:
         """Remove entities by name with cascade deletion of relations.
 
-        Also removes any associated VectorEntry embeddings from the vector index.
+        Also removes any associated VectorEntry embeddings from VectorStoreActor.
 
         Returns:
             List of error strings for entities not found.
@@ -361,7 +359,7 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
     def _delete_relations(self, deletions: list[RelationDelete]) -> list[str]:
         """Remove relations by ``(from_entity, to_entity, relation_type)`` triple.
 
-        Also removes any associated VectorEntry embeddings from the vector index.
+        Also removes any associated VectorEntry embeddings from VectorStoreActor.
 
         Returns:
             List of error strings for relations not found.

--- a/src/akgentic/tool/knowledge_graph/kg_tool.py
+++ b/src/akgentic/tool/knowledge_graph/kg_tool.py
@@ -38,6 +38,8 @@ from akgentic.tool.knowledge_graph.models import (
     SearchQuery,
     SearchResult,
 )
+from akgentic.tool.vector_store.actor import VS_ACTOR_NAME, VectorStoreActor
+from akgentic.tool.vector_store.protocol import VectorStoreConfig
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -114,8 +116,8 @@ class KnowledgeGraphTool(ToolCard):
     def observer(self, observer: ActorToolObserver) -> None:  # type: ignore[override]
         """Attach observer and set up the KG actor proxy.
 
-        Creates/retrieves the singleton ``KnowledgeGraphActor`` via the
-        orchestrator, identical to PlanningTool's observer pattern.
+        Ensures the ``VectorStoreActor`` singleton exists (AC10) before
+        creating/retrieving the ``KnowledgeGraphActor`` singleton.
         """
         from akgentic.tool.knowledge_graph import _check_kg_dependencies
 
@@ -126,8 +128,23 @@ class KnowledgeGraphTool(ToolCard):
             raise ValueError("KnowledgeGraphTool requires access to the orchestrator.")
 
         orchestrator_proxy = observer.proxy_ask(observer.orchestrator, Orchestrator)
-        kg_addr = orchestrator_proxy.get_team_member(KG_ACTOR_NAME)
 
+        # Ensure VectorStoreActor singleton exists (AC10)
+        vs_addr = orchestrator_proxy.get_team_member(VS_ACTOR_NAME)
+        if vs_addr is None:
+            logger.info("KnowledgeGraphTool: creating singleton %s.", VS_ACTOR_NAME)
+            vs_addr = orchestrator_proxy.createActor(
+                VectorStoreActor,
+                config=VectorStoreConfig(
+                    name=VS_ACTOR_NAME,
+                    role="ToolActor",
+                    embedding_model=self.embedding_model,
+                    embedding_provider=self.embedding_provider,
+                ),
+            )
+
+        # Create/retrieve KnowledgeGraphActor singleton
+        kg_addr = orchestrator_proxy.get_team_member(KG_ACTOR_NAME)
         if kg_addr is None:
             logger.info("KnowledgeGraphTool: creating singleton %s.", KG_ACTOR_NAME)
             kg_addr = orchestrator_proxy.createActor(
@@ -135,8 +152,6 @@ class KnowledgeGraphTool(ToolCard):
                 config=KnowledgeGraphConfig(
                     name=KG_ACTOR_NAME,
                     role=KG_ACTOR_ROLE,
-                    embedding_model=self.embedding_model,
-                    embedding_provider=self.embedding_provider,
                 ),
             )
 

--- a/src/akgentic/tool/knowledge_graph/models.py
+++ b/src/akgentic/tool/knowledge_graph/models.py
@@ -16,7 +16,6 @@ from pydantic import Field
 
 from akgentic.core.agent_state import BaseState
 from akgentic.core.utils.serializer import SerializableBaseModel
-from akgentic.tool.vector import VectorEntry as VectorEntry  # re-exported for KG consumers
 
 # ---------------------------------------------------------------------------
 # Core domain models

--- a/src/akgentic/tool/knowledge_graph/vector_index.py
+++ b/src/akgentic/tool/knowledge_graph/vector_index.py
@@ -1,5 +1,0 @@
-"""Backward-compat shim — import from akgentic.tool.vector instead."""
-
-from akgentic.tool.vector import EmbeddingService, VectorIndex  # noqa: F401
-
-__all__ = ["EmbeddingService", "VectorIndex"]

--- a/tests/test_kg_actor.py
+++ b/tests/test_kg_actor.py
@@ -2,13 +2,13 @@
 
 Covers: all CRUD ops, cascade deletion, error collection, partial updates,
 state change notification, deduplication logic, singleton constants (Task 2.9).
-Also covers embedding wiring: entity/relation embedding on create, re-embedding
-on description update, removal on delete, graceful degradation on API failure
-(Task 5.11, Story 2.1 ACs 3-7).
-Also covers vector search and hybrid search (Story 2.2 ACs 1-5).
+Also covers embedding wiring via VectorStoreActor proxy: entity/relation
+embedding on create, re-embedding on description update, removal on delete,
+graceful degradation on API failure.
+Also covers vector search and hybrid search.
 
 Pattern: Instantiate KnowledgeGraphActor() directly, call on_start(),
-test methods. Same pattern as test_planning_actor.py.
+test methods.  The VectorStoreActor proxy is mocked.
 """
 
 from __future__ import annotations
@@ -23,6 +23,7 @@ from akgentic.tool.errors import RetriableError
 from akgentic.tool.knowledge_graph.kg_actor import (
     KG_ACTOR_NAME,
     KG_ACTOR_ROLE,
+    KG_COLLECTION,
     KnowledgeGraphActor,
     KnowledgeGraphConfig,
 )
@@ -35,6 +36,9 @@ from akgentic.tool.knowledge_graph.models import (
     RelationDelete,
     SearchQuery,
 )
+from akgentic.tool.vector_store.protocol import CollectionStatus
+from akgentic.tool.vector_store.protocol import SearchHit as VsSearchHit
+from akgentic.tool.vector_store.protocol import SearchResult as VsSearchResult
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -89,9 +93,18 @@ class MockActorAddress(ActorAddress):
 
 
 def _actor() -> KnowledgeGraphActor:
-    """Create and initialize a KnowledgeGraphActor for testing."""
+    """Create and initialize a KnowledgeGraphActor for testing.
+
+    The VectorStoreActor proxy is not available (degraded mode) -- suitable
+    for pure CRUD tests that do not need embedding.
+    """
+    from akgentic.tool.knowledge_graph.models import KnowledgeGraphState
+
     actor = KnowledgeGraphActor()
-    actor.on_start()
+    # Bypass _acquire_vs_proxy (no orchestrator in unit tests)
+    actor.state = KnowledgeGraphState()
+    actor.state.observer(actor)
+    actor._vs_proxy = None
     return actor
 
 
@@ -128,25 +141,22 @@ def _seed_with_relation(actor: KnowledgeGraphActor) -> None:
 
 
 class TestKnowledgeGraphConfig:
-    """AC-1: KnowledgeGraphConfig extends BaseConfig with embedding settings."""
+    """AC-8: KnowledgeGraphConfig is an empty BaseConfig subclass."""
 
-    def test_default_embedding_model(self) -> None:
+    def test_config_is_base_config_subclass(self) -> None:
+        from akgentic.core.agent_config import BaseConfig
+
+        assert issubclass(KnowledgeGraphConfig, BaseConfig)
+
+    def test_config_creates_with_name_and_role(self) -> None:
         cfg = KnowledgeGraphConfig(name="test", role="ToolActor")
-        assert cfg.embedding_model == "text-embedding-3-small"
+        assert cfg.name == "test"
+        assert cfg.role == "ToolActor"
 
-    def test_default_embedding_provider(self) -> None:
+    def test_config_has_no_embedding_fields(self) -> None:
         cfg = KnowledgeGraphConfig(name="test", role="ToolActor")
-        assert cfg.embedding_provider == "openai"
-
-    def test_custom_embedding_model(self) -> None:
-        cfg = KnowledgeGraphConfig(
-            name="test", role="ToolActor", embedding_model="text-embedding-ada-002"
-        )
-        assert cfg.embedding_model == "text-embedding-ada-002"
-
-    def test_azure_provider(self) -> None:
-        cfg = KnowledgeGraphConfig(name="test", role="ToolActor", embedding_provider="azure")
-        assert cfg.embedding_provider == "azure"
+        assert not hasattr(cfg, "embedding_model")
+        assert not hasattr(cfg, "embedding_provider")
 
 
 # ---------------------------------------------------------------------------
@@ -646,23 +656,34 @@ class TestIsRootWiring:
 # ---------------------------------------------------------------------------
 
 _FAKE_VECTOR = [0.1, 0.2, 0.3]
-_EMBED_MODULE = "akgentic.tool.knowledge_graph.kg_actor.EmbeddingService"
+
+
+def _make_mock_vs_proxy() -> MagicMock:
+    """Create a mock VectorStoreActor proxy with default return values."""
+    proxy = MagicMock()
+    proxy.embed.return_value = [_FAKE_VECTOR]
+    proxy.add.return_value = None
+    proxy.remove.return_value = None
+    proxy.create_collection.return_value = None
+    proxy.search.return_value = VsSearchResult(
+        hits=[], status=CollectionStatus.READY, indexing_pending=0
+    )
+    return proxy
 
 
 def _actor_with_mock_embed() -> tuple[KnowledgeGraphActor, MagicMock]:
-    """Return (actor, mock_embed_method) with a pre-wired mock EmbeddingService."""
+    """Return (actor, mock_vs_proxy) with a pre-wired mock VectorStoreActor proxy."""
     actor = _actor()
-    mock_svc = MagicMock()
-    mock_svc.embed.return_value = [_FAKE_VECTOR]
-    actor._embedding_svc = mock_svc  # inject mock directly, bypassing lazy init
-    return actor, mock_svc
+    mock_proxy = _make_mock_vs_proxy()
+    actor._vs_proxy = mock_proxy
+    return actor, mock_proxy
 
 
 class TestEmbeddingOnCreate:
-    """AC-3, AC-4: embedding called when entities/relations are created."""
+    """AC-4, AC-6: embedding called when entities/relations are created via vs_proxy."""
 
     def test_embedding_called_on_entity_create(self) -> None:
-        actor, mock_svc = _actor_with_mock_embed()
+        actor, mock_proxy = _actor_with_mock_embed()
         actor.update_graph(
             ManageGraph(
                 create_entities=[
@@ -670,15 +691,29 @@ class TestEmbeddingOnCreate:
                 ]
             )
         )
-        mock_svc.embed.assert_called_once()
-        call_args = mock_svc.embed.call_args[0][0]
+        mock_proxy.embed.assert_called_once()
+        call_args = mock_proxy.embed.call_args[0][0]
         assert "Alice" in call_args[0]
         assert "Eng" in call_args[0]
 
+    def test_add_called_on_entity_create(self) -> None:
+        actor, mock_proxy = _actor_with_mock_embed()
+        actor.update_graph(
+            ManageGraph(
+                create_entities=[
+                    EntityCreate(name="Alice", entity_type="Person", description="Eng")
+                ]
+            )
+        )
+        mock_proxy.add.assert_called_once()
+        call_args = mock_proxy.add.call_args
+        assert call_args[0][0] == KG_COLLECTION
+
     def test_embedding_called_on_relation_create_with_description(self) -> None:
-        actor, mock_svc = _actor_with_mock_embed()
+        actor, mock_proxy = _actor_with_mock_embed()
         _seed_entities(actor)
-        mock_svc.reset_mock()
+        mock_proxy.reset_mock()
+        mock_proxy.embed.return_value = [_FAKE_VECTOR]
         actor.update_graph(
             ManageGraph(
                 create_relations=[
@@ -691,14 +726,14 @@ class TestEmbeddingOnCreate:
                 ]
             )
         )
-        mock_svc.embed.assert_called_once()
-        call_args = mock_svc.embed.call_args[0][0]
+        mock_proxy.embed.assert_called_once()
+        call_args = mock_proxy.embed.call_args[0][0]
         assert "long colleagues" in call_args[0]
 
     def test_embedding_skipped_on_relation_create_empty_description(self) -> None:
-        actor, mock_svc = _actor_with_mock_embed()
+        actor, mock_proxy = _actor_with_mock_embed()
         _seed_entities(actor)
-        mock_svc.reset_mock()
+        mock_proxy.reset_mock()
         actor.update_graph(
             ManageGraph(
                 create_relations=[
@@ -706,14 +741,14 @@ class TestEmbeddingOnCreate:
                 ]
             )
         )
-        mock_svc.embed.assert_not_called()
+        mock_proxy.embed.assert_not_called()
 
 
 class TestEmbeddingOnUpdate:
-    """AC-5: re-embedding on description change."""
+    """AC-5: re-embedding on description change via vs_proxy."""
 
     def test_embedding_updated_on_description_change(self) -> None:
-        actor, mock_svc = _actor_with_mock_embed()
+        actor, mock_proxy = _actor_with_mock_embed()
         actor.update_graph(
             ManageGraph(
                 create_entities=[
@@ -721,17 +756,17 @@ class TestEmbeddingOnUpdate:
                 ]
             )
         )
-        embed_count_before = mock_svc.embed.call_count
+        embed_count_before = mock_proxy.embed.call_count
         actor.update_graph(
             ManageGraph(update_entities=[EntityUpdate(name="Alice", description="Senior Eng")])
         )
-        assert mock_svc.embed.call_count == embed_count_before + 1
+        assert mock_proxy.embed.call_count == embed_count_before + 1
         # Verify the new description is embedded, not the old one
-        last_call = mock_svc.embed.call_args[0][0]
+        last_call = mock_proxy.embed.call_args[0][0]
         assert "Senior Eng" in last_call[0]
 
-    def test_no_re_embedding_when_description_unchanged(self) -> None:
-        actor, mock_svc = _actor_with_mock_embed()
+    def test_remove_called_before_re_embedding(self) -> None:
+        actor, mock_proxy = _actor_with_mock_embed()
         actor.update_graph(
             ManageGraph(
                 create_entities=[
@@ -739,19 +774,36 @@ class TestEmbeddingOnUpdate:
                 ]
             )
         )
-        embed_count_before = mock_svc.embed.call_count
+        mock_proxy.remove.reset_mock()
+        actor.update_graph(
+            ManageGraph(update_entities=[EntityUpdate(name="Alice", description="Senior Eng")])
+        )
+        mock_proxy.remove.assert_called_once()
+        call_args = mock_proxy.remove.call_args
+        assert call_args[0][0] == KG_COLLECTION
+
+    def test_no_re_embedding_when_description_unchanged(self) -> None:
+        actor, mock_proxy = _actor_with_mock_embed()
+        actor.update_graph(
+            ManageGraph(
+                create_entities=[
+                    EntityCreate(name="Alice", entity_type="Person", description="Eng")
+                ]
+            )
+        )
+        embed_count_before = mock_proxy.embed.call_count
         # Update entity_type only — no description change
         actor.update_graph(
             ManageGraph(update_entities=[EntityUpdate(name="Alice", entity_type="Engineer")])
         )
-        assert mock_svc.embed.call_count == embed_count_before
+        assert mock_proxy.embed.call_count == embed_count_before
 
 
 class TestEmbeddingOnDelete:
-    """AC-6: embedding removed when entities/relations are deleted."""
+    """AC-7: embedding removed when entities/relations are deleted via vs_proxy."""
 
     def test_entity_embedding_removed_on_delete(self) -> None:
-        actor, mock_svc = _actor_with_mock_embed()
+        actor, mock_proxy = _actor_with_mock_embed()
         actor.update_graph(
             ManageGraph(
                 create_entities=[
@@ -759,15 +811,17 @@ class TestEmbeddingOnDelete:
                 ]
             )
         )
-        # Check an embedding was stored
-        assert len(actor._vector_index._entries) == 1
-
+        mock_proxy.remove.reset_mock()
         actor.update_graph(ManageGraph(delete_entities=["Alice"]))
-        assert len(actor._vector_index._entries) == 0
+        mock_proxy.remove.assert_called_once()
+        call_args = mock_proxy.remove.call_args
+        assert call_args[0][0] == KG_COLLECTION
+        assert len(call_args[0][1]) == 1  # 1 entity ref_id
 
     def test_relation_embedding_removed_on_delete(self) -> None:
-        actor, mock_svc = _actor_with_mock_embed()
+        actor, mock_proxy = _actor_with_mock_embed()
         _seed_entities(actor)
+        mock_proxy.remove.reset_mock()
         actor.update_graph(
             ManageGraph(
                 create_relations=[
@@ -780,9 +834,7 @@ class TestEmbeddingOnDelete:
                 ]
             )
         )
-        # 2 entity embeddings + 1 relation embedding
-        assert len(actor._vector_index._entries) == 3
-
+        mock_proxy.remove.reset_mock()
         actor.update_graph(
             ManageGraph(
                 delete_relations=[
@@ -790,15 +842,18 @@ class TestEmbeddingOnDelete:
                 ]
             )
         )
-        assert len(actor._vector_index._entries) == 2
+        mock_proxy.remove.assert_called_once()
+        call_args = mock_proxy.remove.call_args
+        assert call_args[0][0] == KG_COLLECTION
+        assert len(call_args[0][1]) == 1  # 1 relation ref_id
 
 
 class TestEmbeddingGracefulDegradation:
-    """AC-7: embedding failures do not block CRUD operations."""
+    """Embedding failures do not block CRUD operations."""
 
     def test_embedding_failure_does_not_block_entity_create(self) -> None:
-        actor, mock_svc = _actor_with_mock_embed()
-        mock_svc.embed.side_effect = RuntimeError("API key invalid")
+        actor, mock_proxy = _actor_with_mock_embed()
+        mock_proxy.embed.side_effect = RuntimeError("API key invalid")
         result = actor.update_graph(
             ManageGraph(
                 create_entities=[
@@ -810,9 +865,9 @@ class TestEmbeddingGracefulDegradation:
         assert len(actor.get_graph().entities) == 1
 
     def test_embedding_failure_does_not_block_relation_create(self) -> None:
-        actor, mock_svc = _actor_with_mock_embed()
+        actor, mock_proxy = _actor_with_mock_embed()
         _seed_entities(actor)
-        mock_svc.embed.side_effect = RuntimeError("API timeout")
+        mock_proxy.embed.side_effect = RuntimeError("API timeout")
         result = actor.update_graph(
             ManageGraph(
                 create_relations=[
@@ -828,6 +883,19 @@ class TestEmbeddingGracefulDegradation:
         assert result == "Done"
         assert len(actor.get_graph().relations) == 1
 
+    def test_degraded_mode_when_no_proxy(self) -> None:
+        """When _vs_proxy is None, CRUD works but no embedding calls are made."""
+        actor = _actor()  # _vs_proxy is None
+        result = actor.update_graph(
+            ManageGraph(
+                create_entities=[
+                    EntityCreate(name="Alice", entity_type="Person", description="Eng")
+                ]
+            )
+        )
+        assert result == "Done"
+        assert len(actor.get_graph().entities) == 1
+
 
 # ---------------------------------------------------------------------------
 # Vector search (Story 2.2 Task 1, ACs 1, 3, 5)
@@ -835,10 +903,10 @@ class TestEmbeddingGracefulDegradation:
 
 
 class TestVectorSearch:
-    """AC-1, AC-5: vector search returns ranked results or empty on no embeddings."""
+    """AC-5: vector search returns ranked results or empty on no embeddings."""
 
     def test_vector_search_returns_top_k_ranked_by_score(self) -> None:
-        actor, mock_svc = _actor_with_mock_embed()
+        actor, mock_proxy = _actor_with_mock_embed()
         actor.update_graph(
             ManageGraph(
                 create_entities=[
@@ -848,35 +916,37 @@ class TestVectorSearch:
             )
         )
         entity_ids = [str(e.id) for e in actor.get_graph().entities]
-        with patch.object(
-            actor._vector_index,  # noqa: SLF001
-            "search_cosine",
-            return_value=[(entity_ids[0], 0.9), (entity_ids[1], 0.5)],
-        ):
-            mock_svc.embed.return_value = [_FAKE_VECTOR]
-            result = actor.search(SearchQuery(query="engineer", top_k=2, mode="vector"))
+        mock_proxy.embed.return_value = [_FAKE_VECTOR]
+        mock_proxy.search.return_value = VsSearchResult(
+            hits=[
+                VsSearchHit(ref_type="entity", ref_id=entity_ids[0], text="", score=0.9),
+                VsSearchHit(ref_type="entity", ref_id=entity_ids[1], text="", score=0.5),
+            ],
+            status=CollectionStatus.READY,
+            indexing_pending=0,
+        )
+        result = actor.search(SearchQuery(query="engineer", top_k=2, mode="vector"))
         assert len(result.hits) == 2
         assert result.hits[0].score == 0.9
         assert result.hits[1].score == 0.5
         assert result.hits[0].entity is not None
 
-    def test_vector_search_returns_empty_when_no_entries_in_index(self) -> None:
-        actor = _actor()
+    def test_vector_search_returns_empty_when_no_proxy(self) -> None:
+        actor = _actor()  # _vs_proxy is None
         result = actor.search(SearchQuery(query="anything", top_k=5, mode="vector"))
         assert result.hits == []
 
     def test_vector_search_returns_empty_when_embed_call_fails(self) -> None:
-        """Verify graceful empty result when embed() raises during vector search (AC-5)."""
-        actor, mock_svc = _actor_with_mock_embed()
-        actor.update_graph(
-            ManageGraph(
-                create_entities=[
-                    EntityCreate(name="Alice", entity_type="Person", description="Eng")
-                ]
-            )
-        )
-        # Index has 1 entry; make embed raise during the search query
-        mock_svc.embed.side_effect = RuntimeError("API quota exceeded")
+        """Verify graceful empty result when embed() raises during vector search."""
+        actor, mock_proxy = _actor_with_mock_embed()
+        mock_proxy.embed.side_effect = RuntimeError("API quota exceeded")
+        result = actor.search(SearchQuery(query="Alice", top_k=5, mode="vector"))
+        assert result.hits == []
+
+    def test_vector_search_returns_empty_when_embed_returns_empty(self) -> None:
+        """VectorStoreActor returns [] on embed failure -- should result in empty search."""
+        actor, mock_proxy = _actor_with_mock_embed()
+        mock_proxy.embed.return_value = []
         result = actor.search(SearchQuery(query="Alice", top_k=5, mode="vector"))
         assert result.hits == []
 
@@ -887,13 +957,13 @@ class TestVectorSearch:
 
 
 class TestHybridSearch:
-    """AC-2, AC-4: hybrid merges keyword+vector, falls back to keyword when no embeddings."""
+    """Hybrid merges keyword+vector, falls back to keyword when no embeddings."""
 
     def _setup_actor_with_known_vectors(
         self,
     ) -> tuple[KnowledgeGraphActor, MagicMock]:
-        """Actor with Alice + Bob; mock embed returns fixed vectors."""
-        actor, mock_svc = _actor_with_mock_embed()
+        """Actor with Alice + Bob; mock vs_proxy."""
+        actor, mock_proxy = _actor_with_mock_embed()
         actor.update_graph(
             ManageGraph(
                 create_entities=[
@@ -906,10 +976,10 @@ class TestHybridSearch:
                 ]
             )
         )
-        return actor, mock_svc
+        return actor, mock_proxy
 
-    def test_hybrid_falls_back_to_keyword_when_no_embeddings(self) -> None:
-        actor = _actor()
+    def test_hybrid_falls_back_to_keyword_when_no_proxy(self) -> None:
+        actor = _actor()  # _vs_proxy is None
         actor.update_graph(
             ManageGraph(
                 create_entities=[
@@ -917,46 +987,46 @@ class TestHybridSearch:
                 ]
             )
         )
-        # No embedding service → vector search returns empty → hybrid falls back
         result = actor.search(SearchQuery(query="Alice", top_k=5, mode="hybrid"))
         assert len(result.hits) == 1
         assert result.hits[0].entity is not None
         assert result.hits[0].entity.name == "Alice"
 
     def test_hybrid_deduplicates_by_ref_id(self) -> None:
-        actor, mock_svc = self._setup_actor_with_known_vectors()
+        actor, mock_proxy = self._setup_actor_with_known_vectors()
         alice_id = str(
             next(e for e in actor.get_graph().entities if e.name == "Alice").id
         )
-        with patch.object(
-            actor._vector_index,  # noqa: SLF001
-            "search_cosine",
-            return_value=[(alice_id, 0.8)],
-        ):
-            mock_svc.embed.return_value = [_FAKE_VECTOR]
-            result = actor.search(SearchQuery(query="Alice", top_k=10, mode="hybrid"))
+        mock_proxy.embed.return_value = [_FAKE_VECTOR]
+        mock_proxy.search.return_value = VsSearchResult(
+            hits=[VsSearchHit(ref_type="entity", ref_id=alice_id, text="", score=0.8)],
+            status=CollectionStatus.READY,
+            indexing_pending=0,
+        )
+        result = actor.search(SearchQuery(query="Alice", top_k=10, mode="hybrid"))
         alice_hits = [h for h in result.hits if h.ref_id == alice_id]
         assert len(alice_hits) == 1, "Alice should appear exactly once (deduplication)"
 
     def test_hybrid_combined_hits_rank_higher_than_vector_only(self) -> None:
-        actor, mock_svc = self._setup_actor_with_known_vectors()
+        actor, mock_proxy = self._setup_actor_with_known_vectors()
         entities = actor.get_graph().entities
         alice_id = str(next(e for e in entities if e.name == "Alice").id)
         bob_id = str(next(e for e in entities if e.name == "Bob").id)
-        # Alice matches keyword "login" AND vector; Bob matches vector only
-        with patch.object(
-            actor._vector_index,  # noqa: SLF001
-            "search_cosine",
-            return_value=[(alice_id, 0.8), (bob_id, 0.9)],
-        ):
-            mock_svc.embed.return_value = [_FAKE_VECTOR]
-            result = actor.search(SearchQuery(query="login", top_k=5, mode="hybrid"))
-        # Alice: vector(0.8) + keyword_boost(0.5) = 1.3; Bob: vector only = 0.9
+        mock_proxy.embed.return_value = [_FAKE_VECTOR]
+        mock_proxy.search.return_value = VsSearchResult(
+            hits=[
+                VsSearchHit(ref_type="entity", ref_id=alice_id, text="", score=0.8),
+                VsSearchHit(ref_type="entity", ref_id=bob_id, text="", score=0.9),
+            ],
+            status=CollectionStatus.READY,
+            indexing_pending=0,
+        )
+        result = actor.search(SearchQuery(query="login", top_k=5, mode="hybrid"))
         ref_ids = [h.ref_id for h in result.hits]
         assert ref_ids[0] == alice_id, "Alice (vector+keyword) should rank above Bob (vector-only)"
 
     def test_hybrid_top_k_limits_results(self) -> None:
-        actor, mock_svc = _actor_with_mock_embed()
+        actor, mock_proxy = _actor_with_mock_embed()
         actor.update_graph(
             ManageGraph(
                 create_entities=[
@@ -966,13 +1036,16 @@ class TestHybridSearch:
             )
         )
         entity_ids = [str(e.id) for e in actor.get_graph().entities]
-        with patch.object(
-            actor._vector_index,  # noqa: SLF001
-            "search_cosine",
-            return_value=[(eid, 0.5) for eid in entity_ids],
-        ):
-            mock_svc.embed.return_value = [_FAKE_VECTOR]
-            result = actor.search(SearchQuery(query="desc", top_k=3, mode="hybrid"))
+        mock_proxy.embed.return_value = [_FAKE_VECTOR]
+        mock_proxy.search.return_value = VsSearchResult(
+            hits=[
+                VsSearchHit(ref_type="entity", ref_id=eid, text="", score=0.5)
+                for eid in entity_ids
+            ],
+            status=CollectionStatus.READY,
+            indexing_pending=0,
+        )
+        result = actor.search(SearchQuery(query="desc", top_k=3, mode="hybrid"))
         assert len(result.hits) <= 3
 
 

--- a/tests/test_kg_actor.py
+++ b/tests/test_kg_actor.py
@@ -950,6 +950,14 @@ class TestVectorSearch:
         result = actor.search(SearchQuery(query="Alice", top_k=5, mode="vector"))
         assert result.hits == []
 
+    def test_vector_search_returns_empty_when_search_call_fails(self) -> None:
+        """Graceful empty result when vs_proxy.search() raises during vector search."""
+        actor, mock_proxy = _actor_with_mock_embed()
+        mock_proxy.embed.return_value = [_FAKE_VECTOR]
+        mock_proxy.search.side_effect = RuntimeError("Connection refused")
+        result = actor.search(SearchQuery(query="Alice", top_k=5, mode="vector"))
+        assert result.hits == []
+
 
 # ---------------------------------------------------------------------------
 # Hybrid search (Story 2.2 Task 2, ACs 2, 4)

--- a/tests/test_kg_imports.py
+++ b/tests/test_kg_imports.py
@@ -42,6 +42,14 @@ class TestPackageImports:
         for name in expected:
             assert hasattr(knowledge_graph, name), f"Missing export: {name}"
 
+    def test_removed_exports_not_in_all(self) -> None:
+        """EmbeddingService, VectorIndex, VectorEntry no longer exported from KG."""
+        from akgentic.tool import knowledge_graph
+
+        removed = ["EmbeddingService", "VectorIndex", "VectorEntry"]
+        for name in removed:
+            assert name not in knowledge_graph.__all__, f"{name} should not be in __all__"
+
     def test_tool_import_does_not_trigger_kg_import(self) -> None:
         """Importing akgentic.tool does NOT eagerly import knowledge_graph."""
         # Remove knowledge_graph from cache if present

--- a/tests/test_kg_integration.py
+++ b/tests/test_kg_integration.py
@@ -88,12 +88,19 @@ class IntegrationObserver:
     """Mock observer wiring a real KnowledgeGraphActor for integration testing."""
 
     def __init__(self) -> None:
+        from akgentic.tool.knowledge_graph.models import KnowledgeGraphState
+        from akgentic.tool.vector_store.actor import VS_ACTOR_NAME
+
         self.events: list[object] = []
         self._address = MockActorAddress("test-agent")
         self._orchestrator_addr = MockActorAddress("orchestrator")
         self._kg_actor = KnowledgeGraphActor()
-        self._kg_actor.on_start()
+        # Manually init without orchestrator dependency
+        self._kg_actor.state = KnowledgeGraphState()
+        self._kg_actor.state.observer(self._kg_actor)
+        self._kg_actor._vs_proxy = None
         self._kg_addr = MockActorAddress(KG_ACTOR_NAME, KG_ACTOR_ROLE)
+        self._vs_addr = MockActorAddress(VS_ACTOR_NAME, "ToolActor")
 
     @property
     def myAddress(self) -> ActorAddress:  # noqa: N802
@@ -112,20 +119,29 @@ class IntegrationObserver:
         actor_type: type[AkgentType] | None = None,
         timeout: int | None = None,
     ) -> Any:
+        from unittest.mock import MagicMock
+
         if actor == self._orchestrator_addr:
-            return _OrchestratorStub(self._kg_addr)
+            return _OrchestratorStub(self._kg_addr, self._vs_addr)
+        if actor == self._vs_addr:
+            return MagicMock()  # mock VectorStoreActor proxy
         return self._kg_actor
 
 
 class _OrchestratorStub:
-    """Minimal orchestrator stub that returns a known KG address."""
+    """Minimal orchestrator stub that returns known actor addresses."""
 
-    def __init__(self, kg_addr: MockActorAddress) -> None:
+    def __init__(self, kg_addr: MockActorAddress, vs_addr: MockActorAddress) -> None:
         self._kg_addr = kg_addr
+        self._vs_addr = vs_addr
 
     def get_team_member(self, name: str) -> ActorAddress | None:
+        from akgentic.tool.vector_store.actor import VS_ACTOR_NAME
+
         if name == KG_ACTOR_NAME:
             return self._kg_addr
+        if name == VS_ACTOR_NAME:
+            return self._vs_addr
         return None
 
     def createActor(self, *args: Any, **kwargs: Any) -> ActorAddress:  # noqa: N802

--- a/tests/test_kg_tool.py
+++ b/tests/test_kg_tool.py
@@ -99,6 +99,7 @@ class MockActorToolObserver:
         self._orchestrator = MockActorAddress("orchestrator")
         self._kg_actor: KnowledgeGraphActor | None = None
         self._orchestrator_proxy = MagicMock(spec=Orchestrator)
+        self._vs_addr = MockActorAddress("#VectorStore", "ToolActor")
 
     @property
     def myAddress(self) -> ActorAddress:  # noqa: N802
@@ -119,6 +120,9 @@ class MockActorToolObserver:
     ) -> Any:
         if actor == self._orchestrator:
             return self._orchestrator_proxy
+        # Return mock VectorStoreActor proxy for VS address
+        if actor == self._vs_addr:
+            return MagicMock()
         # Return the real KG actor for KG actor address
         if self._kg_actor is not None:
             return self._kg_actor
@@ -126,11 +130,26 @@ class MockActorToolObserver:
 
     def setup_kg_actor(self) -> KnowledgeGraphActor:
         """Create a real KG actor and wire it for proxy_ask."""
+        from akgentic.tool.knowledge_graph.models import KnowledgeGraphState
+        from akgentic.tool.vector_store.actor import VS_ACTOR_NAME
+
         actor = KnowledgeGraphActor()
-        actor.on_start()
+        # Manually init without orchestrator dependency
+        actor.state = KnowledgeGraphState()
+        actor.state.observer(actor)
+        actor._vs_proxy = None
         self._kg_actor = actor
         kg_addr = MockActorAddress(KG_ACTOR_NAME, KG_ACTOR_ROLE)
-        self._orchestrator_proxy.get_team_member.return_value = kg_addr
+
+        # get_team_member returns VS addr for #VectorStore, KG addr for #KnowledgeGraphTool
+        def _get_team_member(name: str) -> MockActorAddress | None:
+            if name == VS_ACTOR_NAME:
+                return self._vs_addr
+            if name == KG_ACTOR_NAME:
+                return kg_addr
+            return None
+
+        self._orchestrator_proxy.get_team_member.side_effect = _get_team_member
         return actor
 
 
@@ -243,28 +262,45 @@ class TestKnowledgeGraphToolObserver:
         with pytest.raises(ValueError, match="orchestrator"):
             tool.observer(observer)
 
-    def test_observer_creates_actor_when_none(self) -> None:
+    def test_observer_creates_actors_when_none(self) -> None:
+        from akgentic.tool.vector_store.actor import VS_ACTOR_NAME
+
         tool = KnowledgeGraphTool()
         observer = MockActorToolObserver()
-        # get_team_member returns None → must createActor
+        # get_team_member returns None → must createActor for both VS and KG
         observer._orchestrator_proxy.get_team_member.return_value = None
-        kg_addr = MockActorAddress(KG_ACTOR_NAME, KG_ACTOR_ROLE)
-        observer._orchestrator_proxy.createActor.return_value = kg_addr
+        addr = MockActorAddress(KG_ACTOR_NAME, KG_ACTOR_ROLE)
+        observer._orchestrator_proxy.createActor.return_value = addr
 
         tool.observer(observer)
 
-        observer._orchestrator_proxy.get_team_member.assert_called_once_with(KG_ACTOR_NAME)
-        observer._orchestrator_proxy.createActor.assert_called_once()
+        # Should check for both VectorStore and KG actors
+        calls = observer._orchestrator_proxy.get_team_member.call_args_list
+        called_names = [c[0][0] for c in calls]
+        assert VS_ACTOR_NAME in called_names
+        assert KG_ACTOR_NAME in called_names
+        # createActor called for both
+        assert observer._orchestrator_proxy.createActor.call_count == 2
 
-    def test_observer_reuses_existing_actor(self) -> None:
+    def test_observer_reuses_existing_actors(self) -> None:
+        from akgentic.tool.vector_store.actor import VS_ACTOR_NAME
+
         tool = KnowledgeGraphTool()
         observer = MockActorToolObserver()
-        existing_addr = MockActorAddress(KG_ACTOR_NAME, KG_ACTOR_ROLE)
-        observer._orchestrator_proxy.get_team_member.return_value = existing_addr
+        vs_addr = MockActorAddress("#VectorStore", "ToolActor")
+        kg_addr = MockActorAddress(KG_ACTOR_NAME, KG_ACTOR_ROLE)
+
+        def _get_team_member(name: str) -> MockActorAddress | None:
+            if name == VS_ACTOR_NAME:
+                return vs_addr
+            if name == KG_ACTOR_NAME:
+                return kg_addr
+            return None
+
+        observer._orchestrator_proxy.get_team_member.side_effect = _get_team_member
 
         tool.observer(observer)
 
-        observer._orchestrator_proxy.get_team_member.assert_called_once_with(KG_ACTOR_NAME)
         observer._orchestrator_proxy.createActor.assert_not_called()
 
 

--- a/tests/test_kg_vector_index.py
+++ b/tests/test_kg_vector_index.py
@@ -260,26 +260,7 @@ class TestVectorIndexPerformance:
 
 
 # ---------------------------------------------------------------------------
-# Backward-compat shim (AC-5: old import paths must still work)
+# Backward-compat shim removed (Story 11.1 AC-9)
+# vector_index.py shim and KG re-exports of VectorEntry/EmbeddingService are deleted.
+# VectorEntry and EmbeddingService should be imported from akgentic.tool.vector directly.
 # ---------------------------------------------------------------------------
-
-
-class TestBackwardCompatImports:
-    """Verify that importing from deprecated paths still works."""
-
-    def test_vector_index_shim_exports_embedding_service(self) -> None:
-        from akgentic.tool.knowledge_graph.vector_index import (
-            EmbeddingService as ShimEmbeddingService,
-        )
-
-        assert ShimEmbeddingService is EmbeddingService
-
-    def test_vector_index_shim_exports_vector_index(self) -> None:
-        from akgentic.tool.knowledge_graph.vector_index import VectorIndex as ShimVectorIndex
-
-        assert ShimVectorIndex is VectorIndex
-
-    def test_knowledge_graph_package_exports_vector_entry(self) -> None:
-        from akgentic.tool.knowledge_graph import VectorEntry as KgVectorEntry
-
-        assert KgVectorEntry is VectorEntry


### PR DESCRIPTION
## Summary
- Migrated KnowledgeGraphActor from internal VectorIndex/EmbeddingService to centralized VectorStoreActor proxy
- KnowledgeGraphConfig stripped to empty BaseConfig subclass (embedding fields moved to VectorStoreConfig)
- KnowledgeGraphTool.observer() ensures VectorStoreActor singleton exists before creating KG actor
- Deleted backward-compat shim vector_index.py, removed old KG re-exports
- All 1068 tests pass, 84% coverage on KG module, ruff clean, mypy strict clean

Closes #122