### PR TITLE
Remove schema-only fields from SearchPlanning and document convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,30 @@ ToolFactory(
 )
 ```
 
+### BaseToolParam: Configuration, Not Schema
+
+Every custom field on a `BaseToolParam` subclass must be read at factory bind time and influence
+the tool's runtime behavior — as a closure variable, function default, or observer setup value.
+Fields that merely mirror the LLM-facing function signature are dead code: they look configurable
+but have no effect.
+
+**Rule:** if a developer writes `MyParam(field=value)`, that value must influence runtime behavior.
+LLM-facing parameters belong exclusively on the factory-produced function signature.
+
+```python
+# CORRECT — field captured at bind time, controls behavior
+class GetPlanning(BaseToolParam):
+    filter_by_agent: bool = True  # read by factory, stored in closure
+
+# CORRECT — no custom fields, search params live on the function signature
+class SearchGraph(BaseToolParam):
+    expose: set[Channels] = {TOOL_CALL, COMMAND}
+
+# WRONG — fields duplicate function signature but are never read
+class BadParam(BaseToolParam):
+    status: str | None = None  # never consumed by factory
+```
+
 ## Channel System
 
 The `Channels` enum (`TOOL_CALL`, `SYSTEM_PROMPT`, `COMMAND`) controls how a capability is

--- a/src/akgentic/tool/planning/planning.py
+++ b/src/akgentic/tool/planning/planning.py
@@ -59,18 +59,6 @@ class SearchPlanning(BaseToolParam):
     """Search tasks by status, owner, creator, and/or natural-language description."""
 
     expose: set[Channels] = {TOOL_CALL, COMMAND}
-    status: TaskStatus | None = Field(default=None, description="Filter by exact task status.")
-    owner: str | None = Field(
-        default=None, description="Filter by exact owner name. Empty string matches unassigned."
-    )
-    creator: str | None = Field(default=None, description="Filter by exact creator name.")
-    query: str | None = Field(
-        default=None,
-        description=(
-            "Case-insensitive keyword search on task description. When vector deps are available, "
-            "also runs semantic similarity search (cosine ≥ 0.5, top_k=20) and unions results."
-        ),
-    )
 
 
 class PlanningTool(ToolCard):
@@ -212,9 +200,7 @@ class PlanningTool(ToolCard):
                             f"{output_part}{suffix}"
                         )
                 else:
-                    lines.append(
-                        f"\nNo tasks assigned to or created by {agent_name} yet."
-                    )
+                    lines.append(f"\nNo tasks assigned to or created by {agent_name} yet.")
             else:
                 lines.append("\n**All tasks:**")
                 for task in tasks:
@@ -222,8 +208,7 @@ class PlanningTool(ToolCard):
                     owner_label = task.owner or "unassigned"
                     suffix = f" (Owner: {owner_label}, Creator: {task.creator})"
                     lines.append(
-                        f"- ID {task.id} [{task.status}] {task.description}"
-                        f"{output_part}{suffix}"
+                        f"- ID {task.id} [{task.status}] {task.description}{output_part}{suffix}"
                     )
 
             lines.append(

--- a/tests/test_planning_search.py
+++ b/tests/test_planning_search.py
@@ -491,7 +491,7 @@ class TestSearchPlanningVectorFallback:
 
 
 class TestSearchPlanningParamClass:
-    """AC1: SearchPlanning has correct expose and field types."""
+    """AC1: SearchPlanning has correct expose and only inherited fields."""
 
     def test_expose_contains_tool_call_and_command(self) -> None:
         from akgentic.tool.core import COMMAND, TOOL_CALL
@@ -504,7 +504,6 @@ class TestSearchPlanningParamClass:
     def test_only_inherited_fields(self) -> None:
         from akgentic.tool.planning.planning import SearchPlanning
 
-        SearchPlanning()
         # SearchPlanning should only have inherited fields from BaseToolParam
         field_names = set(SearchPlanning.model_fields.keys())
         assert field_names == {"expose", "instructions"}

--- a/tests/test_planning_search.py
+++ b/tests/test_planning_search.py
@@ -501,23 +501,13 @@ class TestSearchPlanningParamClass:
         assert TOOL_CALL in sp.expose
         assert COMMAND in sp.expose
 
-    def test_all_fields_default_to_none(self) -> None:
+    def test_only_inherited_fields(self) -> None:
         from akgentic.tool.planning.planning import SearchPlanning
 
-        sp = SearchPlanning()
-        assert sp.status is None
-        assert sp.owner is None
-        assert sp.creator is None
-        assert sp.query is None
-
-    def test_fields_accept_values(self) -> None:
-        from akgentic.tool.planning.planning import SearchPlanning
-
-        sp = SearchPlanning(status="pending", owner="@Alice", creator="@Bob", query="auth")
-        assert sp.status == "pending"
-        assert sp.owner == "@Alice"
-        assert sp.creator == "@Bob"
-        assert sp.query == "auth"
+        SearchPlanning()
+        # SearchPlanning should only have inherited fields from BaseToolParam
+        field_names = set(SearchPlanning.model_fields.keys())
+        assert field_names == {"expose", "instructions"}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Remove dead `status`, `owner`, `creator`, `query` fields from `SearchPlanning` param class (they duplicated the factory-produced function signature and were never consumed at bind time)
- Add "BaseToolParam: Configuration, Not Schema" convention documentation to README under Architecture
- Update tests to assert only inherited fields remain on `SearchPlanning`

Closes #128

## Quality Gate
- 955 tests pass, 90.43% coverage
- mypy strict: clean
- ruff check: clean
- ruff format: clean (changed files only; 6 pre-existing formatting issues in other files)