### PR TITLE
Replace address.stop() with proxy-based stop in fire member

### DIFF
--- a/src/akgentic/tool/team/team.py
+++ b/src/akgentic/tool/team/team.py
@@ -11,6 +11,7 @@ from typing import Callable
 from pydantic import Field
 
 from akgentic.core.actor_address import ActorAddress
+from akgentic.core.agent import Akgent
 from akgentic.core.agent_card import AgentCard
 from akgentic.core.orchestrator import Orchestrator
 from akgentic.tool.core import (
@@ -148,7 +149,7 @@ def _fire_single_member(
             f"Current team members: {team_members}"
         )
 
-    address.stop()
+    observer.proxy_ask(address, Akgent).stop()
     observer.on_fire(address)
     logger.info(f"Fired team member: {name}")
     return name

--- a/tests/test_team_tool.py
+++ b/tests/test_team_tool.py
@@ -205,7 +205,7 @@ def test_hire_members_string_agent_class():
 
 
 def test_fire_members_tool_execution():
-    """fire_members looks up address, calls address.stop(), calls on_fire hook."""
+    """fire_members looks up address, calls observer.proxy_ask(address, Akgent).stop(), calls on_fire hook."""
     member_address = Mock()
     member_address.name = "@Developer123"
     member_address.role = "Developer"
@@ -213,9 +213,21 @@ def test_fire_members_tool_execution():
     orchestrator_mock = Mock(spec=Orchestrator)
     orchestrator_mock.get_team_member.return_value = member_address
 
+    stop_proxy_mock = Mock()
+
     observer_mock = Mock(spec=TeamManagementToolObserver)
     observer_mock.orchestrator = create_test_address("@Orchestrator", "Orchestrator")
-    observer_mock.proxy_ask.return_value = orchestrator_mock
+
+    def proxy_ask_side_effect(target, actor_type):
+        from akgentic.core.agent import Akgent
+
+        if actor_type is Orchestrator:
+            return orchestrator_mock
+        if actor_type is Akgent:
+            return stop_proxy_mock
+        return Mock()
+
+    observer_mock.proxy_ask.side_effect = proxy_ask_side_effect
 
     tool = TeamTool()
     tool.observer(observer_mock)
@@ -226,7 +238,7 @@ def test_fire_members_tool_execution():
     assert "Developer123" in result
     assert "fired" in result.lower()
     orchestrator_mock.get_team_member.assert_called_once_with("@Developer123")
-    member_address.stop.assert_called_once()  # address.stop() called
+    stop_proxy_mock.stop.assert_called_once()  # proxy-based stop called
     observer_mock.on_fire.assert_called_once()  # Hook called
 
 
@@ -475,7 +487,7 @@ def test_fire_members_batch_with_multiple_errors():
 
 
 def test_fire_members_batch_partial_success():
-    """fire_members continues on errors and fires valid members."""
+    """fire_members continues on errors and fires valid members via proxy-based stop."""
     valid_address = Mock()
     valid_address.name = "@Valid123"
     valid_address.role = "Developer"
@@ -490,9 +502,21 @@ def test_fire_members_batch_partial_success():
     orchestrator_mock.get_team_member.side_effect = get_member_side_effect
     orchestrator_mock.get_team.return_value = []
 
+    stop_proxy_mock = Mock()
+
     observer_mock = Mock(spec=TeamManagementToolObserver)
     observer_mock.orchestrator = create_test_address("@Orchestrator", "Orchestrator")
-    observer_mock.proxy_ask.return_value = orchestrator_mock
+
+    def proxy_ask_side_effect(target, actor_type):
+        from akgentic.core.agent import Akgent
+
+        if actor_type is Orchestrator:
+            return orchestrator_mock
+        if actor_type is Akgent:
+            return stop_proxy_mock
+        return Mock()
+
+    observer_mock.proxy_ask.side_effect = proxy_ask_side_effect
 
     tool = TeamTool()
     tool.observer(observer_mock)
@@ -502,8 +526,8 @@ def test_fire_members_batch_partial_success():
     with pytest.raises(RetriableError) as exc_info:
         fire_members(["@Valid123", "@NonExistent"])
 
-    # Should have stopped the valid one before failing
-    valid_address.stop.assert_called_once()
+    # Should have stopped the valid one via proxy-based stop
+    stop_proxy_mock.stop.assert_called_once()
     # Error should mention partial success and the invalid member
     assert "Partial success" in str(exc_info.value)
     assert "NonExistent" in str(exc_info.value)
@@ -639,7 +663,7 @@ def test_hire_member_command_invalid_role():
 
 
 def test_fire_member_command_execution():
-    """fire_member command fires a single member."""
+    """fire_member command fires a single member via proxy-based stop."""
     member_address = Mock()
     member_address.name = "@Developer123"
     member_address.role = "Developer"
@@ -647,9 +671,21 @@ def test_fire_member_command_execution():
     orchestrator_mock = Mock(spec=Orchestrator)
     orchestrator_mock.get_team_member.return_value = member_address
 
+    stop_proxy_mock = Mock()
+
     observer_mock = Mock(spec=TeamManagementToolObserver)
     observer_mock.orchestrator = create_test_address("@Orchestrator", "Orchestrator")
-    observer_mock.proxy_ask.return_value = orchestrator_mock
+
+    def proxy_ask_side_effect(target, actor_type):
+        from akgentic.core.agent import Akgent
+
+        if actor_type is Orchestrator:
+            return orchestrator_mock
+        if actor_type is Akgent:
+            return stop_proxy_mock
+        return Mock()
+
+    observer_mock.proxy_ask.side_effect = proxy_ask_side_effect
 
     tool = TeamTool()
     tool.observer(observer_mock)
@@ -659,7 +695,7 @@ def test_fire_member_command_execution():
 
     assert "Developer123" in result
     assert "fired" in result.lower()
-    member_address.stop.assert_called_once()
+    stop_proxy_mock.stop.assert_called_once()  # proxy-based stop called
     observer_mock.on_fire.assert_called_once()
 
 

--- a/tests/test_team_tool.py
+++ b/tests/test_team_tool.py
@@ -8,6 +8,7 @@ from unittest.mock import Mock
 import pytest
 from akgentic.core import ActorAddressProxy
 from akgentic.core.actor_address import ActorAddress
+from akgentic.core.agent import Akgent
 from akgentic.core.agent_card import AgentCard
 from akgentic.core.agent_config import BaseConfig
 from akgentic.core.orchestrator import Orchestrator
@@ -180,7 +181,7 @@ def test_hire_members_invalid_role():
 
 
 def test_hire_members_string_agent_class():
-    """hire_members raises ValueError if get_agent_class() returns a string (non-recoverable config error)."""
+    """hire_members raises ValueError if get_agent_class() returns a string."""
     # Mock AgentCard with get_agent_class returning a string
     agent_card = Mock(spec=AgentCard)
     agent_card.role = "Developer"
@@ -205,7 +206,7 @@ def test_hire_members_string_agent_class():
 
 
 def test_fire_members_tool_execution():
-    """fire_members looks up address, calls observer.proxy_ask(address, Akgent).stop(), calls on_fire hook."""
+    """fire_members looks up address, stops via proxy_ask, calls on_fire hook."""
     member_address = Mock()
     member_address.name = "@Developer123"
     member_address.role = "Developer"
@@ -219,8 +220,6 @@ def test_fire_members_tool_execution():
     observer_mock.orchestrator = create_test_address("@Orchestrator", "Orchestrator")
 
     def proxy_ask_side_effect(target, actor_type):
-        from akgentic.core.agent import Akgent
-
         if actor_type is Orchestrator:
             return orchestrator_mock
         if actor_type is Akgent:
@@ -238,6 +237,7 @@ def test_fire_members_tool_execution():
     assert "Developer123" in result
     assert "fired" in result.lower()
     orchestrator_mock.get_team_member.assert_called_once_with("@Developer123")
+    observer_mock.proxy_ask.assert_any_call(member_address, Akgent)
     stop_proxy_mock.stop.assert_called_once()  # proxy-based stop called
     observer_mock.on_fire.assert_called_once()  # Hook called
 
@@ -508,8 +508,6 @@ def test_fire_members_batch_partial_success():
     observer_mock.orchestrator = create_test_address("@Orchestrator", "Orchestrator")
 
     def proxy_ask_side_effect(target, actor_type):
-        from akgentic.core.agent import Akgent
-
         if actor_type is Orchestrator:
             return orchestrator_mock
         if actor_type is Akgent:
@@ -527,6 +525,7 @@ def test_fire_members_batch_partial_success():
         fire_members(["@Valid123", "@NonExistent"])
 
     # Should have stopped the valid one via proxy-based stop
+    observer_mock.proxy_ask.assert_any_call(valid_address, Akgent)
     stop_proxy_mock.stop.assert_called_once()
     # Error should mention partial success and the invalid member
     assert "Partial success" in str(exc_info.value)
@@ -677,8 +676,6 @@ def test_fire_member_command_execution():
     observer_mock.orchestrator = create_test_address("@Orchestrator", "Orchestrator")
 
     def proxy_ask_side_effect(target, actor_type):
-        from akgentic.core.agent import Akgent
-
         if actor_type is Orchestrator:
             return orchestrator_mock
         if actor_type is Akgent:
@@ -695,6 +692,7 @@ def test_fire_member_command_execution():
 
     assert "Developer123" in result
     assert "fired" in result.lower()
+    observer_mock.proxy_ask.assert_any_call(member_address, Akgent)
     stop_proxy_mock.stop.assert_called_once()  # proxy-based stop called
     observer_mock.on_fire.assert_called_once()
 


### PR DESCRIPTION
## Summary

- Replace `orchestrator_proxy.proxy_tell(address, Akgent).stop()` with `observer.proxy_ask(address, Akgent).stop()` in `_fire_single_member`, aligning with the proxy-based lifecycle pattern from akgentic-core ADR-006
- Update 3 fire tests to use `side_effect`-based `proxy_ask` mock dispatch and assert proxy-based stop
- Code review fixes: lint E501 violations, add proxy_ask argument assertions, consolidate duplicate imports

## Review Fixes Applied
- Fixed E501 lint violation in `test_fire_members_tool_execution` docstring (110 > 100 chars)
- Fixed pre-existing E501 in `test_hire_members_string_agent_class` docstring
- Added `observer_mock.proxy_ask.assert_any_call(address, Akgent)` assertions to all 3 fire tests to verify correct address is passed
- Moved `Akgent` import to module level, removing 3 duplicate local imports in `proxy_ask_side_effect` closures

Closes #134