### PR TITLE
feat: emit ToolStateEvent from KnowledgeGraphActor (Story 17.2)

### DIFF
--- a/src/akgentic/tool/knowledge_graph/kg_actor.py
+++ b/src/akgentic/tool/knowledge_graph/kg_actor.py
@@ -19,6 +19,7 @@ from pydantic import Field
 from akgentic.core.agent import Akgent
 from akgentic.core.agent_config import BaseConfig
 from akgentic.tool.errors import RetriableError
+from akgentic.tool.event import ToolStateEvent
 from akgentic.tool.knowledge_graph.models import (
     Entity,
     EntityCreate,
@@ -26,6 +27,7 @@ from akgentic.tool.knowledge_graph.models import (
     GetGraphQuery,
     GraphView,
     KnowledgeGraphState,
+    KnowledgeGraphStateEvent,
     ManageGraph,
     PathStep,
     Relation,
@@ -86,6 +88,7 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
         self.state.observer(self)
         self._vector_index = VectorIndex()
         self._embedding_svc: EmbeddingService | None = None
+        self._state_event_seq: int = 0
 
     # ------------------------------------------------------------------
     # Embedding helpers
@@ -186,13 +189,14 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
     # CRUD: Create
     # ------------------------------------------------------------------
 
-    def _create_entities(self, entities: list[EntityCreate]) -> list[str]:
+    def _create_entities(self, entities: list[EntityCreate]) -> tuple[list[Entity], list[str]]:
         """Add new entities, skipping duplicates by name.
 
         Returns:
-            List of error strings for duplicate names already in graph.
+            Tuple of (applied entities, error strings for duplicate names).
         """
         errors: list[str] = []
+        applied: list[Entity] = []
         existing_names = {e.name for e in self.state.knowledge_graph.entities}
 
         for ec in entities:
@@ -210,15 +214,20 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
             self.state.knowledge_graph.entities.append(entity)
             existing_names.add(ec.name)
             self._embed_entity(entity)
-        return errors
+            applied.append(entity)
+        return applied, errors
 
-    def _create_relations(self, relations: list[RelationCreate]) -> list[str]:
+    def _create_relations(
+        self, relations: list[RelationCreate]
+    ) -> tuple[list[Relation], list[str]]:
         """Add new relations, validating entity references and deduplicating.
 
         Returns:
-            List of error strings for missing entity references or duplicates.
+            Tuple of (applied relations, error strings for missing refs).
+            Duplicate triples are silently skipped and NOT included in applied.
         """
         errors: list[str] = []
+        applied: list[Relation] = []
         existing_names = {e.name for e in self.state.knowledge_graph.entities}
         existing_triples = {
             (r.from_entity, r.to_entity, r.relation_type)
@@ -248,22 +257,26 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
             self.state.knowledge_graph.relations.append(relation)
             existing_triples.add(triple)
             self._embed_relation(relation)
-        return errors
+            applied.append(relation)
+        return applied, errors
 
     # ------------------------------------------------------------------
     # CRUD: Update
     # ------------------------------------------------------------------
 
-    def _update_entities(self, updates: list[EntityUpdate]) -> list[str]:
+    def _update_entities(self, updates: list[EntityUpdate]) -> tuple[list[Entity], list[str]]:
         """Apply partial updates to existing entities.
 
         Only non-None fields are applied. ``add_observations`` appends,
-        ``remove_observations`` removes from the existing list.
+        ``remove_observations`` removes from the existing list. An entity
+        appears in the applied list only if at least one mutation
+        effectively changed it.
 
         Returns:
-            List of error strings for entities not found.
+            Tuple of (post-update snapshots of changed entities, errors).
         """
         errors: list[str] = []
+        applied: list[Entity] = []
         entity_map = self._entity_map()
 
         for eu in updates:
@@ -272,34 +285,50 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
                 errors.append(f"Entity '{eu.name}' not found for update")
                 continue
 
+            changed: bool = False
+
             if eu.description is not None and eu.description != entity.description:
                 self._vector_index.remove({str(entity.id)})
                 entity.description = eu.description
                 self._embed_entity(entity)
+                changed = True
             elif eu.description is not None:
+                # Same value -> no-op
                 entity.description = eu.description
-            if eu.entity_type is not None:
+            if eu.entity_type is not None and eu.entity_type != entity.entity_type:
                 entity.entity_type = eu.entity_type
-            if eu.is_root is not None:
+                changed = True
+            if eu.is_root is not None and eu.is_root != entity.is_root:
                 entity.is_root = eu.is_root
-            if eu.add_observations is not None:
+                changed = True
+            if eu.add_observations:
                 entity.observations.extend(eu.add_observations)
+                changed = True
             if eu.remove_observations is not None:
                 to_remove = set(eu.remove_observations)
-                entity.observations = [o for o in entity.observations if o not in to_remove]
-        return errors
+                before = entity.observations
+                after = [o for o in before if o not in to_remove]
+                if len(after) != len(before):
+                    changed = True
+                entity.observations = after
+
+            if changed:
+                applied.append(entity)
+        return applied, errors
 
     # ------------------------------------------------------------------
     # CRUD: Delete
     # ------------------------------------------------------------------
 
-    def _delete_entities(self, names: list[str]) -> list[str]:
+    def _delete_entities(
+        self, names: list[str]
+    ) -> tuple[list[uuid.UUID], list[uuid.UUID], list[str]]:
         """Remove entities by name with cascade deletion of relations.
 
         Also removes any associated VectorEntry embeddings from the vector index.
 
         Returns:
-            List of error strings for entities not found.
+            Tuple of (deleted entity ids, cascaded relation ids, errors).
         """
         errors: list[str] = []
         existing_names = {e.name for e in self.state.knowledge_graph.entities}
@@ -310,44 +339,48 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
 
         names_set = set(names) & existing_names
 
-        if names_set:
-            # Collect UUIDs of deleted entities for embedding removal
-            _deleted_ids = [
-                e.id for e in self.state.knowledge_graph.entities if e.name in names_set
-            ]
+        if not names_set:
+            return [], [], errors
 
-            # Collect UUIDs of cascade-deleted relations
-            _deleted_rel_ids = [
-                r.id
-                for r in self.state.knowledge_graph.relations
-                if r.from_entity in names_set or r.to_entity in names_set
-            ]
+        # Collect UUIDs of deleted entities for embedding removal
+        deleted_entity_ids: list[uuid.UUID] = [
+            e.id for e in self.state.knowledge_graph.entities if e.name in names_set
+        ]
 
-            # Remove entities
-            self.state.knowledge_graph.entities = [
-                e for e in self.state.knowledge_graph.entities if e.name not in names_set
-            ]
+        # Collect UUIDs of cascade-deleted relations
+        cascaded_rel_ids: list[uuid.UUID] = [
+            r.id
+            for r in self.state.knowledge_graph.relations
+            if r.from_entity in names_set or r.to_entity in names_set
+        ]
 
-            # Cascade-delete relations referencing deleted entities
-            self.state.knowledge_graph.relations = [
-                r
-                for r in self.state.knowledge_graph.relations
-                if r.from_entity not in names_set and r.to_entity not in names_set
-            ]
+        # Remove entities
+        self.state.knowledge_graph.entities = [
+            e for e in self.state.knowledge_graph.entities if e.name not in names_set
+        ]
 
-            self._vector_index.remove(
-                {str(eid) for eid in _deleted_ids} | {str(rid) for rid in _deleted_rel_ids}
-            )
+        # Cascade-delete relations referencing deleted entities
+        self.state.knowledge_graph.relations = [
+            r
+            for r in self.state.knowledge_graph.relations
+            if r.from_entity not in names_set and r.to_entity not in names_set
+        ]
 
-        return errors
+        self._vector_index.remove(
+            {str(eid) for eid in deleted_entity_ids} | {str(rid) for rid in cascaded_rel_ids}
+        )
 
-    def _delete_relations(self, deletions: list[RelationDelete]) -> list[str]:
+        return deleted_entity_ids, cascaded_rel_ids, errors
+
+    def _delete_relations(
+        self, deletions: list[RelationDelete]
+    ) -> tuple[list[uuid.UUID], list[str]]:
         """Remove relations by ``(from_entity, to_entity, relation_type)`` triple.
 
         Also removes any associated VectorEntry embeddings from the vector index.
 
         Returns:
-            List of error strings for relations not found.
+            Tuple of (ids of relations actually removed, errors).
         """
         errors: list[str] = []
         existing_triples = {
@@ -365,9 +398,9 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
             else:
                 triples_to_delete.add(triple)
 
+        deleted_rel_ids: list[uuid.UUID] = []
         if triples_to_delete:
-            # Collect UUIDs for embedding removal
-            _deleted_rel_ids = [
+            deleted_rel_ids = [
                 r.id
                 for r in self.state.knowledge_graph.relations
                 if (r.from_entity, r.to_entity, r.relation_type) in triples_to_delete
@@ -379,9 +412,9 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
                 if (r.from_entity, r.to_entity, r.relation_type) not in triples_to_delete
             ]
 
-            self._vector_index.remove({str(rid) for rid in _deleted_rel_ids})
+            self._vector_index.remove({str(rid) for rid in deleted_rel_ids})
 
-        return errors
+        return deleted_rel_ids, errors
 
     # ------------------------------------------------------------------
     # Public API
@@ -408,17 +441,66 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
         """
         errors: list[str] = []
 
-        errors.extend(self._create_entities(update.create_entities))
-        errors.extend(self._create_relations(update.create_relations))
-        errors.extend(self._update_entities(update.update_entities))
-        errors.extend(self._delete_relations(update.delete_relations))
-        errors.extend(self._delete_entities(update.delete_entities))
+        created_entities, errs = self._create_entities(update.create_entities)
+        errors.extend(errs)
+
+        created_relations, errs = self._create_relations(update.create_relations)
+        errors.extend(errs)
+
+        modified_entities, errs = self._update_entities(update.update_entities)
+        errors.extend(errs)
+
+        deleted_relation_ids, errs = self._delete_relations(update.delete_relations)
+        errors.extend(errs)
+
+        deleted_entity_ids, cascaded_relation_ids, errs = self._delete_entities(
+            update.delete_entities
+        )
+        errors.extend(errs)
+
+        # Merge explicit + cascaded relation deletions, preserving order and deduping.
+        merged_relations_removed: list[uuid.UUID] = list(deleted_relation_ids)
+        seen_rel_ids: set[uuid.UUID] = set(deleted_relation_ids)
+        for rid in cascaded_relation_ids:
+            if rid not in seen_rel_ids:
+                merged_relations_removed.append(rid)
+                seen_rel_ids.add(rid)
+
+        delta = KnowledgeGraphStateEvent(
+            entities_added=created_entities,
+            entities_modified=modified_entities,
+            entities_removed=deleted_entity_ids,
+            relations_added=created_relations,
+            relations_removed=merged_relations_removed,
+        )
 
         self.state.notify_state_change()
+
+        if self._delta_is_non_empty(delta):
+            self._state_event_seq += 1
+            self.notify_event(
+                ToolStateEvent(
+                    tool_id=KG_ACTOR_NAME,
+                    seq=self._state_event_seq,
+                    payload=delta,
+                )
+            )
 
         if errors:
             raise RetriableError("Update errors: " + "; ".join(errors))
         return "Done"
+
+    @staticmethod
+    def _delta_is_non_empty(delta: KnowledgeGraphStateEvent) -> bool:
+        """Return ``True`` iff any collection on the delta is non-empty."""
+        return bool(
+            delta.entities_added
+            or delta.entities_modified
+            or delta.entities_removed
+            or delta.relations_added
+            or delta.relations_modified
+            or delta.relations_removed
+        )
 
     def get_graph(self, query: GetGraphQuery | None = None) -> GraphView:
         """Return a full or filtered subgraph view.
@@ -751,9 +833,7 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
         for kw_hit in keyword_result.hits:
             if kw_hit.ref_id in merged:
                 existing = merged[kw_hit.ref_id]
-                merged[kw_hit.ref_id] = existing.model_copy(
-                    update={"score": existing.score + 0.5}
-                )
+                merged[kw_hit.ref_id] = existing.model_copy(update={"score": existing.score + 0.5})
             else:
                 merged[kw_hit.ref_id] = kw_hit  # keyword-only hit (score = 1.0)
 
@@ -798,9 +878,7 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
 
         return SearchResult(hits=sorted(hits, key=lambda h: h.score, reverse=True)[:top_k])
 
-    def _expand_search_result(
-        self, hits: list[SearchHit], query: SearchQuery
-    ) -> SearchResult:
+    def _expand_search_result(self, hits: list[SearchHit], query: SearchQuery) -> SearchResult:
         """Post-process search hits with Epic 3 expansion options.
 
         Applies ``include_neighbors``, ``include_edges``, and ``find_paths``

--- a/tests/test_kg_state_event.py
+++ b/tests/test_kg_state_event.py
@@ -1,0 +1,448 @@
+"""Tests for ToolStateEvent emission from KnowledgeGraphActor (Story 17.2, ADR-024).
+
+These tests exercise the actor's emission contract — the single-event-per-batch
+rule, the monotonic ``seq`` counter, the empty / partial-failure rules, and the
+envelope shape. The orchestrator is not required: each test installs a
+``MagicMock`` on ``actor.notify_event`` to capture emitted events.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from akgentic.tool.errors import RetriableError
+from akgentic.tool.event import ToolStateEvent
+from akgentic.tool.knowledge_graph.kg_actor import (
+    KG_ACTOR_NAME,
+    KnowledgeGraphActor,
+)
+from akgentic.tool.knowledge_graph.models import (
+    EntityCreate,
+    EntityUpdate,
+    KnowledgeGraphStateEvent,
+    ManageGraph,
+    RelationCreate,
+    RelationDelete,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _actor() -> KnowledgeGraphActor:
+    """Create and initialize a KnowledgeGraphActor for testing (same as test_kg_actor)."""
+    actor = KnowledgeGraphActor()
+    actor.on_start()
+    return actor
+
+
+def _capture(actor: KnowledgeGraphActor) -> list[Any]:
+    """Replace ``actor.notify_event`` with a capture-list-backed MagicMock.
+
+    Returns:
+        The list that will be populated with each emitted event, in order.
+    """
+    captured: list[Any] = []
+    actor.notify_event = MagicMock(side_effect=lambda evt: captured.append(evt))  # type: ignore[method-assign]
+    return captured
+
+
+class _StateNotifyObserver:
+    """Minimal observer that counts ``notify_state_change`` invocations."""
+
+    def __init__(self) -> None:
+        self.calls: int = 0
+
+    def notify_state_change(self, state: object) -> None:
+        self.calls += 1
+
+
+# ---------------------------------------------------------------------------
+# Scenario (a) — create-entities-only batch
+# ---------------------------------------------------------------------------
+
+
+def test_create_entities_emits_single_event_with_added() -> None:
+    actor = _actor()
+    captured = _capture(actor)
+
+    actor.update_graph(
+        ManageGraph(
+            create_entities=[
+                EntityCreate(name="Alice", entity_type="Person", description="Engineer")
+            ]
+        )
+    )
+
+    assert len(captured) == 1
+    event = captured[0]
+    assert isinstance(event, ToolStateEvent)
+    assert event.tool_id == KG_ACTOR_NAME
+    assert event.seq == 1
+    assert isinstance(event.payload, KnowledgeGraphStateEvent)
+    assert event.payload.entities_added == actor.get_graph().entities
+    assert event.payload.entities_modified == []
+    assert event.payload.entities_removed == []
+    assert event.payload.relations_added == []
+    assert event.payload.relations_modified == []
+    assert event.payload.relations_removed == []
+
+
+# ---------------------------------------------------------------------------
+# Scenario (b) — create-relations batch, seq increments
+# ---------------------------------------------------------------------------
+
+
+def test_create_relations_emits_added_and_seq_increments() -> None:
+    actor = _actor()
+    captured = _capture(actor)
+
+    actor.update_graph(
+        ManageGraph(
+            create_entities=[
+                EntityCreate(name="Alice", entity_type="Person", description="Engineer"),
+                EntityCreate(name="Bob", entity_type="Person", description="Designer"),
+            ]
+        )
+    )
+    assert len(captured) == 1
+    assert captured[0].seq == 1
+
+    actor.update_graph(
+        ManageGraph(
+            create_relations=[
+                RelationCreate(from_entity="Alice", to_entity="Bob", relation_type="knows")
+            ]
+        )
+    )
+    assert len(captured) == 2
+    second = captured[1]
+    assert second.seq == 2
+    assert second.payload.entities_added == []
+    assert len(second.payload.relations_added) == 1
+    assert second.payload.relations_added[0].from_entity == "Alice"
+
+
+# ---------------------------------------------------------------------------
+# Scenario (c) — update with description change emits modified snapshot
+# ---------------------------------------------------------------------------
+
+
+def test_update_entity_description_emits_modified_with_post_state() -> None:
+    actor = _actor()
+    captured = _capture(actor)
+
+    actor.update_graph(
+        ManageGraph(
+            create_entities=[
+                EntityCreate(name="Alice", entity_type="Person", description="Engineer")
+            ]
+        )
+    )
+    actor.update_graph(
+        ManageGraph(update_entities=[EntityUpdate(name="Alice", description="Architect")])
+    )
+
+    assert len(captured) == 2
+    update_event = captured[1]
+    assert update_event.seq == 2
+    assert update_event.payload.entities_added == []
+    assert len(update_event.payload.entities_modified) == 1
+    assert update_event.payload.entities_modified[0].description == "Architect"
+
+
+# ---------------------------------------------------------------------------
+# Scenario (d) — no-op update emits nothing
+# ---------------------------------------------------------------------------
+
+
+def test_update_entity_no_op_emits_nothing() -> None:
+    actor = _actor()
+    captured = _capture(actor)
+
+    actor.update_graph(
+        ManageGraph(
+            create_entities=[
+                EntityCreate(name="Alice", entity_type="Person", description="Engineer")
+            ]
+        )
+    )
+
+    observer = _StateNotifyObserver()
+    actor.state.observer(observer)  # type: ignore[arg-type]
+    baseline = observer.calls
+
+    # Description matches existing value -> no-op
+    actor.update_graph(
+        ManageGraph(update_entities=[EntityUpdate(name="Alice", description="Engineer")])
+    )
+
+    assert len(captured) == 1  # only the seed event
+    assert actor._state_event_seq == 1
+    # notify_state_change still invoked on the second update_graph call
+    assert observer.calls > baseline
+
+
+# ---------------------------------------------------------------------------
+# Scenario (e) — delete entity with no incident relations
+# ---------------------------------------------------------------------------
+
+
+def test_delete_entity_no_relations_emits_entities_removed() -> None:
+    actor = _actor()
+    captured = _capture(actor)
+
+    actor.update_graph(
+        ManageGraph(
+            create_entities=[
+                EntityCreate(name="Alice", entity_type="Person", description="Engineer")
+            ]
+        )
+    )
+    alice_id = actor.get_graph().entities[0].id
+
+    actor.update_graph(ManageGraph(delete_entities=["Alice"]))
+
+    assert len(captured) == 2
+    delete_event = captured[1]
+    assert delete_event.seq == 2
+    assert delete_event.payload.entities_removed == [alice_id]
+    assert delete_event.payload.relations_removed == []
+
+
+# ---------------------------------------------------------------------------
+# Scenario (f) — delete entity with cascade
+# ---------------------------------------------------------------------------
+
+
+def test_delete_entity_cascades_single_event() -> None:
+    actor = _actor()
+    captured = _capture(actor)
+
+    actor.update_graph(
+        ManageGraph(
+            create_entities=[
+                EntityCreate(name="Alice", entity_type="Person", description="Engineer"),
+                EntityCreate(name="Bob", entity_type="Person", description="Designer"),
+            ],
+            create_relations=[
+                RelationCreate(from_entity="Alice", to_entity="Bob", relation_type="knows")
+            ],
+        )
+    )
+
+    graph = actor.get_graph()
+    alice_id = next(e.id for e in graph.entities if e.name == "Alice")
+    rel_id = graph.relations[0].id
+
+    actor.update_graph(ManageGraph(delete_entities=["Alice"]))
+
+    assert len(captured) == 2
+    cascade_event = captured[1]
+    assert cascade_event.payload.entities_removed == [alice_id]
+    assert cascade_event.payload.relations_removed == [rel_id]
+
+
+# ---------------------------------------------------------------------------
+# Scenario (g) — duplicate batch emits nothing but still notifies state
+# ---------------------------------------------------------------------------
+
+
+def test_duplicate_batch_emits_nothing_but_notifies_state_change() -> None:
+    actor = _actor()
+    captured = _capture(actor)
+
+    actor.update_graph(
+        ManageGraph(
+            create_entities=[
+                EntityCreate(name="Alice", entity_type="Person", description="Engineer")
+            ]
+        )
+    )
+    assert len(captured) == 1
+
+    observer = _StateNotifyObserver()
+    actor.state.observer(observer)  # type: ignore[arg-type]
+    baseline = observer.calls
+
+    with pytest.raises(RetriableError):
+        actor.update_graph(
+            ManageGraph(
+                create_entities=[
+                    EntityCreate(name="Alice", entity_type="Person", description="Engineer")
+                ]
+            )
+        )
+
+    assert len(captured) == 1  # no new event
+    assert actor._state_event_seq == 1
+    assert observer.calls > baseline
+
+
+# ---------------------------------------------------------------------------
+# Scenario (h) — partial failure emits before raising
+# ---------------------------------------------------------------------------
+
+
+def test_partial_failure_emits_before_raise() -> None:
+    actor = _actor()
+    captured = _capture(actor)
+
+    actor.update_graph(
+        ManageGraph(
+            create_entities=[
+                EntityCreate(name="Alice", entity_type="Person", description="Engineer")
+            ]
+        )
+    )
+    assert len(captured) == 1
+
+    with pytest.raises(RetriableError):
+        actor.update_graph(
+            ManageGraph(
+                create_entities=[
+                    EntityCreate(name="Bob", entity_type="Person", description="Designer"),
+                    EntityCreate(name="Alice", entity_type="Person", description="Duplicate Alice"),
+                ]
+            )
+        )
+
+    # Event for the Bob success was emitted before the raise.
+    assert len(captured) == 2
+    partial_event = captured[1]
+    assert partial_event.seq == 2
+    assert len(partial_event.payload.entities_added) == 1
+    assert partial_event.payload.entities_added[0].name == "Bob"
+
+
+# ---------------------------------------------------------------------------
+# Scenario (i) — seq monotonic
+# ---------------------------------------------------------------------------
+
+
+def test_seq_is_monotonic_across_batches() -> None:
+    actor = _actor()
+    captured = _capture(actor)
+
+    for name in ["A", "B", "C"]:
+        actor.update_graph(
+            ManageGraph(
+                create_entities=[EntityCreate(name=name, entity_type="Person", description="x")]
+            )
+        )
+
+    assert [e.seq for e in captured] == [1, 2, 3]
+
+
+# ---------------------------------------------------------------------------
+# Scenario (j) — mixed batch single event, no duplicate cascaded ids
+# ---------------------------------------------------------------------------
+
+
+def test_mixed_batch_single_event_with_all_sections() -> None:
+    actor = _actor()
+    captured = _capture(actor)
+
+    # Seed: Alice, Bob, Carol; two relations — Alice→Bob (knows), Alice→Carol (knows).
+    actor.update_graph(
+        ManageGraph(
+            create_entities=[
+                EntityCreate(name="Alice", entity_type="Person", description="Engineer"),
+                EntityCreate(name="Bob", entity_type="Person", description="Designer"),
+                EntityCreate(name="Carol", entity_type="Person", description="PM"),
+            ],
+            create_relations=[
+                RelationCreate(from_entity="Alice", to_entity="Bob", relation_type="knows"),
+                RelationCreate(from_entity="Alice", to_entity="Carol", relation_type="knows"),
+            ],
+        )
+    )
+    assert len(captured) == 1
+
+    # Mixed batch: create new entity Dave, create new relation Bob→Carol,
+    # update Carol's description, and explicitly delete Alice→Bob (knows).
+    actor.update_graph(
+        ManageGraph(
+            create_entities=[EntityCreate(name="Dave", entity_type="Person", description="QA")],
+            create_relations=[
+                RelationCreate(from_entity="Bob", to_entity="Carol", relation_type="works_with")
+            ],
+            update_entities=[EntityUpdate(name="Carol", description="Senior PM")],
+            delete_relations=[
+                RelationDelete(from_entity="Alice", to_entity="Bob", relation_type="knows")
+            ],
+        )
+    )
+
+    assert len(captured) == 2
+    mixed_event = captured[1]
+    payload = mixed_event.payload
+    assert len(payload.entities_added) == 1
+    assert payload.entities_added[0].name == "Dave"
+    assert len(payload.relations_added) == 1
+    assert payload.relations_added[0].from_entity == "Bob"
+    assert len(payload.entities_modified) == 1
+    assert payload.entities_modified[0].name == "Carol"
+    assert payload.entities_modified[0].description == "Senior PM"
+    assert len(payload.relations_removed) == 1  # the Alice→Bob relation
+
+    # Follow-up: delete an entity whose incident relation was already
+    # removed in the earlier batch — assert no duplicate relation id
+    # appears in relations_removed (dedup across explicit + cascade).
+    # Alice→Carol still exists; delete Alice, cascading only Alice→Carol.
+    carol_rel_id = next(
+        r.id
+        for r in actor.get_graph().relations
+        if r.from_entity == "Alice" and r.to_entity == "Carol"
+    )
+    actor.update_graph(ManageGraph(delete_entities=["Alice"]))
+
+    assert len(captured) == 3
+    cascade_event = captured[2]
+    # Only the cascade id should appear, exactly once.
+    assert cascade_event.payload.relations_removed == [carol_rel_id]
+    assert len(cascade_event.payload.relations_removed) == len(
+        set(cascade_event.payload.relations_removed)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Scenario (k) — on_start emits no event
+# ---------------------------------------------------------------------------
+
+
+def test_on_start_emits_no_event() -> None:
+    actor = KnowledgeGraphActor()
+    notify = MagicMock()
+    actor.notify_event = notify  # type: ignore[method-assign]
+    actor.on_start()
+    assert notify.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Scenario (l) — envelope shape
+# ---------------------------------------------------------------------------
+
+
+def test_event_envelope_shape() -> None:
+    actor = _actor()
+    captured = _capture(actor)
+
+    actor.update_graph(
+        ManageGraph(
+            create_entities=[
+                EntityCreate(name="Alice", entity_type="Person", description="Engineer")
+            ]
+        )
+    )
+
+    event = captured[0]
+    assert isinstance(event, ToolStateEvent)
+    assert isinstance(event.payload, KnowledgeGraphStateEvent)
+    assert event.tool_id == KG_ACTOR_NAME
+    assert event.seq >= 1
+    assert hasattr(event, "team_id")


### PR DESCRIPTION
## Summary

Implements Story 17.2 — `KnowledgeGraphActor.update_graph` now emits a single `ToolStateEvent` per non-empty batch, aggregated into a `KnowledgeGraphStateEvent` payload (ADR-024 §2–§3).

- Per-instance monotonic `_state_event_seq` counter (starts at 0; first emitted event carries `seq=1`).
- Five private mutation helpers now return `tuple[applied_models, errors]`; duplicate triples, all-no-op updates, and missing-entity failures never land in `applied`.
- Explicit + cascaded relation deletions merged with order-preserving deduplication.
- Empty delta → no event, no seq bump (`state.notify_state_change()` still called).
- Partial failure → event emitted BEFORE `RetriableError` is raised.
- `on_start()` emits no event.

## Test coverage

- 12 new unit tests in `tests/test_kg_state_event.py` covering AC-10 scenarios (a)–(l).
- Full submodule suite: 1003 passed (`pytest packages/akgentic-tool/tests/` with `--cov-fail-under=80`).
- `ruff check packages/akgentic-tool/src/`: clean.
- `mypy --strict packages/akgentic-tool/src/`: clean.

## Stacked on

This PR is stacked on `feat/137-tool-state-event-envelope` (Story 17.1, PR #138).

Relates to #139
