### PR TITLE
PlanActor migration to VectorStoreActor proxy

### DIFF
--- a/src/akgentic/tool/planning/planning.py
+++ b/src/akgentic/tool/planning/planning.py
@@ -23,6 +23,8 @@ from akgentic.tool.planning.planning_actor import (
     TaskStatus,
     UpdatePlan,
 )
+from akgentic.tool.vector_store.actor import VS_ACTOR_NAME, VS_ACTOR_ROLE, VectorStoreActor
+from akgentic.tool.vector_store.protocol import VectorStoreConfig
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -97,6 +99,9 @@ class PlanningTool(ToolCard):
     def observer(self, observer: ActorToolObserver) -> None:  # type: ignore[override]
         """Attach observer and set up the planning actor proxy.
 
+        Ensures the ``VectorStoreActor`` singleton exists before
+        creating/retrieving the ``PlanActor`` singleton.
+
         Requires an ActorToolObserver for actor system access.
         """
         self._observer = observer
@@ -104,15 +109,29 @@ class PlanningTool(ToolCard):
             raise ValueError("PlanningTool requires access to the orchestrator.")
 
         orchestrator_proxy_ask = observer.proxy_ask(observer.orchestrator, Orchestrator)
+
+        # Ensure VectorStoreActor singleton exists (AC10)
+        vs_addr = orchestrator_proxy_ask.get_team_member(VS_ACTOR_NAME)
+        if vs_addr is None:
+            logger.info("PlanningTool: creating singleton %s.", VS_ACTOR_NAME)
+            vs_addr = orchestrator_proxy_ask.createActor(
+                VectorStoreActor,
+                config=VectorStoreConfig(
+                    name=VS_ACTOR_NAME,
+                    role=VS_ACTOR_ROLE,
+                    embedding_model=self.embedding_model,
+                    embedding_provider=self.embedding_provider,
+                ),
+            )
+
+        # Create/retrieve PlanActor singleton
         planning_tool_addr = orchestrator_proxy_ask.get_team_member(PLANNING_ACTOR_NAME)
 
         if planning_tool_addr is None:
-            logger.info(f"PlanningTool: create {PLANNING_ACTOR_NAME}.")
+            logger.info("PlanningTool: creating %s.", PLANNING_ACTOR_NAME)
             config = PlanConfig(
                 name=PLANNING_ACTOR_NAME,
                 role=PLANNING_ACTOR_ROLE,
-                embedding_model=self.embedding_model,
-                embedding_provider=self.embedding_provider,
             )
             planning_tool_addr = orchestrator_proxy_ask.createActor(PlanActor, config=config)
 

--- a/src/akgentic/tool/planning/planning_actor.py
+++ b/src/akgentic/tool/planning/planning_actor.py
@@ -2,17 +2,18 @@ from __future__ import annotations
 
 import datetime
 import logging
-from typing import TYPE_CHECKING, Literal
+from typing import Literal
 
 from pydantic import BaseModel, Field, field_validator
 
 from akgentic.core.actor_address import ActorAddress
 from akgentic.core.agent import Akgent, BaseConfig, BaseState
+from akgentic.core.orchestrator import Orchestrator
 from akgentic.core.utils.serializer import SerializableBaseModel
 from akgentic.tool.errors import RetriableError
-
-if TYPE_CHECKING:
-    from akgentic.tool.vector import EmbeddingService, VectorIndex
+from akgentic.tool.vector import VectorEntry
+from akgentic.tool.vector_store.actor import VS_ACTOR_NAME, VectorStoreActor
+from akgentic.tool.vector_store.protocol import CollectionConfig
 
 logger = logging.getLogger(__name__)
 
@@ -83,16 +84,18 @@ class PlanManagerState(BaseState):
     task_list: list[Task] = Field(default_factory=list)
 
 
+PLAN_COLLECTION: str = "planning"
+"""Collection name used in VectorStoreActor."""
+
+
 class PlanConfig(BaseConfig):
     """Configuration for PlanActor with optional semantic search support."""
 
-    embedding_model: str = Field(default="text-embedding-3-small")
-    embedding_provider: Literal["openai", "azure"] = Field(default="openai")
     semantic_search: bool = Field(
         default=True,
         description=(
             "When True, task descriptions are embedded on create/update/delete "
-            "for semantic search. Falls back gracefully if [vector_search] deps are not installed."
+            "for semantic search. Falls back gracefully if VectorStoreActor is unavailable."
         ),
     )
 
@@ -121,62 +124,62 @@ class PlanActor(Akgent[PlanConfig, PlanManagerState]):
                 name=self.config.name,
                 role=self.config.role,
             )
-        # Only instantiate VectorIndex (which imports numpy) when semantic_search is enabled.
-        # This preserves the graceful fallback behaviour: if numpy is absent and
-        # semantic_search=False, on_start must not crash (AC#7, AC#8).
-        self._vector_index: VectorIndex | None = None
+        self._vs_proxy: VectorStoreActor | None = None
         if self.config.semantic_search:
-            from akgentic.tool.vector import VectorIndex
+            self._acquire_vs_proxy()
 
-            self._vector_index = VectorIndex()
-        self._embedding_svc: EmbeddingService | None = None
+    def _acquire_vs_proxy(self) -> None:
+        """Acquire the VectorStoreActor proxy and create the planning collection.
 
-    def _get_or_create_embedding_svc(self) -> EmbeddingService | None:
-        """Return (or lazily create) the EmbeddingService.
-
-        Returns None when semantic_search is disabled or [vector_search]
-        optional dependencies are not installed.
+        Operates in degraded mode (no vector search) if the proxy cannot
+        be acquired.
         """
-        if not self.config.semantic_search:
-            return None
-        if self._embedding_svc is None:
-            try:
-                from akgentic.tool.vector import EmbeddingService, _check_vector_search_dependencies
-
-                _check_vector_search_dependencies()
-            except ImportError:
-                return None
-            self._embedding_svc = EmbeddingService(
-                model=self.config.embedding_model,
-                provider=self.config.embedding_provider,
+        try:
+            if self.orchestrator is None:
+                logger.warning(
+                    "[%s] No orchestrator; operating in degraded mode",
+                    self.config.name,
+                )
+                return
+            orch_proxy = self.proxy_ask(self.orchestrator, Orchestrator)
+            vs_addr = orch_proxy.get_team_member(VS_ACTOR_NAME)
+            if vs_addr is None:
+                logger.warning(
+                    "[%s] VectorStoreActor not found; operating in degraded mode",
+                    self.config.name,
+                )
+                return
+            self._vs_proxy = self.proxy_ask(vs_addr, VectorStoreActor)
+            self._vs_proxy.create_collection(PLAN_COLLECTION, CollectionConfig())
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "[%s] Failed to acquire VectorStoreActor proxy: %s",
+                self.config.name,
+                exc,
             )
-        return self._embedding_svc
 
     def _embed_task(self, task: Task) -> None:
         """Embed a task's description and store the resulting VectorEntry.
 
-        Called after task create or update. Does nothing when embedding service
-        is unavailable (semantic_search=False or missing deps). Any embedding
-        error (import, network, auth) is logged and swallowed so that task CRUD
+        Called after task create or update. Does nothing when VectorStoreActor
+        proxy is unavailable (semantic_search=False or proxy not acquired).
+        Any embedding error is logged and swallowed so that task CRUD
         is never interrupted by a transient embedding failure.
         """
+        if self._vs_proxy is None:
+            return
         try:
-            svc = self._get_or_create_embedding_svc()
-            if svc is None or self._vector_index is None:
+            vectors = self._vs_proxy.embed([task.description])
+            if not vectors:
                 return
-            from akgentic.tool.vector import VectorEntry
-
-            vector = svc.embed([task.description])[0]
             entry = VectorEntry(
                 ref_type="task",
                 ref_id=str(task.id),
                 text=task.description,
-                vector=vector,
+                vector=vectors[0],
             )
-            self._vector_index.add(entry)
-        except ImportError:
-            logger.warning("Vector search deps missing — skipping embedding for task %s", task.id)
-        except Exception:
+            self._vs_proxy.add(PLAN_COLLECTION, [entry])
+        except Exception:  # noqa: BLE001
             logger.warning(
                 "Embedding failed for task %s — semantic index not updated", task.id, exc_info=True
             )
@@ -202,9 +205,9 @@ class PlanActor(Akgent[PlanConfig, PlanManagerState]):
                 if (
                     self.config.semantic_search
                     and description_changed
-                    and self._vector_index is not None
+                    and self._vs_proxy is not None
                 ):
-                    self._vector_index.remove({str(task.id)})
+                    self._vs_proxy.remove(PLAN_COLLECTION, [str(task.id)])
                     self._embed_task(updated_task)
                 return None
         return f"Update error - no task with ID {task_update.id} found."
@@ -263,15 +266,16 @@ class PlanActor(Akgent[PlanConfig, PlanManagerState]):
             keyword_ids = {t.id for t in tasks if q_lower in t.description.lower()}
 
             semantic_ids: set[int] = set()
-            svc = self._get_or_create_embedding_svc()
-            if svc is not None and self._vector_index is not None and len(self._vector_index) > 0:
+            if self._vs_proxy is not None:
                 try:
-                    query_vector = svc.embed([query])[0]
-                    pairs = self._vector_index.search_cosine(query_vector, top_k=20)
-                    for ref_id, score in pairs:
-                        if score >= 0.5:
-                            semantic_ids.add(int(ref_id))
-                except Exception:
+                    vectors = self._vs_proxy.embed([query])
+                    if vectors:
+                        query_vector = vectors[0]
+                        result = self._vs_proxy.search(PLAN_COLLECTION, query_vector, 20)
+                        for hit in result.hits:
+                            if hit.score >= 0.5:
+                                semantic_ids.add(int(hit.ref_id))
+                except Exception:  # noqa: BLE001
                     logger.warning(
                         "Semantic search failed for query — falling back to keyword only",
                         exc_info=True,
@@ -310,8 +314,8 @@ class PlanActor(Akgent[PlanConfig, PlanManagerState]):
             if not any(task.id == task_id for task in self.state.task_list):
                 errors.append(f"Delete error - no task with ID {task_id} found.")
             else:
-                if self.config.semantic_search and self._vector_index is not None:
-                    self._vector_index.remove({str(task_id)})
+                if self.config.semantic_search and self._vs_proxy is not None:
+                    self._vs_proxy.remove(PLAN_COLLECTION, [str(task_id)])
                 self.state.task_list = [task for task in self.state.task_list if task.id != task_id]
 
         self.state.notify_state_change()

--- a/tests/test_planning_search.py
+++ b/tests/test_planning_search.py
@@ -5,7 +5,7 @@ Covers AC#2–#12 from Story 4.3: search_planning Filtered Search Capability.
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -258,15 +258,13 @@ class TestSearchPlanningQueryKeyword:
         assert result == []
 
     def test_keyword_with_semantic_search_disabled(self) -> None:
-        """Keyword-only mode when semantic_search=False — embedding svc returns None."""
+        """Keyword-only mode when semantic_search=False — _vs_proxy is None."""
         actor = _make_actor(semantic_search=False)
         _add_task(actor, 1, "auth flow")
         _add_task(actor, 2, "payment gateway")
 
-        # Patch returns None to simulate the svc-unavailable path explicitly.
-        # _vector_index is also None because semantic_search=False.
-        with patch.object(actor, "_get_or_create_embedding_svc", return_value=None):
-            result = actor.search_planning(query="auth")
+        # _vs_proxy is None because semantic_search=False — keyword-only path.
+        result = actor.search_planning(query="auth")
 
         assert len(result) == 1
         assert result[0].id == 1
@@ -278,7 +276,28 @@ class TestSearchPlanningQueryKeyword:
 
 
 class TestSearchPlanningQuerySemantic:
-    """AC6: query with mocked vector deps — union of keyword + semantic, dedup, cosine ≥ 0.5."""
+    """AC6: query with mocked VectorStoreActor proxy — union of keyword + semantic, dedup, cosine ≥ 0.5."""
+
+    def _make_vs_proxy_mock(
+        self, embed_return: list[list[float]], search_hits: list[tuple[str, float]]
+    ) -> MagicMock:
+        """Build a mock VectorStoreActor proxy with embed and search stubs."""
+        from akgentic.tool.vector_store.protocol import (
+            CollectionStatus,
+            SearchHit,
+            SearchResult,
+        )
+
+        mock = MagicMock()
+        mock.embed.return_value = embed_return
+        mock.search.return_value = SearchResult(
+            hits=[
+                SearchHit(ref_type="task", ref_id=ref_id, text="", score=score)
+                for ref_id, score in search_hits
+            ],
+            status=CollectionStatus.READY,
+        )
+        return mock
 
     def test_semantic_union_with_keyword(self) -> None:
         """Semantic hits union with keyword hits; tasks with score ≥ 0.5 included."""
@@ -287,19 +306,13 @@ class TestSearchPlanningQuerySemantic:
         _add_task(actor, 2, "database schema")  # semantic match only
         _add_task(actor, 3, "deployment pipeline")  # no match
 
-        # Mock embedding service
-        mock_svc = MagicMock()
-        mock_svc.embed.return_value = [[0.1, 0.2, 0.3]]
-
-        # Mock vector index with non-zero size
-        mock_index = MagicMock()
-        mock_index.__len__ = MagicMock(return_value=3)
         # Task 2 has cosine score ≥ 0.5, task 3 has score < 0.5
-        mock_index.search_cosine.return_value = [("2", 0.75), ("3", 0.3)]
-        actor._vector_index = mock_index
+        actor._vs_proxy = self._make_vs_proxy_mock(
+            embed_return=[[0.1, 0.2, 0.3]],
+            search_hits=[("2", 0.75), ("3", 0.3)],
+        )
 
-        with patch.object(actor, "_get_or_create_embedding_svc", return_value=mock_svc):
-            result = actor.search_planning(query="auth flow")
+        result = actor.search_planning(query="auth flow")
 
         # task 1 via keyword, task 2 via semantic (score 0.75 ≥ 0.5)
         # task 3 excluded (score 0.3 < 0.5)
@@ -310,17 +323,13 @@ class TestSearchPlanningQuerySemantic:
         actor = _make_actor(semantic_search=True)
         _add_task(actor, 1, "auth module")
 
-        mock_svc = MagicMock()
-        mock_svc.embed.return_value = [[0.1, 0.2, 0.3]]
-
-        mock_index = MagicMock()
-        mock_index.__len__ = MagicMock(return_value=1)
         # Task 1 is both a keyword match AND semantic match
-        mock_index.search_cosine.return_value = [("1", 0.9)]
-        actor._vector_index = mock_index
+        actor._vs_proxy = self._make_vs_proxy_mock(
+            embed_return=[[0.1, 0.2, 0.3]],
+            search_hits=[("1", 0.9)],
+        )
 
-        with patch.object(actor, "_get_or_create_embedding_svc", return_value=mock_svc):
-            result = actor.search_planning(query="auth")
+        result = actor.search_planning(query="auth")
 
         # Deduplicated: only one entry for task 1
         assert len(result) == 1
@@ -331,16 +340,12 @@ class TestSearchPlanningQuerySemantic:
         actor = _make_actor(semantic_search=True)
         _add_task(actor, 1, "database task")
 
-        mock_svc = MagicMock()
-        mock_svc.embed.return_value = [[0.1, 0.2]]
+        actor._vs_proxy = self._make_vs_proxy_mock(
+            embed_return=[[0.1, 0.2]],
+            search_hits=[("1", 0.5)],
+        )
 
-        mock_index = MagicMock()
-        mock_index.__len__ = MagicMock(return_value=1)
-        mock_index.search_cosine.return_value = [("1", 0.5)]
-        actor._vector_index = mock_index
-
-        with patch.object(actor, "_get_or_create_embedding_svc", return_value=mock_svc):
-            result = actor.search_planning(query="db")
+        result = actor.search_planning(query="db")
 
         assert len(result) == 1
         assert result[0].id == 1
@@ -350,36 +355,31 @@ class TestSearchPlanningQuerySemantic:
         actor = _make_actor(semantic_search=True)
         _add_task(actor, 1, "database task")
 
-        mock_svc = MagicMock()
-        mock_svc.embed.return_value = [[0.1, 0.2]]
+        actor._vs_proxy = self._make_vs_proxy_mock(
+            embed_return=[[0.1, 0.2]],
+            search_hits=[("1", 0.49)],
+        )
 
-        mock_index = MagicMock()
-        mock_index.__len__ = MagicMock(return_value=1)
-        mock_index.search_cosine.return_value = [("1", 0.49)]
-        actor._vector_index = mock_index
-
-        with patch.object(actor, "_get_or_create_embedding_svc", return_value=mock_svc):
-            result = actor.search_planning(query="completely different topic")
+        result = actor.search_planning(query="completely different topic")
 
         # Not a keyword match AND cosine < 0.5 → excluded
         assert result == []
 
-    def test_empty_vector_index_falls_back_to_keyword(self) -> None:
-        """When vector index is empty (len=0), semantic phase is skipped."""
+    def test_empty_embed_result_falls_back_to_keyword(self) -> None:
+        """When embed returns empty list, semantic phase is skipped."""
         actor = _make_actor(semantic_search=True)
         _add_task(actor, 1, "auth flow setup")
 
-        mock_svc = MagicMock()
+        # Embed returns empty list (no vectors) — semantic skipped
+        actor._vs_proxy = self._make_vs_proxy_mock(
+            embed_return=[],
+            search_hits=[],
+        )
 
-        mock_index = MagicMock()
-        mock_index.__len__ = MagicMock(return_value=0)
-        actor._vector_index = mock_index
+        result = actor.search_planning(query="auth")
 
-        with patch.object(actor, "_get_or_create_embedding_svc", return_value=mock_svc):
-            result = actor.search_planning(query="auth")
-
-        # Keyword match only; search_cosine should not be called (index is empty)
-        mock_index.search_cosine.assert_not_called()
+        # Keyword match only; search should not be called (embed returned empty)
+        actor._vs_proxy.search.assert_not_called()
         assert len(result) == 1
         assert result[0].id == 1
 
@@ -436,50 +436,45 @@ class TestSearchPlanningCombinedFilters:
 
 
 class TestSearchPlanningVectorFallback:
-    """AC5/AC6: when _get_or_create_embedding_svc returns None, degrades to keyword-only."""
+    """AC5/AC6: when _vs_proxy is None or raises, degrades to keyword-only."""
 
-    def test_no_exception_when_svc_returns_none(self) -> None:
-        """When embedding svc unavailable, search_planning works via keyword only."""
+    def test_no_exception_when_vs_proxy_is_none(self) -> None:
+        """When VectorStoreActor proxy unavailable, search_planning works via keyword only."""
         actor = _make_actor(semantic_search=True)
         _add_task(actor, 1, "auth service")
         _add_task(actor, 2, "payment service")
 
-        with patch.object(actor, "_get_or_create_embedding_svc", return_value=None):
-            result = actor.search_planning(query="auth")
+        # _vs_proxy is None (degraded mode) — keyword-only
+        assert actor._vs_proxy is None
+        result = actor.search_planning(query="auth")
 
         # Falls back to keyword-only, no exception raised
         assert len(result) == 1
         assert result[0].id == 1
 
-    def test_no_exception_when_vector_index_is_none(self) -> None:
-        """When _vector_index is None (semantic_search=False), keyword fallback works."""
+    def test_no_exception_when_semantic_search_disabled(self) -> None:
+        """When semantic_search=False, _vs_proxy is None and keyword fallback works."""
         actor = _make_actor(semantic_search=False)
         _add_task(actor, 1, "auth service")
 
-        mock_svc = MagicMock()
-        # Even if svc somehow returned non-None, _vector_index being None skips semantic
-        with patch.object(actor, "_get_or_create_embedding_svc", return_value=mock_svc):
-            # _vector_index is None because semantic_search=False
-            result = actor.search_planning(query="auth")
+        # _vs_proxy is None because semantic_search=False
+        assert actor._vs_proxy is None
+        result = actor.search_planning(query="auth")
 
         assert len(result) == 1
         assert result[0].id == 1
 
     def test_semantic_exception_falls_back_to_keyword(self) -> None:
-        """When semantic search raises an exception, keyword results still returned."""
+        """When VectorStoreActor proxy raises an exception, keyword results still returned."""
         actor = _make_actor(semantic_search=True)
         _add_task(actor, 1, "auth service")
 
-        mock_svc = MagicMock()
-        mock_svc.embed.side_effect = RuntimeError("embedding API error")
+        mock_proxy = MagicMock()
+        mock_proxy.embed.side_effect = RuntimeError("embedding API error")
+        actor._vs_proxy = mock_proxy
 
-        mock_index = MagicMock()
-        mock_index.__len__ = MagicMock(return_value=1)
-        actor._vector_index = mock_index
-
-        with patch.object(actor, "_get_or_create_embedding_svc", return_value=mock_svc):
-            # Should not raise; falls back to keyword
-            result = actor.search_planning(query="auth")
+        # Should not raise; falls back to keyword
+        result = actor.search_planning(query="auth")
 
         assert len(result) == 1
         assert result[0].id == 1

--- a/tests/test_planning_semantic.py
+++ b/tests/test_planning_semantic.py
@@ -165,4 +165,4 @@ class TestPlanningToolObserverWiring:
         # Second: PlanConfig without embedding fields
         plan_config = captured_configs[1]
         assert isinstance(plan_config, PlanConfig)
-        assert not hasattr(plan_config, "embedding_model") or "embedding_model" not in PlanConfig.model_fields
+        assert "embedding_model" not in PlanConfig.model_fields

--- a/tests/test_planning_semantic.py
+++ b/tests/test_planning_semantic.py
@@ -6,7 +6,7 @@ Also covers AC#8–#9 (PlanningTool embedding field wiring).
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from akgentic.tool.planning.planning_actor import (
     PlanActor,
@@ -59,13 +59,11 @@ class TestGetPlanningTaskIntFound:
         actor = _make_actor()
         _add_task(actor, task_id=3, description="Auth module")
 
-        with patch.object(actor, "_get_or_create_embedding_svc") as mock_svc:
-            result = actor.get_planning_task(3)
+        result = actor.get_planning_task(3)
 
         assert isinstance(result, Task)
         assert result.id == 3
         assert result.description == "Auth module"
-        mock_svc.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -124,25 +122,27 @@ class TestPlanningToolFields:
 
 
 class TestPlanningToolObserverWiring:
-    """AC9: observer() wires PlanConfig(embedding_model, embedding_provider) to PlanActor."""
+    """AC9/AC10: observer() creates VectorStoreActor and PlanActor with correct configs."""
 
-    def test_observer_creates_plan_actor_with_plan_config(self) -> None:
-        """observer() must pass PlanConfig (not BaseConfig) with embedding fields to PlanActor."""
+    def test_observer_creates_vectorstore_and_plan_actors(self) -> None:
+        """observer() must create VectorStoreActor with embedding fields, then PlanActor."""
         from akgentic.tool.planning.planning import PlanningTool
+        from akgentic.tool.vector_store.actor import VectorStoreActor
+        from akgentic.tool.vector_store.protocol import VectorStoreConfig
 
         tool = PlanningTool(
             embedding_model="text-embedding-ada-002",
             embedding_provider="azure",
         )
 
-        # Capture the config passed to createActor
-        captured_config: list[PlanConfig] = []
+        # Capture configs passed to createActor calls
+        captured_configs: list[object] = []
 
         mock_proxy_ask = MagicMock()
         mock_proxy_ask.get_team_member.return_value = None  # Force actor creation path
 
-        def capture_create_actor(actor_cls: type, config: PlanConfig) -> MagicMock:
-            captured_config.append(config)
+        def capture_create_actor(actor_cls: type, config: object) -> MagicMock:
+            captured_configs.append(config)
             return MagicMock()
 
         mock_proxy_ask.createActor.side_effect = capture_create_actor
@@ -153,11 +153,16 @@ class TestPlanningToolObserverWiring:
 
         tool.observer(mock_observer)
 
-        assert len(captured_config) == 1
-        config = captured_config[0]
-        assert isinstance(config, PlanConfig), (
-            f"Expected PlanConfig, got {type(config).__name__}. "
-            "observer() must not pass a plain BaseConfig."
-        )
-        assert config.embedding_model == "text-embedding-ada-002"
-        assert config.embedding_provider == "azure"
+        # Two actors created: VectorStoreActor first, PlanActor second
+        assert len(captured_configs) == 2
+
+        # First: VectorStoreConfig with embedding fields
+        vs_config = captured_configs[0]
+        assert isinstance(vs_config, VectorStoreConfig)
+        assert vs_config.embedding_model == "text-embedding-ada-002"
+        assert vs_config.embedding_provider == "azure"
+
+        # Second: PlanConfig without embedding fields
+        plan_config = captured_configs[1]
+        assert isinstance(plan_config, PlanConfig)
+        assert not hasattr(plan_config, "embedding_model") or "embedding_model" not in PlanConfig.model_fields


### PR DESCRIPTION
## Summary

- Migrated PlanActor from internal VectorIndex/EmbeddingService to centralized VectorStoreActor proxy
- Removed embedding_model and embedding_provider from PlanConfig (now owned by VectorStoreConfig)
- Updated PlanningTool.observer() to ensure VectorStoreActor singleton before PlanActor creation
- All vector operations (add, remove, search, embed) now go through VectorStoreActor proxy
- Graceful degradation preserved across all scenarios (disabled, proxy unavailable, deps missing)
- Updated test mocks in test_planning_search.py and test_planning_semantic.py for new proxy pattern

Closes #124