### PR TITLE
Add graceful degradation to Tavily search tools

### DIFF
--- a/src/akgentic/tool/search/search.py
+++ b/src/akgentic/tool/search/search.py
@@ -1,8 +1,30 @@
+from __future__ import annotations
+
+import logging
+import os
 from typing import Any, Callable, Literal
 
 from tavily import TavilyClient
 
 from akgentic.tool.core import TOOL_CALL, BaseToolParam, ToolCard, _resolve
+
+logger = logging.getLogger(__name__)
+
+
+def _check_tavily_api_key() -> bool:
+    """Check whether ``TAVILY_API_KEY`` is configured in the environment.
+
+    Returns:
+        ``True`` when the key is present and non-empty, ``False`` otherwise.
+        A warning is logged when the key is missing.
+    """
+    if os.environ.get("TAVILY_API_KEY", "").strip():
+        return True
+    logger.warning(
+        "TAVILY_API_KEY is not set in the environment. "
+        "Tavily search tools will be non-functional until the key is configured."
+    )
+    return False
 
 
 class WebSearch(BaseToolParam):
@@ -41,6 +63,11 @@ class SearchTool(ToolCard):
     web_fetch: WebFetch | bool = True
 
     def get_tools(self) -> list[Callable]:
+        if not _check_tavily_api_key():
+            logger.warning(
+                "SearchTool: Tavily tools registered but will be non-functional "
+                "— TAVILY_API_KEY is not set."
+            )
         tools: list[Callable] = []
         ws = _resolve(self.web_search, WebSearch)
         if ws and TOOL_CALL in ws.expose:
@@ -73,18 +100,31 @@ class SearchTool(ToolCard):
                     - ``advanced``: higher relevance, potentially slower and more expensive.
                     If ``None``, Tavily default behavior is used.
             """
+            if not os.environ.get("TAVILY_API_KEY", "").strip():
+                return (
+                    "Web search is unavailable: TAVILY_API_KEY is not set. "
+                    "Ask the user to configure it and restart."
+                )
 
-            tavily_client = TavilyClient()
+            try:
+                tavily_client = TavilyClient()
 
-            search_kwargs: dict[str, Any] = {}
-            if search_depth is not None:
-                search_kwargs["search_depth"] = search_depth
+                search_kwargs: dict[str, Any] = {}
+                if search_depth is not None:
+                    search_kwargs["search_depth"] = search_depth
 
-            return tavily_client.search(
-                query,
-                max_results=max_results,
-                **search_kwargs,
-            )
+                return tavily_client.search(
+                    query,
+                    max_results=max_results,
+                    **search_kwargs,
+                )
+            except Exception as exc:
+                logger.warning("web_search failed: %s", exc)
+                return (
+                    f"Web search failed: {exc}. "
+                    "The TAVILY_API_KEY may be invalid or the service may be "
+                    "temporarily unavailable."
+                )
 
         web_search_tool.__doc__ = params.format_docstring(web_search_tool.__doc__)
         return web_search_tool
@@ -110,18 +150,31 @@ class SearchTool(ToolCard):
                       potentially slower and more expensive.
                     If ``None``, Tavily default behavior is used.
             """
+            if not os.environ.get("TAVILY_API_KEY", "").strip():
+                return (
+                    "Web fetch is unavailable: TAVILY_API_KEY is not set. "
+                    "Ask the user to configure it and restart."
+                )
 
-            tavily_client = TavilyClient()
+            try:
+                tavily_client = TavilyClient()
 
-            fetch_kwargs: dict[str, Any] = {}
-            if extract_depth is not None:
-                fetch_kwargs["extract_depth"] = extract_depth
+                fetch_kwargs: dict[str, Any] = {}
+                if extract_depth is not None:
+                    fetch_kwargs["extract_depth"] = extract_depth
 
-            return tavily_client.extract(
-                urls,
-                timeout=timeout,
-                **fetch_kwargs,
-            )
+                return tavily_client.extract(
+                    urls,
+                    timeout=timeout,
+                    **fetch_kwargs,
+                )
+            except Exception as exc:
+                logger.warning("web_fetch failed: %s", exc)
+                return (
+                    f"Web fetch failed: {exc}. "
+                    "The TAVILY_API_KEY may be invalid or the service may be "
+                    "temporarily unavailable."
+                )
 
         web_fetch_tool.__doc__ = params.format_docstring(web_fetch_tool.__doc__)
         return web_fetch_tool
@@ -158,26 +211,39 @@ class SearchTool(ToolCard):
                     - ``advanced``: richer extraction with higher latency/cost.
                     If ``None``, Tavily default behavior is used.
             """
+            if not os.environ.get("TAVILY_API_KEY", "").strip():
+                return (
+                    "Web crawl is unavailable: TAVILY_API_KEY is not set. "
+                    "Ask the user to configure it and restart."
+                )
 
-            tavily_client = TavilyClient()
+            try:
+                tavily_client = TavilyClient()
 
-            crawl_kwargs: dict[str, Any] = {}
-            if max_depth is not None:
-                crawl_kwargs["max_depth"] = max_depth
-            if max_breadth is not None:
-                crawl_kwargs["max_breadth"] = max_breadth
-            if limit is not None:
-                crawl_kwargs["limit"] = limit
-            if instructions is not None:
-                crawl_kwargs["instructions"] = instructions
-            if extract_depth is not None:
-                crawl_kwargs["extract_depth"] = extract_depth
+                crawl_kwargs: dict[str, Any] = {}
+                if max_depth is not None:
+                    crawl_kwargs["max_depth"] = max_depth
+                if max_breadth is not None:
+                    crawl_kwargs["max_breadth"] = max_breadth
+                if limit is not None:
+                    crawl_kwargs["limit"] = limit
+                if instructions is not None:
+                    crawl_kwargs["instructions"] = instructions
+                if extract_depth is not None:
+                    crawl_kwargs["extract_depth"] = extract_depth
 
-            return tavily_client.crawl(
-                url,
-                timeout=timeout,
-                **crawl_kwargs,
-            )
+                return tavily_client.crawl(
+                    url,
+                    timeout=timeout,
+                    **crawl_kwargs,
+                )
+            except Exception as exc:
+                logger.warning("web_crawl failed: %s", exc)
+                return (
+                    f"Web crawl failed: {exc}. "
+                    "The TAVILY_API_KEY may be invalid or the service may be "
+                    "temporarily unavailable."
+                )
 
         web_crawl_tool.__doc__ = params.format_docstring(web_crawl_tool.__doc__)
         return web_crawl_tool

--- a/src/akgentic/tool/search/search.py
+++ b/src/akgentic/tool/search/search.py
@@ -11,18 +11,23 @@ from akgentic.tool.core import TOOL_CALL, BaseToolParam, ToolCard, _resolve
 logger = logging.getLogger(__name__)
 
 
+def _has_tavily_api_key() -> bool:
+    """Return ``True`` when ``TAVILY_API_KEY`` is present and non-empty."""
+    return bool(os.environ.get("TAVILY_API_KEY", "").strip())
+
+
 def _check_tavily_api_key() -> bool:
-    """Check whether ``TAVILY_API_KEY`` is configured in the environment.
+    """Check whether ``TAVILY_API_KEY`` is configured and log a warning if not.
 
     Returns:
         ``True`` when the key is present and non-empty, ``False`` otherwise.
         A warning is logged when the key is missing.
     """
-    if os.environ.get("TAVILY_API_KEY", "").strip():
+    if _has_tavily_api_key():
         return True
     logger.warning(
         "TAVILY_API_KEY is not set in the environment. "
-        "Tavily search tools will be non-functional until the key is configured."
+        "Tavily search tools will be registered but non-functional until the key is configured."
     )
     return False
 
@@ -63,11 +68,7 @@ class SearchTool(ToolCard):
     web_fetch: WebFetch | bool = True
 
     def get_tools(self) -> list[Callable]:
-        if not _check_tavily_api_key():
-            logger.warning(
-                "SearchTool: Tavily tools registered but will be non-functional "
-                "— TAVILY_API_KEY is not set."
-            )
+        _check_tavily_api_key()
         tools: list[Callable] = []
         ws = _resolve(self.web_search, WebSearch)
         if ws and TOOL_CALL in ws.expose:
@@ -100,7 +101,7 @@ class SearchTool(ToolCard):
                     - ``advanced``: higher relevance, potentially slower and more expensive.
                     If ``None``, Tavily default behavior is used.
             """
-            if not os.environ.get("TAVILY_API_KEY", "").strip():
+            if not _has_tavily_api_key():
                 return (
                     "Web search is unavailable: TAVILY_API_KEY is not set. "
                     "Ask the user to configure it and restart."
@@ -150,7 +151,7 @@ class SearchTool(ToolCard):
                       potentially slower and more expensive.
                     If ``None``, Tavily default behavior is used.
             """
-            if not os.environ.get("TAVILY_API_KEY", "").strip():
+            if not _has_tavily_api_key():
                 return (
                     "Web fetch is unavailable: TAVILY_API_KEY is not set. "
                     "Ask the user to configure it and restart."
@@ -211,7 +212,7 @@ class SearchTool(ToolCard):
                     - ``advanced``: richer extraction with higher latency/cost.
                     If ``None``, Tavily default behavior is used.
             """
-            if not os.environ.get("TAVILY_API_KEY", "").strip():
+            if not _has_tavily_api_key():
                 return (
                     "Web crawl is unavailable: TAVILY_API_KEY is not set. "
                     "Ask the user to configure it and restart."

--- a/tests/search/test_search_graceful.py
+++ b/tests/search/test_search_graceful.py
@@ -8,8 +8,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from akgentic.tool.search.search import SearchTool
-
+from akgentic.tool.search.search import SearchTool, _check_tavily_api_key, _has_tavily_api_key
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -41,6 +40,57 @@ def _get_tool_by_name(tools: list, name: str) -> Any:
             return tool
     msg = f"Tool {name!r} not found in {[t.__name__ for t in tools]}"
     raise ValueError(msg)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _has_tavily_api_key / _check_tavily_api_key helpers
+# ---------------------------------------------------------------------------
+
+
+class TestHasTavilyApiKey:
+    """Direct unit tests for the _has_tavily_api_key helper."""
+
+    def test_returns_true_when_key_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("TAVILY_API_KEY", "sk-test-123")
+        assert _has_tavily_api_key() is True
+
+    def test_returns_false_when_key_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+        assert _has_tavily_api_key() is False
+
+    def test_returns_false_when_key_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("TAVILY_API_KEY", "")
+        assert _has_tavily_api_key() is False
+
+    def test_returns_false_when_key_whitespace_only(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("TAVILY_API_KEY", "   ")
+        assert _has_tavily_api_key() is False
+
+
+class TestCheckTavilyApiKey:
+    """Direct unit tests for _check_tavily_api_key (logs warning on missing key)."""
+
+    def test_returns_true_no_log_when_key_set(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        monkeypatch.setenv("TAVILY_API_KEY", "sk-test-123")
+        with caplog.at_level(logging.WARNING, logger="akgentic.tool.search.search"):
+            assert _check_tavily_api_key() is True
+        assert len(caplog.records) == 0
+
+    def test_returns_false_and_logs_when_key_unset(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+        with caplog.at_level(logging.WARNING, logger="akgentic.tool.search.search"):
+            assert _check_tavily_api_key() is False
+        assert any("non-functional" in rec.message for rec in caplog.records)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/search/test_search_graceful.py
+++ b/tests/search/test_search_graceful.py
@@ -1,0 +1,307 @@
+"""Tests for graceful degradation of Tavily search tools (Story 15-1)."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from akgentic.tool.search.search import SearchTool
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _MockTavilyClient:
+    """Fake TavilyClient that records calls and returns canned responses."""
+
+    def __init__(self) -> None:
+        self.search = MagicMock(return_value={"results": [{"title": "test"}]})
+        self.extract = MagicMock(return_value={"results": [{"url": "http://example.com"}]})
+        self.crawl = MagicMock(return_value={"results": [{"url": "http://example.com"}]})
+
+
+class _RaisingTavilyClient:
+    """Fake TavilyClient whose methods always raise."""
+
+    def __init__(self) -> None:
+        self.search = MagicMock(side_effect=RuntimeError("rate limit exceeded"))
+        self.extract = MagicMock(side_effect=RuntimeError("network timeout"))
+        self.crawl = MagicMock(side_effect=RuntimeError("invalid key"))
+
+
+def _get_tool_by_name(tools: list, name: str) -> Any:
+    """Return the tool function whose ``__name__`` matches *name*."""
+    for tool in tools:
+        if tool.__name__ == name:
+            return tool
+    msg = f"Tool {name!r} not found in {[t.__name__ for t in tools]}"
+    raise ValueError(msg)
+
+
+# ---------------------------------------------------------------------------
+# AC #1 — Startup warning when key is unset
+# ---------------------------------------------------------------------------
+
+
+class TestSearchToolStartupWarning:
+    """SearchTool.get_tools() logs a warning when TAVILY_API_KEY is unset."""
+
+    def test_warning_logged_when_key_unset(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+        with caplog.at_level(logging.WARNING, logger="akgentic.tool.search.search"):
+            SearchTool().get_tools()
+        assert any("non-functional" in rec.message for rec in caplog.records)
+
+    def test_no_warning_when_key_set(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        monkeypatch.setenv("TAVILY_API_KEY", "test-key")
+        with caplog.at_level(logging.WARNING, logger="akgentic.tool.search.search"):
+            SearchTool().get_tools()
+        assert not any("non-functional" in rec.message for rec in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# AC #2 — web_search graceful degradation
+# ---------------------------------------------------------------------------
+
+
+class TestWebSearchGraceful:
+    """web_search returns informative string when key is unset."""
+
+    def test_returns_message_when_key_unset(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+        # Need to set key temporarily so get_tools doesn't warn during tool creation
+        tools = SearchTool().get_tools()
+        tool = _get_tool_by_name(tools, "web_search_tool")
+        result = tool(query="test query")
+        assert isinstance(result, str)
+        assert "unavailable" in result.lower()
+        assert "TAVILY_API_KEY" in result
+
+    def test_no_exception_when_key_unset(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+        tools = SearchTool().get_tools()
+        tool = _get_tool_by_name(tools, "web_search_tool")
+        # Must not raise — just return a string
+        result = tool(query="test query")
+        assert isinstance(result, str)
+
+
+# ---------------------------------------------------------------------------
+# AC #3 — web_fetch graceful degradation
+# ---------------------------------------------------------------------------
+
+
+class TestWebFetchGraceful:
+    """web_fetch returns informative string when key is unset."""
+
+    def test_returns_message_when_key_unset(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+        tools = SearchTool().get_tools()
+        tool = _get_tool_by_name(tools, "web_fetch_tool")
+        result = tool(urls=["http://example.com"])
+        assert isinstance(result, str)
+        assert "unavailable" in result.lower()
+        assert "TAVILY_API_KEY" in result
+
+    def test_no_exception_when_key_unset(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+        tools = SearchTool().get_tools()
+        tool = _get_tool_by_name(tools, "web_fetch_tool")
+        result = tool(urls=["http://example.com"])
+        assert isinstance(result, str)
+
+
+# ---------------------------------------------------------------------------
+# AC #4 — web_crawl graceful degradation
+# ---------------------------------------------------------------------------
+
+
+class TestWebCrawlGraceful:
+    """web_crawl returns informative string when key is unset."""
+
+    def test_returns_message_when_key_unset(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+        tools = SearchTool().get_tools()
+        tool = _get_tool_by_name(tools, "web_crawl_tool")
+        result = tool(url="http://example.com")
+        assert isinstance(result, str)
+        assert "unavailable" in result.lower()
+        assert "TAVILY_API_KEY" in result
+
+    def test_no_exception_when_key_unset(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+        tools = SearchTool().get_tools()
+        tool = _get_tool_by_name(tools, "web_crawl_tool")
+        result = tool(url="http://example.com")
+        assert isinstance(result, str)
+
+
+# ---------------------------------------------------------------------------
+# AC #5 — Happy path (key set, API succeeds)
+# ---------------------------------------------------------------------------
+
+
+class TestSearchToolHappyPath:
+    """Tools work normally when key is set — TavilyClient is mocked."""
+
+    def test_web_search_happy_path(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("TAVILY_API_KEY", "test-key")
+        mock_client = _MockTavilyClient()
+        monkeypatch.setattr(
+            "akgentic.tool.search.search.TavilyClient", lambda: mock_client
+        )
+        tools = SearchTool().get_tools()
+        tool = _get_tool_by_name(tools, "web_search_tool")
+        result = tool(query="python testing")
+        assert result == {"results": [{"title": "test"}]}
+        mock_client.search.assert_called_once()
+
+    def test_web_fetch_happy_path(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("TAVILY_API_KEY", "test-key")
+        mock_client = _MockTavilyClient()
+        monkeypatch.setattr(
+            "akgentic.tool.search.search.TavilyClient", lambda: mock_client
+        )
+        tools = SearchTool().get_tools()
+        tool = _get_tool_by_name(tools, "web_fetch_tool")
+        result = tool(urls=["http://example.com"])
+        assert result == {"results": [{"url": "http://example.com"}]}
+        mock_client.extract.assert_called_once()
+
+    def test_web_crawl_happy_path(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("TAVILY_API_KEY", "test-key")
+        mock_client = _MockTavilyClient()
+        monkeypatch.setattr(
+            "akgentic.tool.search.search.TavilyClient", lambda: mock_client
+        )
+        tools = SearchTool().get_tools()
+        tool = _get_tool_by_name(tools, "web_crawl_tool")
+        result = tool(url="http://example.com")
+        assert result == {"results": [{"url": "http://example.com"}]}
+        mock_client.crawl.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# AC #6 — API error handling (key set, API fails)
+# ---------------------------------------------------------------------------
+
+
+class TestSearchToolApiError:
+    """Tools catch exceptions from TavilyClient and return error strings."""
+
+    def test_web_search_api_error(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        monkeypatch.setenv("TAVILY_API_KEY", "test-key")
+        mock_client = _RaisingTavilyClient()
+        monkeypatch.setattr(
+            "akgentic.tool.search.search.TavilyClient", lambda: mock_client
+        )
+        with caplog.at_level(logging.WARNING, logger="akgentic.tool.search.search"):
+            tools = SearchTool().get_tools()
+            tool = _get_tool_by_name(tools, "web_search_tool")
+            result = tool(query="test")
+        assert isinstance(result, str)
+        assert "failed" in result.lower()
+        assert "rate limit exceeded" in result
+        assert any("web_search failed" in rec.message for rec in caplog.records)
+
+    def test_web_fetch_api_error(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        monkeypatch.setenv("TAVILY_API_KEY", "test-key")
+        mock_client = _RaisingTavilyClient()
+        monkeypatch.setattr(
+            "akgentic.tool.search.search.TavilyClient", lambda: mock_client
+        )
+        with caplog.at_level(logging.WARNING, logger="akgentic.tool.search.search"):
+            tools = SearchTool().get_tools()
+            tool = _get_tool_by_name(tools, "web_fetch_tool")
+            result = tool(urls=["http://example.com"])
+        assert isinstance(result, str)
+        assert "failed" in result.lower()
+        assert "network timeout" in result
+        assert any("web_fetch failed" in rec.message for rec in caplog.records)
+
+    def test_web_crawl_api_error(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        monkeypatch.setenv("TAVILY_API_KEY", "test-key")
+        mock_client = _RaisingTavilyClient()
+        monkeypatch.setattr(
+            "akgentic.tool.search.search.TavilyClient", lambda: mock_client
+        )
+        with caplog.at_level(logging.WARNING, logger="akgentic.tool.search.search"):
+            tools = SearchTool().get_tools()
+            tool = _get_tool_by_name(tools, "web_crawl_tool")
+            result = tool(url="http://example.com")
+        assert isinstance(result, str)
+        assert "failed" in result.lower()
+        assert "invalid key" in result
+        assert any("web_crawl failed" in rec.message for rec in caplog.records)
+
+    def test_client_construction_error(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """TavilyClient() itself raises — still caught gracefully."""
+        monkeypatch.setenv("TAVILY_API_KEY", "test-key")
+
+        def _raise_on_construct() -> None:
+            msg = "invalid API key format"
+            raise ValueError(msg)
+
+        monkeypatch.setattr(
+            "akgentic.tool.search.search.TavilyClient", _raise_on_construct
+        )
+        tools = SearchTool().get_tools()
+        tool = _get_tool_by_name(tools, "web_search_tool")
+        result = tool(query="test")
+        assert isinstance(result, str)
+        assert "failed" in result.lower()


### PR DESCRIPTION
## Summary

- Add `_check_tavily_api_key()` startup validation with warning when `TAVILY_API_KEY` is unset
- Add early-return guards in all three tool functions (web_search, web_fetch, web_crawl) returning actionable error messages to the LLM when key is missing
- Wrap TavilyClient construction and API calls in try/except for runtime error resilience (rate limits, network timeouts, invalid keys)
- Tools remain registered when key is unset so the LLM can inform users the capability exists but is unconfigured
- Extract `_has_tavily_api_key()` pure check to eliminate repeated env var checks (DRY)
- 21 tests across 8 test classes covering all acceptance criteria

Closes #132