### PR TITLE
feat: VectorStoreActor abstraction layer (Epic 10-12)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ vector_search = [
     "openai>=1.0.0",
     "numpy>=1.26.0",
 ]
+weaviate = ["weaviate-client>=4.9.0"]
 docs = ["markitdown[pdf,docx,xlsx,xls,pptx,outlook]>=0.1"]
 vision = ["Pillow>=10.0"]
 dev = [

--- a/src/akgentic/tool/knowledge_graph/__init__.py
+++ b/src/akgentic/tool/knowledge_graph/__init__.py
@@ -55,14 +55,7 @@ from akgentic.tool.knowledge_graph.models import (
     SearchQuery,
     SearchResult,
 )
-from akgentic.tool.vector import (
-    EmbeddingService,
-    VectorEntry,
-    VectorIndex,
-)
-from akgentic.tool.vector import (
-    _check_vector_search_dependencies as _check_kg_dependencies,
-)
+from akgentic.tool.vector import _check_vector_search_dependencies as _check_kg_dependencies
 
 __all__ = [
     # Core domain models
@@ -83,8 +76,6 @@ __all__ = [
     "SearchQuery",
     "SearchHit",
     "SearchResult",
-    # Vector index models (Story 2.1)
-    "VectorEntry",
     # ToolCard (Story 1.3)
     "KnowledgeGraphTool",
     "GetGraph",
@@ -95,9 +86,6 @@ __all__ = [
     "KnowledgeGraphConfig",
     "KG_ACTOR_NAME",
     "KG_ACTOR_ROLE",
-    # Vector index services (Story 2.1)
-    "EmbeddingService",
-    "VectorIndex",
     # Utilities
     "_check_kg_dependencies",
 ]

--- a/src/akgentic/tool/knowledge_graph/kg_actor.py
+++ b/src/akgentic/tool/knowledge_graph/kg_actor.py
@@ -12,12 +12,10 @@ from __future__ import annotations
 import logging
 import uuid
 from collections import deque
-from typing import Literal
-
-from pydantic import Field
 
 from akgentic.core.agent import Akgent
 from akgentic.core.agent_config import BaseConfig
+from akgentic.core.orchestrator import Orchestrator
 from akgentic.tool.errors import RetriableError
 from akgentic.tool.knowledge_graph.models import (
     Entity,
@@ -35,7 +33,10 @@ from akgentic.tool.knowledge_graph.models import (
     SearchQuery,
     SearchResult,
 )
-from akgentic.tool.vector import EmbeddingService, VectorEntry, VectorIndex
+from akgentic.tool.vector import VectorEntry
+from akgentic.tool.vector_store.actor import VS_ACTOR_NAME, VectorStoreActor
+from akgentic.tool.vector_store.protocol import CollectionConfig
+from akgentic.tool.vector_store.protocol import SearchResult as VsSearchResult
 
 logger = logging.getLogger(__name__)
 
@@ -45,22 +46,16 @@ KG_ACTOR_NAME: str = "#KnowledgeGraphTool"
 KG_ACTOR_ROLE: str = "ToolActor"
 """Actor role constant for ToolCard integration."""
 
+KG_COLLECTION: str = "knowledge_graph"
+"""Collection name used in VectorStoreActor."""
+
 
 class KnowledgeGraphConfig(BaseConfig):
-    """Configuration for ``KnowledgeGraphActor`` with embedding provider settings.
+    """Configuration for ``KnowledgeGraphActor``.
 
-    Extends ``BaseConfig`` with the embedding model and provider fields so
-    the actor can initialize ``EmbeddingService`` from its config object.
+    An empty ``BaseConfig`` subclass retained for type stability
+    (the actor generic parameter still references it).
     """
-
-    embedding_model: str = Field(
-        default="text-embedding-3-small",
-        description="OpenAI embedding model identifier",
-    )
-    embedding_provider: Literal["openai", "azure"] = Field(
-        default="openai",
-        description="Which OpenAI SDK variant to use for embeddings",
-    )
 
 
 class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
@@ -81,54 +76,69 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
     # ------------------------------------------------------------------
 
     def on_start(self) -> None:  # noqa: ANN201
-        """Initialize state, attach observer, and set up the vector index."""
+        """Initialize state, attach observer, and acquire VectorStoreActor proxy."""
         self.state = KnowledgeGraphState()
         self.state.observer(self)
-        self._vector_index = VectorIndex()
-        self._embedding_svc: EmbeddingService | None = None
+        self._vs_proxy: VectorStoreActor | None = None
+        self._acquire_vs_proxy()
 
-    # ------------------------------------------------------------------
-    # Embedding helpers
-    # ------------------------------------------------------------------
+    def _acquire_vs_proxy(self) -> None:
+        """Acquire the VectorStoreActor proxy and create the KG collection.
 
-    def _get_or_create_embedding_svc(self) -> EmbeddingService | None:
-        """Return the ``EmbeddingService``, creating it lazily on first call.
-
-        Returns:
-            The service instance, or ``None`` if creation fails (e.g. missing deps).
+        Operates in degraded mode (no vector search) if the proxy cannot
+        be acquired.
         """
-        if self._embedding_svc is None:
-            try:
-                self._embedding_svc = EmbeddingService(
-                    model=self.config.embedding_model,
-                    provider=self.config.embedding_provider,
-                )
-            except Exception as exc:  # noqa: BLE001
+        try:
+            if self.orchestrator is None:
                 logger.warning(
-                    "[%s] Failed to initialize EmbeddingService: %s", self.config.name, exc
+                    "[%s] No orchestrator; operating in degraded mode",
+                    self.config.name,
                 )
-                return None
-        return self._embedding_svc
+                return
+            orch_proxy = self.proxy_ask(self.orchestrator, Orchestrator)
+            vs_addr = orch_proxy.get_team_member(VS_ACTOR_NAME)
+            if vs_addr is None:
+                logger.warning(
+                    "[%s] VectorStoreActor not found; operating in degraded mode",
+                    self.config.name,
+                )
+                return
+            self._vs_proxy = self.proxy_ask(vs_addr, VectorStoreActor)
+            self._vs_proxy.create_collection(KG_COLLECTION, CollectionConfig())
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "[%s] Failed to acquire VectorStoreActor proxy: %s",
+                self.config.name,
+                exc,
+            )
+
+    # ------------------------------------------------------------------
+    # Embedding helpers (via VectorStoreActor proxy)
+    # ------------------------------------------------------------------
 
     def _embed_entity(self, entity: Entity) -> None:
-        """Embed an entity and store the result in the vector index.
+        """Embed an entity and store the result via VectorStoreActor proxy.
 
-        Silently logs a WARNING and returns if the embedding service is
-        unavailable or if the API call fails (AC-7).
+        Silently logs a WARNING and returns if the proxy is unavailable
+        or if the embedding call fails.
         """
-        svc = self._get_or_create_embedding_svc()
-        if svc is None:
+        if self._vs_proxy is None:
             return
         try:
             text = f"{entity.name}: {entity.description}"
-            vectors = svc.embed([text])
-            self._vector_index.add(
-                VectorEntry(
-                    ref_type="entity",
-                    ref_id=str(entity.id),
-                    text=text,
-                    vector=vectors[0],
-                )
+            vectors = self._vs_proxy.embed([text])
+            if not vectors:
+                return
+            self._vs_proxy.add(
+                KG_COLLECTION,
+                [
+                    VectorEntry(
+                        ref_type="entity",
+                        ref_id=str(entity.id),
+                        text=text,
+                        vector=vectors[0],
+                    )
+                ],
             )
         except Exception as exc:  # noqa: BLE001
             logger.warning(
@@ -139,30 +149,34 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
         """Embed a relation if it has a non-empty description.
 
         Relations without descriptions are not embedded (no meaningful text).
-        Silently logs WARNING on embedding failure (AC-7).
+        Silently logs WARNING on embedding failure.
         """
         if not relation.description:
             return
-        svc = self._get_or_create_embedding_svc()
-        if svc is None:
+        if self._vs_proxy is None:
             return
         try:
             text = (
                 f"{relation.from_entity} {relation.relation_type} "
                 f"{relation.to_entity}: {relation.description}"
             )
-            vectors = svc.embed([text])
-            self._vector_index.add(
-                VectorEntry(
-                    ref_type="relation",
-                    ref_id=str(relation.id),
-                    text=text,
-                    vector=vectors[0],
-                )
+            vectors = self._vs_proxy.embed([text])
+            if not vectors:
+                return
+            self._vs_proxy.add(
+                KG_COLLECTION,
+                [
+                    VectorEntry(
+                        ref_type="relation",
+                        ref_id=str(relation.id),
+                        text=text,
+                        vector=vectors[0],
+                    )
+                ],
             )
         except Exception as exc:  # noqa: BLE001
             logger.warning(
-                "[%s] Failed to embed relation '%s→%s': %s",
+                "[%s] Failed to embed relation '%s->%s': %s",
                 self.config.name,
                 relation.from_entity,
                 relation.to_entity,
@@ -273,7 +287,8 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
                 continue
 
             if eu.description is not None and eu.description != entity.description:
-                self._vector_index.remove({str(entity.id)})
+                if self._vs_proxy is not None:
+                    self._vs_proxy.remove(KG_COLLECTION, [str(entity.id)])
                 entity.description = eu.description
                 self._embed_entity(entity)
             elif eu.description is not None:
@@ -335,9 +350,11 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
                 if r.from_entity not in names_set and r.to_entity not in names_set
             ]
 
-            self._vector_index.remove(
-                {str(eid) for eid in _deleted_ids} | {str(rid) for rid in _deleted_rel_ids}
-            )
+            if self._vs_proxy is not None:
+                ref_ids = [str(eid) for eid in _deleted_ids] + [
+                    str(rid) for rid in _deleted_rel_ids
+                ]
+                self._vs_proxy.remove(KG_COLLECTION, ref_ids)
 
         return errors
 
@@ -379,7 +396,8 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
                 if (r.from_entity, r.to_entity, r.relation_type) not in triples_to_delete
             ]
 
-            self._vector_index.remove({str(rid) for rid in _deleted_rel_ids})
+            if self._vs_proxy is not None:
+                self._vs_proxy.remove(KG_COLLECTION, [str(rid) for rid in _deleted_rel_ids])
 
         return errors
 
@@ -684,8 +702,8 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
     def _vector_search(self, query_text: str, top_k: int) -> SearchResult:
         """Embed ``query_text`` and return top-k results by cosine similarity.
 
-        Returns an empty ``SearchResult`` when the embedding service is
-        unavailable, the index is empty, or the embedding call fails.
+        Returns an empty ``SearchResult`` when the VectorStoreActor proxy is
+        unavailable or the embedding call fails.
 
         Args:
             query_text: The natural-language query to embed and search.
@@ -694,17 +712,26 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
         Returns:
             ``SearchResult`` with hits ranked by cosine similarity score.
         """
-        svc = self._get_or_create_embedding_svc()
-        if svc is None or len(self._vector_index) == 0:
+        if self._vs_proxy is None:
             return SearchResult(hits=[])
         try:
-            vectors = svc.embed([query_text])
+            vectors = self._vs_proxy.embed([query_text])
+            if not vectors:
+                return SearchResult(hits=[])
             query_vector = vectors[0]
         except Exception as exc:  # noqa: BLE001
             logger.warning("[%s] Vector search embedding failed: %s", self.config.name, exc)
             return SearchResult(hits=[])
 
-        pairs = self._vector_index.search_cosine(query_vector, top_k)
+        try:
+            vs_result: VsSearchResult = self._vs_proxy.search(
+                KG_COLLECTION, query_vector, top_k
+            )
+            pairs = [(hit.ref_id, hit.score) for hit in vs_result.hits]
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[%s] Vector search failed: %s", self.config.name, exc)
+            return SearchResult(hits=[])
+
         hits: list[SearchHit] = []
         for ref_id, score in pairs:
             obj = self._resolve_ref(ref_id)

--- a/src/akgentic/tool/knowledge_graph/kg_actor.py
+++ b/src/akgentic/tool/knowledge_graph/kg_actor.py
@@ -291,8 +291,6 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
                     self._vs_proxy.remove(KG_COLLECTION, [str(entity.id)])
                 entity.description = eu.description
                 self._embed_entity(entity)
-            elif eu.description is not None:
-                entity.description = eu.description
             if eu.entity_type is not None:
                 entity.entity_type = eu.entity_type
             if eu.is_root is not None:
@@ -311,7 +309,7 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
     def _delete_entities(self, names: list[str]) -> list[str]:
         """Remove entities by name with cascade deletion of relations.
 
-        Also removes any associated VectorEntry embeddings from the vector index.
+        Also removes any associated VectorEntry embeddings from VectorStoreActor.
 
         Returns:
             List of error strings for entities not found.
@@ -361,7 +359,7 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
     def _delete_relations(self, deletions: list[RelationDelete]) -> list[str]:
         """Remove relations by ``(from_entity, to_entity, relation_type)`` triple.
 
-        Also removes any associated VectorEntry embeddings from the vector index.
+        Also removes any associated VectorEntry embeddings from VectorStoreActor.
 
         Returns:
             List of error strings for relations not found.

--- a/src/akgentic/tool/knowledge_graph/kg_tool.py
+++ b/src/akgentic/tool/knowledge_graph/kg_tool.py
@@ -38,6 +38,8 @@ from akgentic.tool.knowledge_graph.models import (
     SearchQuery,
     SearchResult,
 )
+from akgentic.tool.vector_store.actor import VS_ACTOR_NAME, VectorStoreActor
+from akgentic.tool.vector_store.protocol import VectorStoreConfig
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -114,8 +116,8 @@ class KnowledgeGraphTool(ToolCard):
     def observer(self, observer: ActorToolObserver) -> None:  # type: ignore[override]
         """Attach observer and set up the KG actor proxy.
 
-        Creates/retrieves the singleton ``KnowledgeGraphActor`` via the
-        orchestrator, identical to PlanningTool's observer pattern.
+        Ensures the ``VectorStoreActor`` singleton exists (AC10) before
+        creating/retrieving the ``KnowledgeGraphActor`` singleton.
         """
         from akgentic.tool.knowledge_graph import _check_kg_dependencies
 
@@ -126,8 +128,23 @@ class KnowledgeGraphTool(ToolCard):
             raise ValueError("KnowledgeGraphTool requires access to the orchestrator.")
 
         orchestrator_proxy = observer.proxy_ask(observer.orchestrator, Orchestrator)
-        kg_addr = orchestrator_proxy.get_team_member(KG_ACTOR_NAME)
 
+        # Ensure VectorStoreActor singleton exists (AC10)
+        vs_addr = orchestrator_proxy.get_team_member(VS_ACTOR_NAME)
+        if vs_addr is None:
+            logger.info("KnowledgeGraphTool: creating singleton %s.", VS_ACTOR_NAME)
+            vs_addr = orchestrator_proxy.createActor(
+                VectorStoreActor,
+                config=VectorStoreConfig(
+                    name=VS_ACTOR_NAME,
+                    role="ToolActor",
+                    embedding_model=self.embedding_model,
+                    embedding_provider=self.embedding_provider,
+                ),
+            )
+
+        # Create/retrieve KnowledgeGraphActor singleton
+        kg_addr = orchestrator_proxy.get_team_member(KG_ACTOR_NAME)
         if kg_addr is None:
             logger.info("KnowledgeGraphTool: creating singleton %s.", KG_ACTOR_NAME)
             kg_addr = orchestrator_proxy.createActor(
@@ -135,8 +152,6 @@ class KnowledgeGraphTool(ToolCard):
                 config=KnowledgeGraphConfig(
                     name=KG_ACTOR_NAME,
                     role=KG_ACTOR_ROLE,
-                    embedding_model=self.embedding_model,
-                    embedding_provider=self.embedding_provider,
                 ),
             )
 

--- a/src/akgentic/tool/knowledge_graph/models.py
+++ b/src/akgentic/tool/knowledge_graph/models.py
@@ -16,7 +16,6 @@ from pydantic import Field
 
 from akgentic.core.agent_state import BaseState
 from akgentic.core.utils.serializer import SerializableBaseModel
-from akgentic.tool.vector import VectorEntry as VectorEntry  # re-exported for KG consumers
 
 # ---------------------------------------------------------------------------
 # Core domain models

--- a/src/akgentic/tool/knowledge_graph/vector_index.py
+++ b/src/akgentic/tool/knowledge_graph/vector_index.py
@@ -1,5 +1,0 @@
-"""Backward-compat shim — import from akgentic.tool.vector instead."""
-
-from akgentic.tool.vector import EmbeddingService, VectorIndex  # noqa: F401
-
-__all__ = ["EmbeddingService", "VectorIndex"]

--- a/src/akgentic/tool/planning/planning.py
+++ b/src/akgentic/tool/planning/planning.py
@@ -23,6 +23,8 @@ from akgentic.tool.planning.planning_actor import (
     TaskStatus,
     UpdatePlan,
 )
+from akgentic.tool.vector_store.actor import VS_ACTOR_NAME, VS_ACTOR_ROLE, VectorStoreActor
+from akgentic.tool.vector_store.protocol import VectorStoreConfig
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -97,6 +99,9 @@ class PlanningTool(ToolCard):
     def observer(self, observer: ActorToolObserver) -> None:  # type: ignore[override]
         """Attach observer and set up the planning actor proxy.
 
+        Ensures the ``VectorStoreActor`` singleton exists before
+        creating/retrieving the ``PlanActor`` singleton.
+
         Requires an ActorToolObserver for actor system access.
         """
         self._observer = observer
@@ -104,15 +109,29 @@ class PlanningTool(ToolCard):
             raise ValueError("PlanningTool requires access to the orchestrator.")
 
         orchestrator_proxy_ask = observer.proxy_ask(observer.orchestrator, Orchestrator)
+
+        # Ensure VectorStoreActor singleton exists (AC10)
+        vs_addr = orchestrator_proxy_ask.get_team_member(VS_ACTOR_NAME)
+        if vs_addr is None:
+            logger.info("PlanningTool: creating singleton %s.", VS_ACTOR_NAME)
+            vs_addr = orchestrator_proxy_ask.createActor(
+                VectorStoreActor,
+                config=VectorStoreConfig(
+                    name=VS_ACTOR_NAME,
+                    role=VS_ACTOR_ROLE,
+                    embedding_model=self.embedding_model,
+                    embedding_provider=self.embedding_provider,
+                ),
+            )
+
+        # Create/retrieve PlanActor singleton
         planning_tool_addr = orchestrator_proxy_ask.get_team_member(PLANNING_ACTOR_NAME)
 
         if planning_tool_addr is None:
-            logger.info(f"PlanningTool: create {PLANNING_ACTOR_NAME}.")
+            logger.info("PlanningTool: creating %s.", PLANNING_ACTOR_NAME)
             config = PlanConfig(
                 name=PLANNING_ACTOR_NAME,
                 role=PLANNING_ACTOR_ROLE,
-                embedding_model=self.embedding_model,
-                embedding_provider=self.embedding_provider,
             )
             planning_tool_addr = orchestrator_proxy_ask.createActor(PlanActor, config=config)
 

--- a/src/akgentic/tool/planning/planning_actor.py
+++ b/src/akgentic/tool/planning/planning_actor.py
@@ -2,17 +2,18 @@ from __future__ import annotations
 
 import datetime
 import logging
-from typing import TYPE_CHECKING, Literal
+from typing import Literal
 
 from pydantic import BaseModel, Field, field_validator
 
 from akgentic.core.actor_address import ActorAddress
 from akgentic.core.agent import Akgent, BaseConfig, BaseState
+from akgentic.core.orchestrator import Orchestrator
 from akgentic.core.utils.serializer import SerializableBaseModel
 from akgentic.tool.errors import RetriableError
-
-if TYPE_CHECKING:
-    from akgentic.tool.vector import EmbeddingService, VectorIndex
+from akgentic.tool.vector import VectorEntry
+from akgentic.tool.vector_store.actor import VS_ACTOR_NAME, VectorStoreActor
+from akgentic.tool.vector_store.protocol import CollectionConfig
 
 logger = logging.getLogger(__name__)
 
@@ -83,16 +84,18 @@ class PlanManagerState(BaseState):
     task_list: list[Task] = Field(default_factory=list)
 
 
+PLAN_COLLECTION: str = "planning"
+"""Collection name used in VectorStoreActor."""
+
+
 class PlanConfig(BaseConfig):
     """Configuration for PlanActor with optional semantic search support."""
 
-    embedding_model: str = Field(default="text-embedding-3-small")
-    embedding_provider: Literal["openai", "azure"] = Field(default="openai")
     semantic_search: bool = Field(
         default=True,
         description=(
             "When True, task descriptions are embedded on create/update/delete "
-            "for semantic search. Falls back gracefully if [vector_search] deps are not installed."
+            "for semantic search. Falls back gracefully if VectorStoreActor is unavailable."
         ),
     )
 
@@ -121,62 +124,62 @@ class PlanActor(Akgent[PlanConfig, PlanManagerState]):
                 name=self.config.name,
                 role=self.config.role,
             )
-        # Only instantiate VectorIndex (which imports numpy) when semantic_search is enabled.
-        # This preserves the graceful fallback behaviour: if numpy is absent and
-        # semantic_search=False, on_start must not crash (AC#7, AC#8).
-        self._vector_index: VectorIndex | None = None
+        self._vs_proxy: VectorStoreActor | None = None
         if self.config.semantic_search:
-            from akgentic.tool.vector import VectorIndex
+            self._acquire_vs_proxy()
 
-            self._vector_index = VectorIndex()
-        self._embedding_svc: EmbeddingService | None = None
+    def _acquire_vs_proxy(self) -> None:
+        """Acquire the VectorStoreActor proxy and create the planning collection.
 
-    def _get_or_create_embedding_svc(self) -> EmbeddingService | None:
-        """Return (or lazily create) the EmbeddingService.
-
-        Returns None when semantic_search is disabled or [vector_search]
-        optional dependencies are not installed.
+        Operates in degraded mode (no vector search) if the proxy cannot
+        be acquired.
         """
-        if not self.config.semantic_search:
-            return None
-        if self._embedding_svc is None:
-            try:
-                from akgentic.tool.vector import EmbeddingService, _check_vector_search_dependencies
-
-                _check_vector_search_dependencies()
-            except ImportError:
-                return None
-            self._embedding_svc = EmbeddingService(
-                model=self.config.embedding_model,
-                provider=self.config.embedding_provider,
+        try:
+            if self.orchestrator is None:
+                logger.warning(
+                    "[%s] No orchestrator; operating in degraded mode",
+                    self.config.name,
+                )
+                return
+            orch_proxy = self.proxy_ask(self.orchestrator, Orchestrator)
+            vs_addr = orch_proxy.get_team_member(VS_ACTOR_NAME)
+            if vs_addr is None:
+                logger.warning(
+                    "[%s] VectorStoreActor not found; operating in degraded mode",
+                    self.config.name,
+                )
+                return
+            self._vs_proxy = self.proxy_ask(vs_addr, VectorStoreActor)
+            self._vs_proxy.create_collection(PLAN_COLLECTION, CollectionConfig())
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "[%s] Failed to acquire VectorStoreActor proxy: %s",
+                self.config.name,
+                exc,
             )
-        return self._embedding_svc
 
     def _embed_task(self, task: Task) -> None:
         """Embed a task's description and store the resulting VectorEntry.
 
-        Called after task create or update. Does nothing when embedding service
-        is unavailable (semantic_search=False or missing deps). Any embedding
-        error (import, network, auth) is logged and swallowed so that task CRUD
+        Called after task create or update. Does nothing when VectorStoreActor
+        proxy is unavailable (semantic_search=False or proxy not acquired).
+        Any embedding error is logged and swallowed so that task CRUD
         is never interrupted by a transient embedding failure.
         """
+        if self._vs_proxy is None:
+            return
         try:
-            svc = self._get_or_create_embedding_svc()
-            if svc is None or self._vector_index is None:
+            vectors = self._vs_proxy.embed([task.description])
+            if not vectors:
                 return
-            from akgentic.tool.vector import VectorEntry
-
-            vector = svc.embed([task.description])[0]
             entry = VectorEntry(
                 ref_type="task",
                 ref_id=str(task.id),
                 text=task.description,
-                vector=vector,
+                vector=vectors[0],
             )
-            self._vector_index.add(entry)
-        except ImportError:
-            logger.warning("Vector search deps missing — skipping embedding for task %s", task.id)
-        except Exception:
+            self._vs_proxy.add(PLAN_COLLECTION, [entry])
+        except Exception:  # noqa: BLE001
             logger.warning(
                 "Embedding failed for task %s — semantic index not updated", task.id, exc_info=True
             )
@@ -202,9 +205,9 @@ class PlanActor(Akgent[PlanConfig, PlanManagerState]):
                 if (
                     self.config.semantic_search
                     and description_changed
-                    and self._vector_index is not None
+                    and self._vs_proxy is not None
                 ):
-                    self._vector_index.remove({str(task.id)})
+                    self._vs_proxy.remove(PLAN_COLLECTION, [str(task.id)])
                     self._embed_task(updated_task)
                 return None
         return f"Update error - no task with ID {task_update.id} found."
@@ -263,15 +266,16 @@ class PlanActor(Akgent[PlanConfig, PlanManagerState]):
             keyword_ids = {t.id for t in tasks if q_lower in t.description.lower()}
 
             semantic_ids: set[int] = set()
-            svc = self._get_or_create_embedding_svc()
-            if svc is not None and self._vector_index is not None and len(self._vector_index) > 0:
+            if self._vs_proxy is not None:
                 try:
-                    query_vector = svc.embed([query])[0]
-                    pairs = self._vector_index.search_cosine(query_vector, top_k=20)
-                    for ref_id, score in pairs:
-                        if score >= 0.5:
-                            semantic_ids.add(int(ref_id))
-                except Exception:
+                    vectors = self._vs_proxy.embed([query])
+                    if vectors:
+                        query_vector = vectors[0]
+                        result = self._vs_proxy.search(PLAN_COLLECTION, query_vector, 20)
+                        for hit in result.hits:
+                            if hit.score >= 0.5:
+                                semantic_ids.add(int(hit.ref_id))
+                except Exception:  # noqa: BLE001
                     logger.warning(
                         "Semantic search failed for query — falling back to keyword only",
                         exc_info=True,
@@ -310,8 +314,8 @@ class PlanActor(Akgent[PlanConfig, PlanManagerState]):
             if not any(task.id == task_id for task in self.state.task_list):
                 errors.append(f"Delete error - no task with ID {task_id} found.")
             else:
-                if self.config.semantic_search and self._vector_index is not None:
-                    self._vector_index.remove({str(task_id)})
+                if self.config.semantic_search and self._vs_proxy is not None:
+                    self._vs_proxy.remove(PLAN_COLLECTION, [str(task_id)])
                 self.state.task_list = [task for task in self.state.task_list if task.id != task_id]
 
         self.state.notify_state_change()

--- a/src/akgentic/tool/vector_store/__init__.py
+++ b/src/akgentic/tool/vector_store/__init__.py
@@ -19,6 +19,11 @@ from akgentic.tool.vector_store.embedding_actor import (
     EmbeddingResult,
 )
 from akgentic.tool.vector_store.inmemory import InMemoryBackend
+
+try:
+    from akgentic.tool.vector_store.weaviate import WeaviateBackend
+except ImportError:
+    WeaviateBackend = None  # type: ignore[assignment,misc]
 from akgentic.tool.vector_store.protocol import (
     CollectionConfig,
     CollectionStatus,
@@ -38,6 +43,7 @@ __all__ = [
     "EmbeddingRequest",
     "EmbeddingResult",
     "InMemoryBackend",
+    "WeaviateBackend",
     "SearchHit",
     "SearchResult",
     "VS_ACTOR_NAME",

--- a/src/akgentic/tool/vector_store/__init__.py
+++ b/src/akgentic/tool/vector_store/__init__.py
@@ -6,6 +6,7 @@ directly from ``akgentic.tool.vector_store``.
 
 from __future__ import annotations
 
+from akgentic.tool.vector_store.inmemory import InMemoryBackend
 from akgentic.tool.vector_store.protocol import (
     CollectionConfig,
     CollectionStatus,
@@ -20,6 +21,7 @@ __all__ = [
     "CollectionConfig",
     "CollectionStatus",
     "EmbeddingProvider",
+    "InMemoryBackend",
     "SearchHit",
     "SearchResult",
     "VectorStoreConfig",

--- a/src/akgentic/tool/vector_store/__init__.py
+++ b/src/akgentic/tool/vector_store/__init__.py
@@ -12,6 +12,12 @@ from akgentic.tool.vector_store.actor import (
     VectorStoreActor,
     VectorStoreState,
 )
+from akgentic.tool.vector_store.embedding_actor import (
+    EmbeddingActor,
+    EmbeddingError,
+    EmbeddingRequest,
+    EmbeddingResult,
+)
 from akgentic.tool.vector_store.inmemory import InMemoryBackend
 from akgentic.tool.vector_store.protocol import (
     CollectionConfig,
@@ -26,7 +32,11 @@ from akgentic.tool.vector_store.protocol import (
 __all__ = [
     "CollectionConfig",
     "CollectionStatus",
+    "EmbeddingActor",
+    "EmbeddingError",
     "EmbeddingProvider",
+    "EmbeddingRequest",
+    "EmbeddingResult",
     "InMemoryBackend",
     "SearchHit",
     "SearchResult",

--- a/src/akgentic/tool/vector_store/__init__.py
+++ b/src/akgentic/tool/vector_store/__init__.py
@@ -6,6 +6,12 @@ directly from ``akgentic.tool.vector_store``.
 
 from __future__ import annotations
 
+from akgentic.tool.vector_store.actor import (
+    VS_ACTOR_NAME,
+    VS_ACTOR_ROLE,
+    VectorStoreActor,
+    VectorStoreState,
+)
 from akgentic.tool.vector_store.inmemory import InMemoryBackend
 from akgentic.tool.vector_store.protocol import (
     CollectionConfig,
@@ -24,6 +30,10 @@ __all__ = [
     "InMemoryBackend",
     "SearchHit",
     "SearchResult",
+    "VS_ACTOR_NAME",
+    "VS_ACTOR_ROLE",
+    "VectorStoreActor",
     "VectorStoreConfig",
     "VectorStoreService",
+    "VectorStoreState",
 ]

--- a/src/akgentic/tool/vector_store/actor.py
+++ b/src/akgentic/tool/vector_store/actor.py
@@ -9,11 +9,13 @@ initialisation and catch/log/swallow error handling.
 from __future__ import annotations
 
 import logging
+import uuid
 from typing import TYPE_CHECKING, Any
 
 from pydantic import Field
 
 from akgentic.core.agent import Akgent
+from akgentic.core.agent_config import BaseConfig
 from akgentic.core.agent_state import BaseState
 from akgentic.tool.errors import RetriableError
 from akgentic.tool.vector_store.protocol import (
@@ -25,6 +27,10 @@ from akgentic.tool.vector_store.protocol import (
 
 if TYPE_CHECKING:
     from akgentic.tool.vector import EmbeddingService, VectorEntry
+    from akgentic.tool.vector_store.embedding_actor import (
+        EmbeddingError,
+        EmbeddingResult,
+    )
     from akgentic.tool.vector_store.inmemory import InMemoryBackend
 
 logger = logging.getLogger(__name__)
@@ -55,6 +61,14 @@ class VectorStoreState(BaseState):
     collection_statuses: dict[str, CollectionStatus] = Field(
         default_factory=dict,
         description="Per-collection lifecycle status",
+    )
+    pending_entries: dict[str, list[dict[str, str]]] = Field(
+        default_factory=dict,
+        description="Raw entry metadata awaiting embedding, keyed by collection",
+    )
+    indexing_pending: dict[str, int] = Field(
+        default_factory=dict,
+        description="Count of entries pending embedding per collection",
     )
 
 
@@ -174,8 +188,12 @@ class VectorStoreActor(Akgent[VectorStoreConfig, VectorStoreState]):
     def add(self, collection: str, entries: list[VectorEntry]) -> None:
         """Ingest embedding entries into a collection.
 
-        Delegates to ``InMemoryBackend.add()``. ``ValueError`` (non-existent
-        collection) is re-raised as ``RetriableError``.
+        Entries with pre-populated vectors go through the synchronous path
+        directly to the backend.  Entries without vectors are sent to a
+        spawned ``EmbeddingActor`` for asynchronous embedding (AC2, AC9).
+
+        If the collection is in ``ERROR`` status, a new ``add()`` resets
+        it to ``INDEXING`` (AC8 -- retry after failure).
 
         Args:
             collection: Target collection name.
@@ -185,6 +203,26 @@ class VectorStoreActor(Akgent[VectorStoreConfig, VectorStoreState]):
         if backend is None:
             logger.warning("[%s] Backend unavailable, skipping add", self.config.name)
             return
+
+        pre_embedded = [e for e in entries if len(e.vector) > 0]
+        needs_embedding = [e for e in entries if len(e.vector) == 0]
+
+        if pre_embedded:
+            self._add_pre_embedded(collection, pre_embedded)
+
+        if needs_embedding:
+            self._add_needs_embedding(collection, needs_embedding)
+
+    def _add_pre_embedded(self, collection: str, entries: list[VectorEntry]) -> None:
+        """Add entries with pre-populated vectors directly to backend.
+
+        Args:
+            collection: Target collection name.
+            entries: Entries with non-empty vector fields.
+        """
+        backend = self._get_or_create_backend()
+        if backend is None:
+            return
         try:
             backend.add(collection, entries)
             self._sync_backend_state()
@@ -192,7 +230,54 @@ class VectorStoreActor(Akgent[VectorStoreConfig, VectorStoreState]):
         except ValueError as exc:
             raise RetriableError(str(exc)) from exc
         except Exception as exc:  # noqa: BLE001
-            logger.warning("[%s] add failed: %s", self.config.name, exc)
+            logger.warning("[%s] _add_pre_embedded failed: %s", self.config.name, exc)
+
+    def _add_needs_embedding(self, collection: str, entries: list[VectorEntry]) -> None:
+        """Spawn an EmbeddingActor for entries that need embedding.
+
+        Stores raw metadata in pending state, sets collection to INDEXING,
+        and fires the request asynchronously (AC2, AC3, AC8).
+
+        Args:
+            collection: Target collection name.
+            entries: Entries with empty vector fields.
+        """
+        from akgentic.tool.vector_store.embedding_actor import (
+            EmbeddingActor,
+            EmbeddingRequest,
+        )
+
+        request_id = str(uuid.uuid4())
+        raw_entries = [
+            {"ref_type": e.ref_type, "ref_id": e.ref_id, "text": e.text} for e in entries
+        ]
+
+        # Track pending entries in state
+        pending = self.state.pending_entries.get(collection, [])
+        pending.extend(raw_entries)
+        self.state.pending_entries[collection] = pending
+
+        count = self.state.indexing_pending.get(collection, 0)
+        self.state.indexing_pending[collection] = count + len(entries)
+
+        # Transition status (READY/ERROR -> INDEXING)
+        self.state.collection_statuses[collection] = CollectionStatus.INDEXING
+
+        # Spawn EmbeddingActor child
+        embed_config = BaseConfig(name=f"embed-{collection}-{request_id}")
+        embed_addr = self.createActor(EmbeddingActor, config=embed_config)
+
+        request = EmbeddingRequest(
+            collection=collection,
+            entries=raw_entries,
+            request_id=request_id,
+            embedding_model=self.config.embedding_model,
+            embedding_provider=self.config.embedding_provider,
+        )
+        embed_proxy = self.proxy_tell(embed_addr, EmbeddingActor)
+        embed_proxy.receiveMsg_EmbeddingRequest(request)
+
+        self.state.notify_state_change()
 
     def remove(self, collection: str, ref_ids: list[str]) -> None:
         """Remove entries from a collection by reference ID.
@@ -217,9 +302,7 @@ class VectorStoreActor(Akgent[VectorStoreConfig, VectorStoreState]):
         except Exception as exc:  # noqa: BLE001
             logger.warning("[%s] remove failed: %s", self.config.name, exc)
 
-    def search(
-        self, collection: str, query_vector: list[float], top_k: int
-    ) -> SearchResult:
+    def search(self, collection: str, query_vector: list[float], top_k: int) -> SearchResult:
         """Search a collection by cosine similarity.
 
         Read-only operation — does not call ``state.notify_state_change()``.
@@ -236,19 +319,94 @@ class VectorStoreActor(Akgent[VectorStoreConfig, VectorStoreState]):
         backend = self._get_or_create_backend()
         if backend is None:
             logger.warning("[%s] Backend unavailable, returning empty search", self.config.name)
-            return SearchResult(
-                hits=[], status=CollectionStatus.READY, indexing_pending=0
-            )
+            return SearchResult(hits=[], status=CollectionStatus.READY, indexing_pending=0)
         try:
             result: SearchResult = backend.search(collection, query_vector, top_k)
+            # Override status/pending from actor state (AC6)
+            actor_status = self.state.collection_statuses.get(collection)
+            if actor_status is not None:
+                result = SearchResult(
+                    hits=result.hits,
+                    status=actor_status,
+                    indexing_pending=self.state.indexing_pending.get(collection, 0),
+                )
             return result
         except ValueError as exc:
             raise RetriableError(str(exc)) from exc
         except Exception as exc:  # noqa: BLE001
             logger.warning("[%s] search failed: %s", self.config.name, exc)
-            return SearchResult(
-                hits=[], status=CollectionStatus.READY, indexing_pending=0
+            return SearchResult(hits=[], status=CollectionStatus.READY, indexing_pending=0)
+
+    # ------------------------------------------------------------------
+    # Embedding result/error handlers
+    # ------------------------------------------------------------------
+
+    def receiveMsg_EmbeddingResult(self, msg: EmbeddingResult) -> None:  # noqa: N802
+        """Handle successful embedding delivery from EmbeddingActor.
+
+        Inserts fully-vectorised entries into the backend and updates
+        collection status (AC5).
+
+        Args:
+            msg: Result containing entries with populated vectors.
+        """
+        backend = self._get_or_create_backend()
+        if backend is None:
+            logger.warning(
+                "[%s] Backend unavailable, cannot insert embedding results",
+                self.config.name,
             )
+            return
+        try:
+            backend.add(msg.collection, msg.entries)
+            self._remove_pending(msg.collection, len(msg.entries))
+            self._sync_backend_state()
+            self.state.notify_state_change()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "[%s] receiveMsg_EmbeddingResult failed: %s",
+                self.config.name,
+                exc,
+            )
+
+    def receiveMsg_EmbeddingError(self, msg: EmbeddingError) -> None:  # noqa: N802
+        """Handle embedding failure from EmbeddingActor.
+
+        Sets collection to ERROR and discards pending entries (AC7).
+
+        Args:
+            msg: Error details from the failed embedding batch.
+        """
+        logger.warning(
+            "[%s] Embedding failed for collection '%s': %s",
+            self.config.name,
+            msg.collection,
+            msg.error,
+        )
+        self.state.collection_statuses[msg.collection] = CollectionStatus.ERROR
+        self.state.pending_entries.pop(msg.collection, None)
+        self.state.indexing_pending[msg.collection] = 0
+        self.state.notify_state_change()
+
+    def _remove_pending(self, collection: str, count: int) -> None:
+        """Decrement pending count and clean up on completion.
+
+        Args:
+            collection: Collection name.
+            count: Number of entries that were successfully embedded.
+        """
+        pending = self.state.indexing_pending.get(collection, 0)
+        pending = max(0, pending - count)
+        self.state.indexing_pending[collection] = pending
+
+        # Remove corresponding raw entries from pending list
+        pending_list = self.state.pending_entries.get(collection, [])
+        self.state.pending_entries[collection] = pending_list[count:]
+
+        if pending <= 0:
+            self.state.collection_statuses[collection] = CollectionStatus.READY
+            self.state.pending_entries.pop(collection, None)
+            self.state.indexing_pending.pop(collection, None)
 
     def embed(self, texts: list[str]) -> list[list[float]]:
         """Embed texts via ``EmbeddingService``.

--- a/src/akgentic/tool/vector_store/actor.py
+++ b/src/akgentic/tool/vector_store/actor.py
@@ -9,7 +9,7 @@ initialisation and catch/log/swallow error handling.
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pydantic import Field
 
@@ -22,6 +22,10 @@ from akgentic.tool.vector_store.protocol import (
     SearchResult,
     VectorStoreConfig,
 )
+
+if TYPE_CHECKING:
+    from akgentic.tool.vector import EmbeddingService, VectorEntry
+    from akgentic.tool.vector_store.inmemory import InMemoryBackend
 
 logger = logging.getLogger(__name__)
 
@@ -75,14 +79,14 @@ class VectorStoreActor(Akgent[VectorStoreConfig, VectorStoreState]):
         """Initialise state, attach observer, and prepare lazy runtime slots."""
         self.state = VectorStoreState()
         self.state.observer(self)
-        self._backend: Any = None  # InMemoryBackend | None — lazy
-        self._embedding_svc: Any = None  # EmbeddingService | None — lazy
+        self._backend: InMemoryBackend | None = None
+        self._embedding_svc: EmbeddingService | None = None
 
     # ------------------------------------------------------------------
     # Lazy initialisation
     # ------------------------------------------------------------------
 
-    def _get_or_create_backend(self) -> Any:
+    def _get_or_create_backend(self) -> InMemoryBackend | None:
         """Return the ``InMemoryBackend``, creating it lazily on first call.
 
         If ``self.state.backend_state`` contains data the backend is restored
@@ -106,7 +110,7 @@ class VectorStoreActor(Akgent[VectorStoreConfig, VectorStoreState]):
             return None
         return self._backend
 
-    def _get_or_create_embedding_svc(self) -> Any:
+    def _get_or_create_embedding_svc(self) -> EmbeddingService | None:
         """Return the ``EmbeddingService``, creating it lazily on first call.
 
         Returns ``None`` when creation fails (e.g. missing deps or bad config).
@@ -167,7 +171,7 @@ class VectorStoreActor(Akgent[VectorStoreConfig, VectorStoreState]):
         except Exception as exc:  # noqa: BLE001
             logger.warning("[%s] create_collection failed: %s", self.config.name, exc)
 
-    def add(self, collection: str, entries: list[Any]) -> None:
+    def add(self, collection: str, entries: list[VectorEntry]) -> None:
         """Ingest embedding entries into a collection.
 
         Delegates to ``InMemoryBackend.add()``. ``ValueError`` (non-existent

--- a/src/akgentic/tool/vector_store/actor.py
+++ b/src/akgentic/tool/vector_store/actor.py
@@ -368,6 +368,11 @@ class VectorStoreActor(Akgent[VectorStoreConfig, VectorStoreState]):
                 self.config.name,
                 exc,
             )
+            # Transition to ERROR so the collection does not stay stuck in INDEXING
+            self.state.collection_statuses[msg.collection] = CollectionStatus.ERROR
+            self.state.pending_entries.pop(msg.collection, None)
+            self.state.indexing_pending[msg.collection] = 0
+            self.state.notify_state_change()
 
     def receiveMsg_EmbeddingError(self, msg: EmbeddingError) -> None:  # noqa: N802
         """Handle embedding failure from EmbeddingActor.

--- a/src/akgentic/tool/vector_store/actor.py
+++ b/src/akgentic/tool/vector_store/actor.py
@@ -1,0 +1,268 @@
+"""VectorStoreActor singleton — centralised vector storage via Pykka proxy.
+
+Exposes the ``VectorStoreService`` protocol methods as actor proxy calls,
+routing all operations to ``InMemoryBackend``.  Follows the established
+KnowledgeGraphActor / PlanActor singleton pattern with lazy backend
+initialisation and catch/log/swallow error handling.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from pydantic import Field
+
+from akgentic.core.agent import Akgent
+from akgentic.core.agent_state import BaseState
+from akgentic.tool.errors import RetriableError
+from akgentic.tool.vector_store.protocol import (
+    CollectionConfig,
+    CollectionStatus,
+    SearchResult,
+    VectorStoreConfig,
+)
+
+logger = logging.getLogger(__name__)
+
+VS_ACTOR_NAME: str = "#VectorStore"
+"""Singleton actor name registered with the orchestrator."""
+
+VS_ACTOR_ROLE: str = "ToolActor"
+"""Actor role constant for ToolCard integration."""
+
+
+# ---------------------------------------------------------------------------
+# VectorStoreState
+# ---------------------------------------------------------------------------
+
+
+class VectorStoreState(BaseState):
+    """Serialisable state for the vector store actor.
+
+    Holds a snapshot of the ``InMemoryBackend`` state (via ``get_state()`` /
+    ``restore_state()``) and per-collection lifecycle statuses.
+    """
+
+    backend_state: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Serialisable snapshot from InMemoryBackend.get_state()",
+    )
+    collection_statuses: dict[str, CollectionStatus] = Field(
+        default_factory=dict,
+        description="Per-collection lifecycle status",
+    )
+
+
+# ---------------------------------------------------------------------------
+# VectorStoreActor
+# ---------------------------------------------------------------------------
+
+
+class VectorStoreActor(Akgent[VectorStoreConfig, VectorStoreState]):
+    """Singleton actor exposing ``VectorStoreService`` via Pykka proxy.
+
+    All vector operations are delegated to ``InMemoryBackend`` which is
+    created lazily on first use. Mutations synchronise serialisable state
+    and notify the orchestrator via ``state.notify_state_change()``.
+    """
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def on_start(self) -> None:  # noqa: ANN201
+        """Initialise state, attach observer, and prepare lazy runtime slots."""
+        self.state = VectorStoreState()
+        self.state.observer(self)
+        self._backend: Any = None  # InMemoryBackend | None — lazy
+        self._embedding_svc: Any = None  # EmbeddingService | None — lazy
+
+    # ------------------------------------------------------------------
+    # Lazy initialisation
+    # ------------------------------------------------------------------
+
+    def _get_or_create_backend(self) -> Any:
+        """Return the ``InMemoryBackend``, creating it lazily on first call.
+
+        If ``self.state.backend_state`` contains data the backend is restored
+        from the persisted snapshot.  Returns ``None`` when ``[vector_search]``
+        dependencies are missing.
+        """
+        if self._backend is not None:
+            return self._backend
+        try:
+            from akgentic.tool.vector_store.inmemory import InMemoryBackend
+
+            self._backend = InMemoryBackend()
+            if self.state.backend_state:
+                self._backend.restore_state(self.state.backend_state)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "[%s] Failed to initialize InMemoryBackend: %s",
+                self.config.name,
+                exc,
+            )
+            return None
+        return self._backend
+
+    def _get_or_create_embedding_svc(self) -> Any:
+        """Return the ``EmbeddingService``, creating it lazily on first call.
+
+        Returns ``None`` when creation fails (e.g. missing deps or bad config).
+        """
+        if self._embedding_svc is not None:
+            return self._embedding_svc
+        try:
+            from akgentic.tool.vector import EmbeddingService
+
+            self._embedding_svc = EmbeddingService(
+                model=self.config.embedding_model,
+                provider=self.config.embedding_provider,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "[%s] Failed to initialize EmbeddingService: %s",
+                self.config.name,
+                exc,
+            )
+            return None
+        return self._embedding_svc
+
+    # ------------------------------------------------------------------
+    # State synchronisation
+    # ------------------------------------------------------------------
+
+    def _sync_backend_state(self) -> None:
+        """Copy the backend's serialisable snapshot into actor state."""
+        if self._backend is not None:
+            self.state.backend_state = self._backend.get_state()
+
+    # ------------------------------------------------------------------
+    # Proxy methods
+    # ------------------------------------------------------------------
+
+    def create_collection(self, name: str, config: CollectionConfig) -> None:
+        """Create or reconfigure a named collection.
+
+        Delegates to ``InMemoryBackend.create_collection()``, marks the
+        collection as ``READY``, and notifies the orchestrator.
+
+        Args:
+            name: Unique collection identifier.
+            config: Collection configuration.
+        """
+        backend = self._get_or_create_backend()
+        if backend is None:
+            logger.warning(
+                "[%s] Backend unavailable, skipping create_collection",
+                self.config.name,
+            )
+            return
+        try:
+            backend.create_collection(name, config)
+            self.state.collection_statuses[name] = CollectionStatus.READY
+            self._sync_backend_state()
+            self.state.notify_state_change()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[%s] create_collection failed: %s", self.config.name, exc)
+
+    def add(self, collection: str, entries: list[Any]) -> None:
+        """Ingest embedding entries into a collection.
+
+        Delegates to ``InMemoryBackend.add()``. ``ValueError`` (non-existent
+        collection) is re-raised as ``RetriableError``.
+
+        Args:
+            collection: Target collection name.
+            entries: List of ``VectorEntry`` to store.
+        """
+        backend = self._get_or_create_backend()
+        if backend is None:
+            logger.warning("[%s] Backend unavailable, skipping add", self.config.name)
+            return
+        try:
+            backend.add(collection, entries)
+            self._sync_backend_state()
+            self.state.notify_state_change()
+        except ValueError as exc:
+            raise RetriableError(str(exc)) from exc
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[%s] add failed: %s", self.config.name, exc)
+
+    def remove(self, collection: str, ref_ids: list[str]) -> None:
+        """Remove entries from a collection by reference ID.
+
+        Delegates to ``InMemoryBackend.remove()``. ``ValueError`` (non-existent
+        collection) is re-raised as ``RetriableError``.
+
+        Args:
+            collection: Target collection name.
+            ref_ids: List of reference IDs to remove.
+        """
+        backend = self._get_or_create_backend()
+        if backend is None:
+            logger.warning("[%s] Backend unavailable, skipping remove", self.config.name)
+            return
+        try:
+            backend.remove(collection, ref_ids)
+            self._sync_backend_state()
+            self.state.notify_state_change()
+        except ValueError as exc:
+            raise RetriableError(str(exc)) from exc
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[%s] remove failed: %s", self.config.name, exc)
+
+    def search(
+        self, collection: str, query_vector: list[float], top_k: int
+    ) -> SearchResult:
+        """Search a collection by cosine similarity.
+
+        Read-only operation — does not call ``state.notify_state_change()``.
+        ``ValueError`` (non-existent collection) is re-raised as ``RetriableError``.
+
+        Args:
+            collection: Target collection name.
+            query_vector: Query embedding vector.
+            top_k: Maximum number of results to return.
+
+        Returns:
+            Search results with hits and collection status.
+        """
+        backend = self._get_or_create_backend()
+        if backend is None:
+            logger.warning("[%s] Backend unavailable, returning empty search", self.config.name)
+            return SearchResult(
+                hits=[], status=CollectionStatus.READY, indexing_pending=0
+            )
+        try:
+            return backend.search(collection, query_vector, top_k)
+        except ValueError as exc:
+            raise RetriableError(str(exc)) from exc
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[%s] search failed: %s", self.config.name, exc)
+            return SearchResult(
+                hits=[], status=CollectionStatus.READY, indexing_pending=0
+            )
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        """Embed texts via ``EmbeddingService``.
+
+        Returns an empty list when the embedding service is unavailable or on
+        any failure (catch/log/swallow pattern).
+
+        Args:
+            texts: List of strings to embed.
+
+        Returns:
+            List of float vectors, one per input text. Empty on failure.
+        """
+        svc = self._get_or_create_embedding_svc()
+        if svc is None:
+            return []
+        try:
+            result: list[list[float]] = svc.embed(texts)
+            return result
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[%s] embed failed: %s", self.config.name, exc)
+            return []

--- a/src/akgentic/tool/vector_store/actor.py
+++ b/src/akgentic/tool/vector_store/actor.py
@@ -70,6 +70,10 @@ class VectorStoreState(BaseState):
         default_factory=dict,
         description="Count of entries pending embedding per collection",
     )
+    collection_configs: dict[str, dict[str, Any]] = Field(
+        default_factory=dict,
+        description="Serialised CollectionConfig per collection (for persistence lookups)",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -156,6 +160,30 @@ class VectorStoreActor(Akgent[VectorStoreConfig, VectorStoreState]):
         if self._backend is not None:
             self.state.backend_state = self._backend.get_state()
 
+    def _save_workspace_collection(self, collection: str) -> None:
+        """Persist a workspace collection to disk if applicable.
+
+        Checks the stored ``CollectionConfig`` for the collection. If
+        ``persistence == "workspace"`` and a ``workspace_path`` is set,
+        delegates to ``InMemoryBackend.save_collection()``.
+
+        Args:
+            collection: Collection name to potentially persist.
+        """
+        cfg_data = self.state.collection_configs.get(collection, {})
+        persistence = cfg_data.get("persistence", "actor_state")
+        workspace_path = cfg_data.get("workspace_path")
+        if persistence == "workspace" and workspace_path and self._backend is not None:
+            try:
+                self._backend.save_collection(collection, workspace_path)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "[%s] _save_workspace_collection failed for '%s': %s",
+                    self.config.name,
+                    collection,
+                    exc,
+                )
+
     # ------------------------------------------------------------------
     # Proxy methods
     # ------------------------------------------------------------------
@@ -163,8 +191,9 @@ class VectorStoreActor(Akgent[VectorStoreConfig, VectorStoreState]):
     def create_collection(self, name: str, config: CollectionConfig) -> None:
         """Create or reconfigure a named collection.
 
-        Delegates to ``InMemoryBackend.create_collection()``, marks the
-        collection as ``READY``, and notifies the orchestrator.
+        For ``persistence="workspace"`` collections, delegates to
+        ``InMemoryBackend.load_collection()`` which restores from disk
+        or starts empty. Otherwise delegates to ``create_collection()``.
 
         Args:
             name: Unique collection identifier.
@@ -178,7 +207,16 @@ class VectorStoreActor(Akgent[VectorStoreConfig, VectorStoreState]):
             )
             return
         try:
-            backend.create_collection(name, config)
+            if config.persistence == "workspace" and config.workspace_path:
+                backend.load_collection(name, config, config.workspace_path)
+            else:
+                backend.create_collection(name, config)
+            self.state.collection_configs[name] = {
+                "dimension": config.dimension,
+                "backend": config.backend,
+                "persistence": config.persistence,
+                "workspace_path": config.workspace_path,
+            }
             self.state.collection_statuses[name] = CollectionStatus.READY
             self._sync_backend_state()
             self.state.notify_state_change()
@@ -226,6 +264,7 @@ class VectorStoreActor(Akgent[VectorStoreConfig, VectorStoreState]):
         try:
             backend.add(collection, entries)
             self._sync_backend_state()
+            self._save_workspace_collection(collection)
             self.state.notify_state_change()
         except ValueError as exc:
             raise RetriableError(str(exc)) from exc
@@ -296,6 +335,7 @@ class VectorStoreActor(Akgent[VectorStoreConfig, VectorStoreState]):
         try:
             backend.remove(collection, ref_ids)
             self._sync_backend_state()
+            self._save_workspace_collection(collection)
             self.state.notify_state_change()
         except ValueError as exc:
             raise RetriableError(str(exc)) from exc
@@ -361,6 +401,7 @@ class VectorStoreActor(Akgent[VectorStoreConfig, VectorStoreState]):
             backend.add(msg.collection, msg.entries)
             self._remove_pending(msg.collection, len(msg.entries))
             self._sync_backend_state()
+            self._save_workspace_collection(msg.collection)
             self.state.notify_state_change()
         except Exception as exc:  # noqa: BLE001
             logger.warning(

--- a/src/akgentic/tool/vector_store/actor.py
+++ b/src/akgentic/tool/vector_store/actor.py
@@ -236,7 +236,8 @@ class VectorStoreActor(Akgent[VectorStoreConfig, VectorStoreState]):
                 hits=[], status=CollectionStatus.READY, indexing_pending=0
             )
         try:
-            return backend.search(collection, query_vector, top_k)
+            result: SearchResult = backend.search(collection, query_vector, top_k)
+            return result
         except ValueError as exc:
             raise RetriableError(str(exc)) from exc
         except Exception as exc:  # noqa: BLE001

--- a/src/akgentic/tool/vector_store/actor.py
+++ b/src/akgentic/tool/vector_store/actor.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
         EmbeddingResult,
     )
     from akgentic.tool.vector_store.inmemory import InMemoryBackend
+    from akgentic.tool.vector_store.weaviate import WeaviateBackend
 
 logger = logging.getLogger(__name__)
 
@@ -98,6 +99,7 @@ class VectorStoreActor(Akgent[VectorStoreConfig, VectorStoreState]):
         self.state = VectorStoreState()
         self.state.observer(self)
         self._backend: InMemoryBackend | None = None
+        self._weaviate_backend: WeaviateBackend | None = None
         self._embedding_svc: EmbeddingService | None = None
 
     # ------------------------------------------------------------------
@@ -151,6 +153,58 @@ class VectorStoreActor(Akgent[VectorStoreConfig, VectorStoreState]):
             return None
         return self._embedding_svc
 
+    def _get_or_create_weaviate_backend(self) -> WeaviateBackend | None:
+        """Return the ``WeaviateBackend``, creating it lazily on first call.
+
+        Uses ``self.config.weaviate_url`` and ``self.config.weaviate_api_key``
+        for connection. Returns ``None`` when ``weaviate-client`` is missing
+        or connection fails.
+        """
+        if self._weaviate_backend is not None:
+            return self._weaviate_backend
+        try:
+            from akgentic.tool.vector_store.weaviate import WeaviateBackend
+
+            url = self.config.weaviate_url
+            if not url:
+                logger.warning(
+                    "[%s] weaviate_url not configured, cannot create WeaviateBackend",
+                    self.config.name,
+                )
+                return None
+            self._weaviate_backend = WeaviateBackend(
+                url=url,
+                api_key=self.config.weaviate_api_key,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "[%s] Failed to initialize WeaviateBackend: %s",
+                self.config.name,
+                exc,
+            )
+            return None
+        return self._weaviate_backend
+
+    def _get_backend_for_collection(
+        self, collection: str,
+    ) -> InMemoryBackend | WeaviateBackend | None:
+        """Return the correct backend for the given collection.
+
+        Checks ``self.state.collection_configs`` to determine whether the
+        collection uses the inmemory or weaviate backend.
+
+        Args:
+            collection: Collection name to look up.
+
+        Returns:
+            The appropriate backend, or ``None`` if unavailable.
+        """
+        cfg_data = self.state.collection_configs.get(collection, {})
+        backend_type = cfg_data.get("backend", "inmemory")
+        if backend_type == "weaviate":
+            return self._get_or_create_weaviate_backend()
+        return self._get_or_create_backend()
+
     # ------------------------------------------------------------------
     # State synchronisation
     # ------------------------------------------------------------------
@@ -191,34 +245,51 @@ class VectorStoreActor(Akgent[VectorStoreConfig, VectorStoreState]):
     def create_collection(self, name: str, config: CollectionConfig) -> None:
         """Create or reconfigure a named collection.
 
-        For ``persistence="workspace"`` collections, delegates to
+        Routes to the appropriate backend based on ``config.backend``:
+        - ``"inmemory"``: delegates to ``InMemoryBackend``
+        - ``"weaviate"``: delegates to ``WeaviateBackend``
+
+        For inmemory ``persistence="workspace"`` collections, delegates to
         ``InMemoryBackend.load_collection()`` which restores from disk
-        or starts empty. Otherwise delegates to ``create_collection()``.
+        or starts empty.
 
         Args:
             name: Unique collection identifier.
             config: Collection configuration.
         """
-        backend = self._get_or_create_backend()
-        if backend is None:
-            logger.warning(
-                "[%s] Backend unavailable, skipping create_collection",
-                self.config.name,
-            )
-            return
         try:
-            if config.persistence == "workspace" and config.workspace_path:
-                backend.load_collection(name, config, config.workspace_path)
+            if config.backend == "weaviate":
+                wb = self._get_or_create_weaviate_backend()
+                if wb is None:
+                    logger.warning(
+                        "[%s] Weaviate backend unavailable, skipping create_collection",
+                        self.config.name,
+                    )
+                    return
+                wb.create_collection(name, config)
             else:
-                backend.create_collection(name, config)
+                backend = self._get_or_create_backend()
+                if backend is None:
+                    logger.warning(
+                        "[%s] Backend unavailable, skipping create_collection",
+                        self.config.name,
+                    )
+                    return
+                if config.persistence == "workspace" and config.workspace_path:
+                    backend.load_collection(name, config, config.workspace_path)
+                else:
+                    backend.create_collection(name, config)
+
             self.state.collection_configs[name] = {
                 "dimension": config.dimension,
                 "backend": config.backend,
                 "persistence": config.persistence,
                 "workspace_path": config.workspace_path,
+                "tenant": config.tenant,
             }
             self.state.collection_statuses[name] = CollectionStatus.READY
-            self._sync_backend_state()
+            if config.backend != "weaviate":
+                self._sync_backend_state()
             self.state.notify_state_change()
         except Exception as exc:  # noqa: BLE001
             logger.warning("[%s] create_collection failed: %s", self.config.name, exc)
@@ -237,7 +308,7 @@ class VectorStoreActor(Akgent[VectorStoreConfig, VectorStoreState]):
             collection: Target collection name.
             entries: List of ``VectorEntry`` to store.
         """
-        backend = self._get_or_create_backend()
+        backend = self._get_backend_for_collection(collection)
         if backend is None:
             logger.warning("[%s] Backend unavailable, skipping add", self.config.name)
             return
@@ -258,13 +329,15 @@ class VectorStoreActor(Akgent[VectorStoreConfig, VectorStoreState]):
             collection: Target collection name.
             entries: Entries with non-empty vector fields.
         """
-        backend = self._get_or_create_backend()
+        backend = self._get_backend_for_collection(collection)
         if backend is None:
             return
         try:
             backend.add(collection, entries)
-            self._sync_backend_state()
-            self._save_workspace_collection(collection)
+            cfg_data = self.state.collection_configs.get(collection, {})
+            if cfg_data.get("backend", "inmemory") != "weaviate":
+                self._sync_backend_state()
+                self._save_workspace_collection(collection)
             self.state.notify_state_change()
         except ValueError as exc:
             raise RetriableError(str(exc)) from exc
@@ -321,21 +394,23 @@ class VectorStoreActor(Akgent[VectorStoreConfig, VectorStoreState]):
     def remove(self, collection: str, ref_ids: list[str]) -> None:
         """Remove entries from a collection by reference ID.
 
-        Delegates to ``InMemoryBackend.remove()``. ``ValueError`` (non-existent
+        Delegates to the appropriate backend. ``ValueError`` (non-existent
         collection) is re-raised as ``RetriableError``.
 
         Args:
             collection: Target collection name.
             ref_ids: List of reference IDs to remove.
         """
-        backend = self._get_or_create_backend()
+        backend = self._get_backend_for_collection(collection)
         if backend is None:
             logger.warning("[%s] Backend unavailable, skipping remove", self.config.name)
             return
         try:
             backend.remove(collection, ref_ids)
-            self._sync_backend_state()
-            self._save_workspace_collection(collection)
+            cfg_data = self.state.collection_configs.get(collection, {})
+            if cfg_data.get("backend", "inmemory") != "weaviate":
+                self._sync_backend_state()
+                self._save_workspace_collection(collection)
             self.state.notify_state_change()
         except ValueError as exc:
             raise RetriableError(str(exc)) from exc
@@ -356,7 +431,7 @@ class VectorStoreActor(Akgent[VectorStoreConfig, VectorStoreState]):
         Returns:
             Search results with hits and collection status.
         """
-        backend = self._get_or_create_backend()
+        backend = self._get_backend_for_collection(collection)
         if backend is None:
             logger.warning("[%s] Backend unavailable, returning empty search", self.config.name)
             return SearchResult(hits=[], status=CollectionStatus.READY, indexing_pending=0)

--- a/src/akgentic/tool/vector_store/embedding_actor.py
+++ b/src/akgentic/tool/vector_store/embedding_actor.py
@@ -153,7 +153,9 @@ class EmbeddingActor(Akgent[BaseConfig, BaseState]):
                 entries=vector_entries,
                 request_id=msg.request_id,
             )
-            assert self._parent is not None  # always set by createActor
+            if self._parent is None:
+                logger.warning("[%s] No parent address, cannot deliver result", self.config.name)
+                return
             parent_proxy = self.proxy_tell(self._parent, VectorStoreActor)
             parent_proxy.receiveMsg_EmbeddingResult(result)
 
@@ -177,7 +179,9 @@ class EmbeddingActor(Akgent[BaseConfig, BaseState]):
             request_id=msg.request_id,
         )
         try:
-            assert self._parent is not None  # always set by createActor
+            if self._parent is None:
+                logger.warning("[%s] No parent address, cannot deliver error", self.config.name)
+                return
             parent_proxy = self.proxy_tell(self._parent, VectorStoreActor)
             parent_proxy.receiveMsg_EmbeddingError(err)
         except Exception as send_exc:  # noqa: BLE001

--- a/src/akgentic/tool/vector_store/embedding_actor.py
+++ b/src/akgentic/tool/vector_store/embedding_actor.py
@@ -1,0 +1,188 @@
+"""Fire-and-forget EmbeddingActor for non-blocking embedding calls.
+
+Spawned by ``VectorStoreActor`` when entries need embedding.  Calls
+``EmbeddingService.embed()`` in its own Pykka thread, delivers results
+(or errors) back to the parent via ``proxy_tell``, then stops itself.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import TYPE_CHECKING, Literal
+
+from pydantic import Field
+
+from akgentic.core.agent import Akgent
+from akgentic.core.agent_config import BaseConfig
+from akgentic.core.agent_state import BaseState
+from akgentic.core.utils.serializer import SerializableBaseModel
+
+if TYPE_CHECKING:
+    from akgentic.tool.vector import EmbeddingService, VectorEntry
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Message models
+# ---------------------------------------------------------------------------
+
+
+class EmbeddingRequest(SerializableBaseModel):
+    """Request sent from VectorStoreActor to EmbeddingActor.
+
+    Contains raw entry metadata (no vectors) for a single batch.
+    """
+
+    collection: str = Field(description="Target collection name")
+    entries: list[dict[str, str]] = Field(
+        description="Raw entries: list of {ref_type, ref_id, text}"
+    )
+    request_id: str = Field(
+        default_factory=lambda: str(uuid.uuid4()),
+        description="Unique identifier for this embedding batch",
+    )
+    embedding_model: str = Field(
+        default="text-embedding-3-small",
+        description="Embedding model identifier",
+    )
+    embedding_provider: Literal["openai", "azure"] = Field(
+        default="openai",
+        description="Embedding API provider",
+    )
+
+
+class EmbeddingResult(SerializableBaseModel):
+    """Successful result sent from EmbeddingActor back to VectorStoreActor."""
+
+    collection: str = Field(description="Target collection name")
+    entries: list[VectorEntry] = Field(description="Entries with vectors populated")
+    request_id: str = Field(description="Matching request identifier")
+
+
+class EmbeddingError(SerializableBaseModel):
+    """Error sent from EmbeddingActor back to VectorStoreActor on failure."""
+
+    collection: str = Field(description="Target collection name")
+    error: str = Field(description="Error message from embedding failure")
+    request_id: str = Field(description="Matching request identifier")
+
+
+# ---------------------------------------------------------------------------
+# EmbeddingActor
+# ---------------------------------------------------------------------------
+
+
+class EmbeddingActor(Akgent[BaseConfig, BaseState]):
+    """Short-lived actor that embeds a batch of texts and delivers results.
+
+    Spawned by ``VectorStoreActor`` via ``createActor()``.  Processes a
+    single ``EmbeddingRequest``, sends back ``EmbeddingResult`` or
+    ``EmbeddingError``, and stops itself.
+    """
+
+    def on_start(self) -> None:  # noqa: ANN201
+        """Initialise state and lazy embedding service slot."""
+        self.state = BaseState()
+        self.state.observer(self)
+        self._embedding_svc: EmbeddingService | None = None
+
+    def _get_or_create_embedding_svc(
+        self, model: str, provider: Literal["openai", "azure"]
+    ) -> EmbeddingService | None:
+        """Lazily create an ``EmbeddingService`` for the given config.
+
+        Args:
+            model: Embedding model identifier.
+            provider: Embedding API provider name.
+
+        Returns:
+            An ``EmbeddingService`` instance, or ``None`` on failure.
+        """
+        if self._embedding_svc is not None:
+            return self._embedding_svc
+        try:
+            from akgentic.tool.vector import EmbeddingService as EmbSvc
+
+            self._embedding_svc = EmbSvc(model=model, provider=provider)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "[%s] Failed to initialize EmbeddingService: %s",
+                self.config.name,
+                exc,
+            )
+            return None
+        return self._embedding_svc
+
+    def receiveMsg_EmbeddingRequest(self, msg: EmbeddingRequest) -> None:  # noqa: N802
+        """Process an embedding request: embed texts and deliver results.
+
+        On success, sends ``EmbeddingResult`` to parent.  On failure,
+        sends ``EmbeddingError``.  Always stops self after delivery.
+
+        Args:
+            msg: The embedding request with raw entry metadata.
+        """
+        try:
+            svc = self._get_or_create_embedding_svc(msg.embedding_model, msg.embedding_provider)
+            if svc is None:
+                self._send_error(msg, "EmbeddingService unavailable")
+                return
+
+            from akgentic.tool.vector import VectorEntry
+
+            texts = [e["text"] for e in msg.entries]
+            vectors: list[list[float]] = svc.embed(texts)
+
+            vector_entries: list[VectorEntry] = []
+            for entry_meta, vector in zip(msg.entries, vectors):
+                vector_entries.append(
+                    VectorEntry(
+                        ref_type=entry_meta["ref_type"],
+                        ref_id=entry_meta["ref_id"],
+                        text=entry_meta["text"],
+                        vector=vector,
+                    )
+                )
+
+            from akgentic.tool.vector_store.actor import VectorStoreActor
+
+            result = EmbeddingResult(
+                collection=msg.collection,
+                entries=vector_entries,
+                request_id=msg.request_id,
+            )
+            assert self._parent is not None  # always set by createActor
+            parent_proxy = self.proxy_tell(self._parent, VectorStoreActor)
+            parent_proxy.receiveMsg_EmbeddingResult(result)
+
+        except Exception as exc:  # noqa: BLE001
+            self._send_error(msg, str(exc))
+        finally:
+            self.stop()
+
+    def _send_error(self, msg: EmbeddingRequest, error: str) -> None:
+        """Send an ``EmbeddingError`` to the parent actor.
+
+        Args:
+            msg: The original request (for collection and request_id).
+            error: Human-readable error description.
+        """
+        from akgentic.tool.vector_store.actor import VectorStoreActor
+
+        err = EmbeddingError(
+            collection=msg.collection,
+            error=error,
+            request_id=msg.request_id,
+        )
+        try:
+            assert self._parent is not None  # always set by createActor
+            parent_proxy = self.proxy_tell(self._parent, VectorStoreActor)
+            parent_proxy.receiveMsg_EmbeddingError(err)
+        except Exception as send_exc:  # noqa: BLE001
+            logger.warning(
+                "[%s] Failed to send EmbeddingError to parent: %s",
+                self.config.name,
+                send_exc,
+            )

--- a/src/akgentic/tool/vector_store/inmemory.py
+++ b/src/akgentic/tool/vector_store/inmemory.py
@@ -1,0 +1,286 @@
+"""In-memory vector store backend with per-collection VectorIndex management.
+
+Implements the ``VectorStoreService`` protocol using numpy-backed
+``VectorIndex`` instances. Supports two persistence modes:
+
+- **actor_state**: serialisable snapshot for orchestrator-driven persistence.
+- **workspace**: numpy/JSON persistence to the filesystem.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from akgentic.tool.vector import VectorEntry, VectorIndex, _check_vector_search_dependencies
+from akgentic.tool.vector_store.protocol import (
+    CollectionConfig,
+    CollectionStatus,
+    SearchHit,
+    SearchResult,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class InMemoryBackend:
+    """In-memory vector store managing one ``VectorIndex`` per collection.
+
+    This is a plain Python class (not a Pydantic model) because it holds
+    non-serialisable runtime state (numpy arrays inside ``VectorIndex``).
+    It satisfies the ``VectorStoreService`` protocol structurally.
+
+    Args:
+        None. Instantiation validates that ``[vector_search]`` extras are
+        installed.
+    """
+
+    def __init__(self) -> None:
+        _check_vector_search_dependencies()
+        self._collections: dict[str, VectorIndex] = {}
+        self._configs: dict[str, CollectionConfig] = {}
+
+    # ------------------------------------------------------------------
+    # VectorStoreService protocol methods
+    # ------------------------------------------------------------------
+
+    def create_collection(self, name: str, config: CollectionConfig) -> None:
+        """Create a named collection. No-op if the collection already exists.
+
+        Args:
+            name: Unique collection identifier.
+            config: Collection configuration.
+        """
+        if name in self._collections:
+            return
+        self._collections[name] = VectorIndex()
+        self._configs[name] = config
+
+    def add(self, collection: str, entries: list[VectorEntry]) -> None:
+        """Ingest embedding entries into a collection.
+
+        Args:
+            collection: Target collection name.
+            entries: List of vector entries to store.
+
+        Raises:
+            ValueError: If the collection does not exist.
+        """
+        index = self._get_index(collection)
+        for entry in entries:
+            index.add(entry)
+
+    def remove(self, collection: str, ref_ids: list[str]) -> None:
+        """Remove entries from a collection by reference ID.
+
+        Args:
+            collection: Target collection name.
+            ref_ids: List of reference IDs to remove.
+
+        Raises:
+            ValueError: If the collection does not exist.
+        """
+        index = self._get_index(collection)
+        index.remove(set(ref_ids))
+
+    def search(
+        self, collection: str, query_vector: list[float], top_k: int
+    ) -> SearchResult:
+        """Search a collection by cosine similarity.
+
+        Args:
+            collection: Target collection name.
+            query_vector: Query embedding vector.
+            top_k: Maximum number of results to return.
+
+        Returns:
+            Search results with hits ranked by cosine similarity, collection
+            status ``READY``, and ``indexing_pending=0``.
+
+        Raises:
+            ValueError: If the collection does not exist.
+        """
+        index = self._get_index(collection)
+        results = index.search_cosine(query_vector, top_k)
+        hits = self._map_search_hits(index, results)
+        return SearchResult(
+            hits=hits,
+            status=CollectionStatus.READY,
+            indexing_pending=0,
+        )
+
+    # ------------------------------------------------------------------
+    # actor_state persistence
+    # ------------------------------------------------------------------
+
+    def get_state(self) -> dict[str, Any]:
+        """Return a serialisable snapshot of all collections.
+
+        The returned dict is suitable for inclusion in a Pydantic ``BaseState``
+        model (Story 10.3). Each collection is stored as its config plus a list
+        of ``VectorEntry`` dicts.
+
+        Returns:
+            Nested dict keyed by collection name.
+        """
+        return {
+            "collections": {
+                name: {
+                    "config": self._configs[name].model_dump(),
+                    "entries": [e.model_dump() for e in index._entries],
+                }
+                for name, index in self._collections.items()
+            }
+        }
+
+    def restore_state(self, state: dict[str, Any]) -> None:
+        """Rebuild all collections from a previously-saved state snapshot.
+
+        Args:
+            state: Dict produced by ``get_state()``.
+        """
+        self._collections.clear()
+        self._configs.clear()
+        collections = state.get("collections", {})
+        for name, col_data in collections.items():
+            config = CollectionConfig.model_validate(col_data["config"])
+            self._configs[name] = config
+            index = VectorIndex()
+            for entry_data in col_data["entries"]:
+                index.add(VectorEntry.model_validate(entry_data))
+            self._collections[name] = index
+
+    # ------------------------------------------------------------------
+    # workspace persistence
+    # ------------------------------------------------------------------
+
+    def save_collection(self, name: str, workspace_path: str) -> None:
+        """Persist a single collection to the filesystem.
+
+        Writes vectors as a compressed numpy array and metadata as a JSON
+        sidecar to ``{workspace_path}/.vector_store/{name}.npz`` and
+        ``{workspace_path}/.vector_store/{name}.json``.
+
+        Args:
+            name: Collection to save.
+            workspace_path: Root workspace directory.
+
+        Raises:
+            ValueError: If the collection does not exist.
+        """
+        import numpy as np
+
+        index = self._get_index(name)
+        base = Path(workspace_path) / ".vector_store"
+        base.mkdir(parents=True, exist_ok=True)
+
+        # Save vectors
+        if len(index) > 0:
+            vectors = index._buf[: index._count].copy()
+        else:
+            vectors = np.empty((0, 0), dtype=np.float64)
+        np.savez_compressed(str(base / f"{name}.npz"), vectors=vectors)
+
+        # Save metadata (entries + config) as JSON
+        meta = {
+            "config": self._configs[name].model_dump(),
+            "entries": [
+                {"ref_type": e.ref_type, "ref_id": e.ref_id, "text": e.text}
+                for e in index._entries
+            ],
+        }
+        (base / f"{name}.json").write_text(json.dumps(meta), encoding="utf-8")
+
+    def load_collection(self, name: str, config: CollectionConfig, workspace_path: str) -> None:
+        """Restore a collection from workspace persistence files.
+
+        If no persisted data exists on disk the collection starts empty.
+
+        Args:
+            name: Collection name.
+            config: Collection configuration.
+            workspace_path: Root workspace directory.
+        """
+        import numpy as np
+
+        base = Path(workspace_path) / ".vector_store"
+        npz_path = base / f"{name}.npz"
+        json_path = base / f"{name}.json"
+
+        self._configs[name] = config
+        index = VectorIndex()
+
+        if npz_path.exists() and json_path.exists():
+            data = np.load(str(npz_path))
+            vectors = data["vectors"]
+            meta = json.loads(json_path.read_text(encoding="utf-8"))
+            entries_meta = meta.get("entries", [])
+
+            for i, em in enumerate(entries_meta):
+                if i < len(vectors):
+                    entry = VectorEntry(
+                        ref_type=em["ref_type"],
+                        ref_id=em["ref_id"],
+                        text=em["text"],
+                        vector=vectors[i].tolist(),
+                    )
+                    index.add(entry)
+
+        self._collections[name] = index
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _get_index(self, collection: str) -> VectorIndex:
+        """Return the ``VectorIndex`` for *collection* or raise.
+
+        Args:
+            collection: Collection name to look up.
+
+        Returns:
+            The ``VectorIndex`` instance.
+
+        Raises:
+            ValueError: If the collection does not exist.
+        """
+        try:
+            return self._collections[collection]
+        except KeyError:
+            msg = f"Collection '{collection}' does not exist"
+            raise ValueError(msg) from None
+
+    @staticmethod
+    def _map_search_hits(
+        index: VectorIndex, results: list[tuple[str, float]]
+    ) -> list[SearchHit]:
+        """Convert raw ``(ref_id, score)`` tuples to ``SearchHit`` models.
+
+        Builds a lookup from ``VectorIndex._entries`` for O(1) metadata
+        resolution.
+
+        Args:
+            index: The VectorIndex that produced the results.
+            results: Raw search output from ``search_cosine``.
+
+        Returns:
+            List of ``SearchHit`` models with full metadata.
+        """
+        entries_by_id: dict[str, VectorEntry] = {e.ref_id: e for e in index._entries}
+        hits: list[SearchHit] = []
+        for ref_id, score in results:
+            entry = entries_by_id.get(ref_id)
+            if entry is None:
+                logger.warning("Search returned ref_id '%s' not found in entries", ref_id)
+                continue
+            hits.append(
+                SearchHit(
+                    ref_type=entry.ref_type,
+                    ref_id=entry.ref_id,
+                    text=entry.text,
+                    score=score,
+                )
+            )
+        return hits

--- a/src/akgentic/tool/vector_store/protocol.py
+++ b/src/akgentic/tool/vector_store/protocol.py
@@ -54,6 +54,10 @@ class CollectionConfig(SerializableBaseModel):
     workspace_path: str | None = Field(
         default=None, description="Filesystem path when persistence is workspace"
     )
+    tenant: str | None = Field(
+        default=None,
+        description="Weaviate tenant ID for multi-tenancy (maps to workspace/team ID)",
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/akgentic/tool/vector_store/weaviate.py
+++ b/src/akgentic/tool/vector_store/weaviate.py
@@ -1,0 +1,278 @@
+"""Weaviate vector store backend with multi-tenancy support.
+
+Implements the ``VectorStoreService`` protocol by delegating all vector
+storage operations to a Weaviate cluster via the ``weaviate-client`` v4 API.
+Vectors are provided externally (no Weaviate-side vectoriser).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+from urllib.parse import urlparse
+
+from akgentic.tool.vector_store.protocol import (
+    CollectionConfig,
+    CollectionStatus,
+    SearchHit,
+    SearchResult,
+)
+
+if TYPE_CHECKING:
+    import weaviate
+    import weaviate.collections
+
+    from akgentic.tool.vector import VectorEntry
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Dependency guard
+# ---------------------------------------------------------------------------
+
+try:
+    import weaviate as _weaviate  # noqa: F811, F401
+except ImportError:
+    _WEAVIATE_AVAILABLE = False
+else:
+    _WEAVIATE_AVAILABLE = True
+
+
+def _check_weaviate_dependencies() -> None:
+    """Validate that ``weaviate-client`` is installed.
+
+    Raises:
+        ImportError: With install instructions when ``weaviate-client`` is missing.
+    """
+    if not _WEAVIATE_AVAILABLE:
+        msg = (
+            "Weaviate backend requires the 'weaviate-client' package. "
+            "Install with: pip install akgentic-tool[weaviate]"
+        )
+        raise ImportError(msg)
+
+
+# ---------------------------------------------------------------------------
+# WeaviateBackend
+# ---------------------------------------------------------------------------
+
+
+class WeaviateBackend:
+    """Weaviate-backed vector store implementing ``VectorStoreService``.
+
+    This is a plain Python class (not a Pydantic model) because it holds
+    non-serialisable runtime state (the Weaviate client connection).
+    It satisfies the ``VectorStoreService`` protocol structurally.
+
+    Args:
+        url: Weaviate cluster URL (e.g. ``http://localhost:8080``).
+        api_key: Optional API key for authentication.
+        tenant: Optional default tenant ID for multi-tenancy.
+    """
+
+    def __init__(self, url: str, api_key: str | None = None, tenant: str | None = None) -> None:
+        _check_weaviate_dependencies()
+
+        import weaviate as _wv
+        from weaviate.auth import AuthApiKey
+
+        self._tenant = tenant
+        parsed = urlparse(url)
+        host = parsed.hostname or "localhost"
+        port = parsed.port or (443 if parsed.scheme == "https" else 8080)
+        use_https = parsed.scheme == "https"
+
+        # gRPC defaults: same host, port 50051
+        grpc_port = 50051
+
+        auth = AuthApiKey(api_key) if api_key else None
+        self._client: weaviate.WeaviateClient = _wv.connect_to_custom(
+            http_host=host,
+            http_port=port,
+            http_secure=use_https,
+            grpc_host=host,
+            grpc_port=grpc_port,
+            grpc_secure=use_https,
+            auth_credentials=auth,
+        )
+        self._collections_created: set[str] = set()
+
+    # ------------------------------------------------------------------
+    # VectorStoreService protocol methods
+    # ------------------------------------------------------------------
+
+    def create_collection(self, name: str, config: CollectionConfig) -> None:
+        """Create a named Weaviate collection. No-op if it already exists.
+
+        When multi-tenancy is enabled (``self._tenant`` or ``config.tenant``
+        is set), the collection is created with multi-tenancy and the tenant
+        is provisioned.
+
+        Args:
+            name: Unique collection identifier.
+            config: Collection configuration.
+        """
+        from weaviate.classes.config import Configure, DataType, Property
+        from weaviate.classes.tenants import Tenant
+
+        tenant = getattr(config, "tenant", None) or self._tenant
+
+        if self._client.collections.exists(name):
+            self._collections_created.add(name)
+            # Ensure tenant exists if multi-tenancy is enabled
+            if tenant:
+                try:
+                    collection = self._client.collections.get(name)
+                    collection.tenants.create([Tenant(name=tenant)])
+                except Exception:  # noqa: BLE001
+                    pass  # Tenant may already exist
+            return
+
+        kwargs: dict[str, object] = {
+            "name": name,
+            "vectorizer_config": Configure.Vectorizer.none(),
+            "properties": [
+                Property(name="ref_type", data_type=DataType.TEXT),
+                Property(name="ref_id", data_type=DataType.TEXT),
+                Property(name="text", data_type=DataType.TEXT),
+            ],
+        }
+
+        if tenant:
+            kwargs["multi_tenancy_config"] = Configure.multi_tenancy(enabled=True)
+
+        self._client.collections.create(**kwargs)
+        self._collections_created.add(name)
+
+        # Create the tenant after multi-tenant collection is created
+        if tenant:
+            collection = self._client.collections.get(name)
+            collection.tenants.create([Tenant(name=tenant)])
+
+    def add(self, collection: str, entries: list[VectorEntry]) -> None:
+        """Ingest embedding entries into a Weaviate collection.
+
+        Uses batch insertion with pre-populated vectors.
+
+        Args:
+            collection: Target collection name.
+            entries: List of vector entries to store.
+
+        Raises:
+            ValueError: If the collection has not been created.
+        """
+        self._check_collection(collection)
+        col = self._get_collection(collection)
+
+        with col.batch.dynamic() as batch:
+            for entry in entries:
+                batch.add_object(
+                    properties={
+                        "ref_type": entry.ref_type,
+                        "ref_id": entry.ref_id,
+                        "text": entry.text,
+                    },
+                    vector=entry.vector,
+                )
+
+    def remove(self, collection: str, ref_ids: list[str]) -> None:
+        """Remove entries from a Weaviate collection by ref_id.
+
+        Uses ``delete_many`` with a property filter on ``ref_id``.
+
+        Args:
+            collection: Target collection name.
+            ref_ids: List of reference IDs to remove.
+
+        Raises:
+            ValueError: If the collection has not been created.
+        """
+        from weaviate.classes.query import Filter
+
+        self._check_collection(collection)
+        col = self._get_collection(collection)
+        col.data.delete_many(
+            where=Filter.by_property("ref_id").contains_any(ref_ids),
+        )
+
+    def search(
+        self, collection: str, query_vector: list[float], top_k: int
+    ) -> SearchResult:
+        """Search a Weaviate collection by cosine similarity.
+
+        Args:
+            collection: Target collection name.
+            query_vector: Query embedding vector.
+            top_k: Maximum number of results to return.
+
+        Returns:
+            Search results with hits ranked by distance (converted to score).
+
+        Raises:
+            ValueError: If the collection has not been created.
+        """
+        from weaviate.classes.query import MetadataQuery
+
+        self._check_collection(collection)
+        col = self._get_collection(collection)
+
+        result = col.query.near_vector(
+            near_vector=query_vector,
+            limit=top_k,
+            return_metadata=MetadataQuery(distance=True),
+        )
+
+        hits: list[SearchHit] = []
+        for obj in result.objects:
+            props = obj.properties
+            distance = obj.metadata.distance if obj.metadata and obj.metadata.distance else 0.0
+            score = 1.0 - distance
+            hits.append(
+                SearchHit(
+                    ref_type=str(props.get("ref_type", "")),
+                    ref_id=str(props.get("ref_id", "")),
+                    text=str(props.get("text", "")),
+                    score=score,
+                )
+            )
+
+        return SearchResult(
+            hits=hits,
+            status=CollectionStatus.READY,
+            indexing_pending=0,
+        )
+
+    def close(self) -> None:
+        """Disconnect the Weaviate client."""
+        self._client.close()
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _check_collection(self, collection: str) -> None:
+        """Raise ``ValueError`` if *collection* was never created via this backend.
+
+        Args:
+            collection: Collection name to validate.
+
+        Raises:
+            ValueError: If the collection has not been created.
+        """
+        if collection not in self._collections_created:
+            msg = f"Collection '{collection}' does not exist"
+            raise ValueError(msg)
+
+    def _get_collection(self, name: str) -> weaviate.collections.Collection:
+        """Return the Weaviate collection handle, with tenant if applicable.
+
+        Args:
+            name: Collection name.
+
+        Returns:
+            Weaviate collection object (optionally scoped to tenant).
+        """
+        col = self._client.collections.get(name)
+        if self._tenant:
+            col = col.with_tenant(self._tenant)
+        return col

--- a/src/akgentic/tool/vector_store/weaviate.py
+++ b/src/akgentic/tool/vector_store/weaviate.py
@@ -128,20 +128,19 @@ class WeaviateBackend:
                     pass  # Tenant may already exist
             return
 
-        kwargs: dict[str, object] = {
-            "name": name,
-            "vectorizer_config": Configure.Vectorizer.none(),
-            "properties": [
-                Property(name="ref_type", data_type=DataType.TEXT),
-                Property(name="ref_id", data_type=DataType.TEXT),
-                Property(name="text", data_type=DataType.TEXT),
-            ],
-        }
+        properties = [
+            Property(name="ref_type", data_type=DataType.TEXT),
+            Property(name="ref_id", data_type=DataType.TEXT),
+            Property(name="text", data_type=DataType.TEXT),
+        ]
+        mt_config = Configure.multi_tenancy(enabled=True) if tenant else None
 
-        if tenant:
-            kwargs["multi_tenancy_config"] = Configure.multi_tenancy(enabled=True)
-
-        self._client.collections.create(**kwargs)
+        self._client.collections.create(
+            name=name,
+            vectorizer_config=Configure.Vectorizer.none(),
+            properties=properties,
+            multi_tenancy_config=mt_config,
+        )
         self._collections_created.add(name)
 
         # Create the tenant after multi-tenant collection is created

--- a/src/akgentic/tool/vector_store/weaviate.py
+++ b/src/akgentic/tool/vector_store/weaviate.py
@@ -96,6 +96,7 @@ class WeaviateBackend:
             auth_credentials=auth,
         )
         self._collections_created: set[str] = set()
+        self._collection_tenants: dict[str, str] = {}
 
     # ------------------------------------------------------------------
     # VectorStoreService protocol methods
@@ -119,13 +120,17 @@ class WeaviateBackend:
 
         if self._client.collections.exists(name):
             self._collections_created.add(name)
-            # Ensure tenant exists if multi-tenancy is enabled
             if tenant:
+                self._collection_tenants[name] = tenant
                 try:
                     collection = self._client.collections.get(name)
                     collection.tenants.create([Tenant(name=tenant)])
                 except Exception:  # noqa: BLE001
-                    pass  # Tenant may already exist
+                    logger.debug(
+                        "Tenant '%s' may already exist on collection '%s'",
+                        tenant,
+                        name,
+                    )
             return
 
         properties = [
@@ -145,6 +150,7 @@ class WeaviateBackend:
 
         # Create the tenant after multi-tenant collection is created
         if tenant:
+            self._collection_tenants[name] = tenant
             collection = self._client.collections.get(name)
             collection.tenants.create([Tenant(name=tenant)])
 
@@ -225,7 +231,7 @@ class WeaviateBackend:
         for obj in result.objects:
             props = obj.properties
             distance = obj.metadata.distance if obj.metadata and obj.metadata.distance else 0.0
-            score = 1.0 - distance
+            score = max(0.0, 1.0 - distance)
             hits.append(
                 SearchHit(
                     ref_type=str(props.get("ref_type", "")),
@@ -265,6 +271,9 @@ class WeaviateBackend:
     def _get_collection(self, name: str) -> weaviate.collections.Collection:
         """Return the Weaviate collection handle, with tenant if applicable.
 
+        Resolves the effective tenant from the per-collection mapping first,
+        falling back to the backend-level default tenant.
+
         Args:
             name: Collection name.
 
@@ -272,6 +281,7 @@ class WeaviateBackend:
             Weaviate collection object (optionally scoped to tenant).
         """
         col = self._client.collections.get(name)
-        if self._tenant:
-            col = col.with_tenant(self._tenant)
+        tenant = self._collection_tenants.get(name) or self._tenant
+        if tenant:
+            col = col.with_tenant(tenant)
         return col

--- a/tests/test_kg_actor.py
+++ b/tests/test_kg_actor.py
@@ -2,13 +2,13 @@
 
 Covers: all CRUD ops, cascade deletion, error collection, partial updates,
 state change notification, deduplication logic, singleton constants (Task 2.9).
-Also covers embedding wiring: entity/relation embedding on create, re-embedding
-on description update, removal on delete, graceful degradation on API failure
-(Task 5.11, Story 2.1 ACs 3-7).
-Also covers vector search and hybrid search (Story 2.2 ACs 1-5).
+Also covers embedding wiring via VectorStoreActor proxy: entity/relation
+embedding on create, re-embedding on description update, removal on delete,
+graceful degradation on API failure.
+Also covers vector search and hybrid search.
 
 Pattern: Instantiate KnowledgeGraphActor() directly, call on_start(),
-test methods. Same pattern as test_planning_actor.py.
+test methods.  The VectorStoreActor proxy is mocked.
 """
 
 from __future__ import annotations
@@ -23,6 +23,7 @@ from akgentic.tool.errors import RetriableError
 from akgentic.tool.knowledge_graph.kg_actor import (
     KG_ACTOR_NAME,
     KG_ACTOR_ROLE,
+    KG_COLLECTION,
     KnowledgeGraphActor,
     KnowledgeGraphConfig,
 )
@@ -35,6 +36,9 @@ from akgentic.tool.knowledge_graph.models import (
     RelationDelete,
     SearchQuery,
 )
+from akgentic.tool.vector_store.protocol import CollectionStatus
+from akgentic.tool.vector_store.protocol import SearchHit as VsSearchHit
+from akgentic.tool.vector_store.protocol import SearchResult as VsSearchResult
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -89,9 +93,18 @@ class MockActorAddress(ActorAddress):
 
 
 def _actor() -> KnowledgeGraphActor:
-    """Create and initialize a KnowledgeGraphActor for testing."""
+    """Create and initialize a KnowledgeGraphActor for testing.
+
+    The VectorStoreActor proxy is not available (degraded mode) -- suitable
+    for pure CRUD tests that do not need embedding.
+    """
+    from akgentic.tool.knowledge_graph.models import KnowledgeGraphState
+
     actor = KnowledgeGraphActor()
-    actor.on_start()
+    # Bypass _acquire_vs_proxy (no orchestrator in unit tests)
+    actor.state = KnowledgeGraphState()
+    actor.state.observer(actor)
+    actor._vs_proxy = None
     return actor
 
 
@@ -128,25 +141,22 @@ def _seed_with_relation(actor: KnowledgeGraphActor) -> None:
 
 
 class TestKnowledgeGraphConfig:
-    """AC-1: KnowledgeGraphConfig extends BaseConfig with embedding settings."""
+    """AC-8: KnowledgeGraphConfig is an empty BaseConfig subclass."""
 
-    def test_default_embedding_model(self) -> None:
+    def test_config_is_base_config_subclass(self) -> None:
+        from akgentic.core.agent_config import BaseConfig
+
+        assert issubclass(KnowledgeGraphConfig, BaseConfig)
+
+    def test_config_creates_with_name_and_role(self) -> None:
         cfg = KnowledgeGraphConfig(name="test", role="ToolActor")
-        assert cfg.embedding_model == "text-embedding-3-small"
+        assert cfg.name == "test"
+        assert cfg.role == "ToolActor"
 
-    def test_default_embedding_provider(self) -> None:
+    def test_config_has_no_embedding_fields(self) -> None:
         cfg = KnowledgeGraphConfig(name="test", role="ToolActor")
-        assert cfg.embedding_provider == "openai"
-
-    def test_custom_embedding_model(self) -> None:
-        cfg = KnowledgeGraphConfig(
-            name="test", role="ToolActor", embedding_model="text-embedding-ada-002"
-        )
-        assert cfg.embedding_model == "text-embedding-ada-002"
-
-    def test_azure_provider(self) -> None:
-        cfg = KnowledgeGraphConfig(name="test", role="ToolActor", embedding_provider="azure")
-        assert cfg.embedding_provider == "azure"
+        assert not hasattr(cfg, "embedding_model")
+        assert not hasattr(cfg, "embedding_provider")
 
 
 # ---------------------------------------------------------------------------
@@ -646,23 +656,34 @@ class TestIsRootWiring:
 # ---------------------------------------------------------------------------
 
 _FAKE_VECTOR = [0.1, 0.2, 0.3]
-_EMBED_MODULE = "akgentic.tool.knowledge_graph.kg_actor.EmbeddingService"
+
+
+def _make_mock_vs_proxy() -> MagicMock:
+    """Create a mock VectorStoreActor proxy with default return values."""
+    proxy = MagicMock()
+    proxy.embed.return_value = [_FAKE_VECTOR]
+    proxy.add.return_value = None
+    proxy.remove.return_value = None
+    proxy.create_collection.return_value = None
+    proxy.search.return_value = VsSearchResult(
+        hits=[], status=CollectionStatus.READY, indexing_pending=0
+    )
+    return proxy
 
 
 def _actor_with_mock_embed() -> tuple[KnowledgeGraphActor, MagicMock]:
-    """Return (actor, mock_embed_method) with a pre-wired mock EmbeddingService."""
+    """Return (actor, mock_vs_proxy) with a pre-wired mock VectorStoreActor proxy."""
     actor = _actor()
-    mock_svc = MagicMock()
-    mock_svc.embed.return_value = [_FAKE_VECTOR]
-    actor._embedding_svc = mock_svc  # inject mock directly, bypassing lazy init
-    return actor, mock_svc
+    mock_proxy = _make_mock_vs_proxy()
+    actor._vs_proxy = mock_proxy
+    return actor, mock_proxy
 
 
 class TestEmbeddingOnCreate:
-    """AC-3, AC-4: embedding called when entities/relations are created."""
+    """AC-4, AC-6: embedding called when entities/relations are created via vs_proxy."""
 
     def test_embedding_called_on_entity_create(self) -> None:
-        actor, mock_svc = _actor_with_mock_embed()
+        actor, mock_proxy = _actor_with_mock_embed()
         actor.update_graph(
             ManageGraph(
                 create_entities=[
@@ -670,15 +691,29 @@ class TestEmbeddingOnCreate:
                 ]
             )
         )
-        mock_svc.embed.assert_called_once()
-        call_args = mock_svc.embed.call_args[0][0]
+        mock_proxy.embed.assert_called_once()
+        call_args = mock_proxy.embed.call_args[0][0]
         assert "Alice" in call_args[0]
         assert "Eng" in call_args[0]
 
+    def test_add_called_on_entity_create(self) -> None:
+        actor, mock_proxy = _actor_with_mock_embed()
+        actor.update_graph(
+            ManageGraph(
+                create_entities=[
+                    EntityCreate(name="Alice", entity_type="Person", description="Eng")
+                ]
+            )
+        )
+        mock_proxy.add.assert_called_once()
+        call_args = mock_proxy.add.call_args
+        assert call_args[0][0] == KG_COLLECTION
+
     def test_embedding_called_on_relation_create_with_description(self) -> None:
-        actor, mock_svc = _actor_with_mock_embed()
+        actor, mock_proxy = _actor_with_mock_embed()
         _seed_entities(actor)
-        mock_svc.reset_mock()
+        mock_proxy.reset_mock()
+        mock_proxy.embed.return_value = [_FAKE_VECTOR]
         actor.update_graph(
             ManageGraph(
                 create_relations=[
@@ -691,14 +726,14 @@ class TestEmbeddingOnCreate:
                 ]
             )
         )
-        mock_svc.embed.assert_called_once()
-        call_args = mock_svc.embed.call_args[0][0]
+        mock_proxy.embed.assert_called_once()
+        call_args = mock_proxy.embed.call_args[0][0]
         assert "long colleagues" in call_args[0]
 
     def test_embedding_skipped_on_relation_create_empty_description(self) -> None:
-        actor, mock_svc = _actor_with_mock_embed()
+        actor, mock_proxy = _actor_with_mock_embed()
         _seed_entities(actor)
-        mock_svc.reset_mock()
+        mock_proxy.reset_mock()
         actor.update_graph(
             ManageGraph(
                 create_relations=[
@@ -706,14 +741,14 @@ class TestEmbeddingOnCreate:
                 ]
             )
         )
-        mock_svc.embed.assert_not_called()
+        mock_proxy.embed.assert_not_called()
 
 
 class TestEmbeddingOnUpdate:
-    """AC-5: re-embedding on description change."""
+    """AC-5: re-embedding on description change via vs_proxy."""
 
     def test_embedding_updated_on_description_change(self) -> None:
-        actor, mock_svc = _actor_with_mock_embed()
+        actor, mock_proxy = _actor_with_mock_embed()
         actor.update_graph(
             ManageGraph(
                 create_entities=[
@@ -721,17 +756,17 @@ class TestEmbeddingOnUpdate:
                 ]
             )
         )
-        embed_count_before = mock_svc.embed.call_count
+        embed_count_before = mock_proxy.embed.call_count
         actor.update_graph(
             ManageGraph(update_entities=[EntityUpdate(name="Alice", description="Senior Eng")])
         )
-        assert mock_svc.embed.call_count == embed_count_before + 1
+        assert mock_proxy.embed.call_count == embed_count_before + 1
         # Verify the new description is embedded, not the old one
-        last_call = mock_svc.embed.call_args[0][0]
+        last_call = mock_proxy.embed.call_args[0][0]
         assert "Senior Eng" in last_call[0]
 
-    def test_no_re_embedding_when_description_unchanged(self) -> None:
-        actor, mock_svc = _actor_with_mock_embed()
+    def test_remove_called_before_re_embedding(self) -> None:
+        actor, mock_proxy = _actor_with_mock_embed()
         actor.update_graph(
             ManageGraph(
                 create_entities=[
@@ -739,19 +774,36 @@ class TestEmbeddingOnUpdate:
                 ]
             )
         )
-        embed_count_before = mock_svc.embed.call_count
+        mock_proxy.remove.reset_mock()
+        actor.update_graph(
+            ManageGraph(update_entities=[EntityUpdate(name="Alice", description="Senior Eng")])
+        )
+        mock_proxy.remove.assert_called_once()
+        call_args = mock_proxy.remove.call_args
+        assert call_args[0][0] == KG_COLLECTION
+
+    def test_no_re_embedding_when_description_unchanged(self) -> None:
+        actor, mock_proxy = _actor_with_mock_embed()
+        actor.update_graph(
+            ManageGraph(
+                create_entities=[
+                    EntityCreate(name="Alice", entity_type="Person", description="Eng")
+                ]
+            )
+        )
+        embed_count_before = mock_proxy.embed.call_count
         # Update entity_type only — no description change
         actor.update_graph(
             ManageGraph(update_entities=[EntityUpdate(name="Alice", entity_type="Engineer")])
         )
-        assert mock_svc.embed.call_count == embed_count_before
+        assert mock_proxy.embed.call_count == embed_count_before
 
 
 class TestEmbeddingOnDelete:
-    """AC-6: embedding removed when entities/relations are deleted."""
+    """AC-7: embedding removed when entities/relations are deleted via vs_proxy."""
 
     def test_entity_embedding_removed_on_delete(self) -> None:
-        actor, mock_svc = _actor_with_mock_embed()
+        actor, mock_proxy = _actor_with_mock_embed()
         actor.update_graph(
             ManageGraph(
                 create_entities=[
@@ -759,15 +811,17 @@ class TestEmbeddingOnDelete:
                 ]
             )
         )
-        # Check an embedding was stored
-        assert len(actor._vector_index._entries) == 1
-
+        mock_proxy.remove.reset_mock()
         actor.update_graph(ManageGraph(delete_entities=["Alice"]))
-        assert len(actor._vector_index._entries) == 0
+        mock_proxy.remove.assert_called_once()
+        call_args = mock_proxy.remove.call_args
+        assert call_args[0][0] == KG_COLLECTION
+        assert len(call_args[0][1]) == 1  # 1 entity ref_id
 
     def test_relation_embedding_removed_on_delete(self) -> None:
-        actor, mock_svc = _actor_with_mock_embed()
+        actor, mock_proxy = _actor_with_mock_embed()
         _seed_entities(actor)
+        mock_proxy.remove.reset_mock()
         actor.update_graph(
             ManageGraph(
                 create_relations=[
@@ -780,9 +834,7 @@ class TestEmbeddingOnDelete:
                 ]
             )
         )
-        # 2 entity embeddings + 1 relation embedding
-        assert len(actor._vector_index._entries) == 3
-
+        mock_proxy.remove.reset_mock()
         actor.update_graph(
             ManageGraph(
                 delete_relations=[
@@ -790,15 +842,18 @@ class TestEmbeddingOnDelete:
                 ]
             )
         )
-        assert len(actor._vector_index._entries) == 2
+        mock_proxy.remove.assert_called_once()
+        call_args = mock_proxy.remove.call_args
+        assert call_args[0][0] == KG_COLLECTION
+        assert len(call_args[0][1]) == 1  # 1 relation ref_id
 
 
 class TestEmbeddingGracefulDegradation:
-    """AC-7: embedding failures do not block CRUD operations."""
+    """Embedding failures do not block CRUD operations."""
 
     def test_embedding_failure_does_not_block_entity_create(self) -> None:
-        actor, mock_svc = _actor_with_mock_embed()
-        mock_svc.embed.side_effect = RuntimeError("API key invalid")
+        actor, mock_proxy = _actor_with_mock_embed()
+        mock_proxy.embed.side_effect = RuntimeError("API key invalid")
         result = actor.update_graph(
             ManageGraph(
                 create_entities=[
@@ -810,9 +865,9 @@ class TestEmbeddingGracefulDegradation:
         assert len(actor.get_graph().entities) == 1
 
     def test_embedding_failure_does_not_block_relation_create(self) -> None:
-        actor, mock_svc = _actor_with_mock_embed()
+        actor, mock_proxy = _actor_with_mock_embed()
         _seed_entities(actor)
-        mock_svc.embed.side_effect = RuntimeError("API timeout")
+        mock_proxy.embed.side_effect = RuntimeError("API timeout")
         result = actor.update_graph(
             ManageGraph(
                 create_relations=[
@@ -828,6 +883,19 @@ class TestEmbeddingGracefulDegradation:
         assert result == "Done"
         assert len(actor.get_graph().relations) == 1
 
+    def test_degraded_mode_when_no_proxy(self) -> None:
+        """When _vs_proxy is None, CRUD works but no embedding calls are made."""
+        actor = _actor()  # _vs_proxy is None
+        result = actor.update_graph(
+            ManageGraph(
+                create_entities=[
+                    EntityCreate(name="Alice", entity_type="Person", description="Eng")
+                ]
+            )
+        )
+        assert result == "Done"
+        assert len(actor.get_graph().entities) == 1
+
 
 # ---------------------------------------------------------------------------
 # Vector search (Story 2.2 Task 1, ACs 1, 3, 5)
@@ -835,10 +903,10 @@ class TestEmbeddingGracefulDegradation:
 
 
 class TestVectorSearch:
-    """AC-1, AC-5: vector search returns ranked results or empty on no embeddings."""
+    """AC-5: vector search returns ranked results or empty on no embeddings."""
 
     def test_vector_search_returns_top_k_ranked_by_score(self) -> None:
-        actor, mock_svc = _actor_with_mock_embed()
+        actor, mock_proxy = _actor_with_mock_embed()
         actor.update_graph(
             ManageGraph(
                 create_entities=[
@@ -848,35 +916,37 @@ class TestVectorSearch:
             )
         )
         entity_ids = [str(e.id) for e in actor.get_graph().entities]
-        with patch.object(
-            actor._vector_index,  # noqa: SLF001
-            "search_cosine",
-            return_value=[(entity_ids[0], 0.9), (entity_ids[1], 0.5)],
-        ):
-            mock_svc.embed.return_value = [_FAKE_VECTOR]
-            result = actor.search(SearchQuery(query="engineer", top_k=2, mode="vector"))
+        mock_proxy.embed.return_value = [_FAKE_VECTOR]
+        mock_proxy.search.return_value = VsSearchResult(
+            hits=[
+                VsSearchHit(ref_type="entity", ref_id=entity_ids[0], text="", score=0.9),
+                VsSearchHit(ref_type="entity", ref_id=entity_ids[1], text="", score=0.5),
+            ],
+            status=CollectionStatus.READY,
+            indexing_pending=0,
+        )
+        result = actor.search(SearchQuery(query="engineer", top_k=2, mode="vector"))
         assert len(result.hits) == 2
         assert result.hits[0].score == 0.9
         assert result.hits[1].score == 0.5
         assert result.hits[0].entity is not None
 
-    def test_vector_search_returns_empty_when_no_entries_in_index(self) -> None:
-        actor = _actor()
+    def test_vector_search_returns_empty_when_no_proxy(self) -> None:
+        actor = _actor()  # _vs_proxy is None
         result = actor.search(SearchQuery(query="anything", top_k=5, mode="vector"))
         assert result.hits == []
 
     def test_vector_search_returns_empty_when_embed_call_fails(self) -> None:
-        """Verify graceful empty result when embed() raises during vector search (AC-5)."""
-        actor, mock_svc = _actor_with_mock_embed()
-        actor.update_graph(
-            ManageGraph(
-                create_entities=[
-                    EntityCreate(name="Alice", entity_type="Person", description="Eng")
-                ]
-            )
-        )
-        # Index has 1 entry; make embed raise during the search query
-        mock_svc.embed.side_effect = RuntimeError("API quota exceeded")
+        """Verify graceful empty result when embed() raises during vector search."""
+        actor, mock_proxy = _actor_with_mock_embed()
+        mock_proxy.embed.side_effect = RuntimeError("API quota exceeded")
+        result = actor.search(SearchQuery(query="Alice", top_k=5, mode="vector"))
+        assert result.hits == []
+
+    def test_vector_search_returns_empty_when_embed_returns_empty(self) -> None:
+        """VectorStoreActor returns [] on embed failure -- should result in empty search."""
+        actor, mock_proxy = _actor_with_mock_embed()
+        mock_proxy.embed.return_value = []
         result = actor.search(SearchQuery(query="Alice", top_k=5, mode="vector"))
         assert result.hits == []
 
@@ -887,13 +957,13 @@ class TestVectorSearch:
 
 
 class TestHybridSearch:
-    """AC-2, AC-4: hybrid merges keyword+vector, falls back to keyword when no embeddings."""
+    """Hybrid merges keyword+vector, falls back to keyword when no embeddings."""
 
     def _setup_actor_with_known_vectors(
         self,
     ) -> tuple[KnowledgeGraphActor, MagicMock]:
-        """Actor with Alice + Bob; mock embed returns fixed vectors."""
-        actor, mock_svc = _actor_with_mock_embed()
+        """Actor with Alice + Bob; mock vs_proxy."""
+        actor, mock_proxy = _actor_with_mock_embed()
         actor.update_graph(
             ManageGraph(
                 create_entities=[
@@ -906,10 +976,10 @@ class TestHybridSearch:
                 ]
             )
         )
-        return actor, mock_svc
+        return actor, mock_proxy
 
-    def test_hybrid_falls_back_to_keyword_when_no_embeddings(self) -> None:
-        actor = _actor()
+    def test_hybrid_falls_back_to_keyword_when_no_proxy(self) -> None:
+        actor = _actor()  # _vs_proxy is None
         actor.update_graph(
             ManageGraph(
                 create_entities=[
@@ -917,46 +987,46 @@ class TestHybridSearch:
                 ]
             )
         )
-        # No embedding service → vector search returns empty → hybrid falls back
         result = actor.search(SearchQuery(query="Alice", top_k=5, mode="hybrid"))
         assert len(result.hits) == 1
         assert result.hits[0].entity is not None
         assert result.hits[0].entity.name == "Alice"
 
     def test_hybrid_deduplicates_by_ref_id(self) -> None:
-        actor, mock_svc = self._setup_actor_with_known_vectors()
+        actor, mock_proxy = self._setup_actor_with_known_vectors()
         alice_id = str(
             next(e for e in actor.get_graph().entities if e.name == "Alice").id
         )
-        with patch.object(
-            actor._vector_index,  # noqa: SLF001
-            "search_cosine",
-            return_value=[(alice_id, 0.8)],
-        ):
-            mock_svc.embed.return_value = [_FAKE_VECTOR]
-            result = actor.search(SearchQuery(query="Alice", top_k=10, mode="hybrid"))
+        mock_proxy.embed.return_value = [_FAKE_VECTOR]
+        mock_proxy.search.return_value = VsSearchResult(
+            hits=[VsSearchHit(ref_type="entity", ref_id=alice_id, text="", score=0.8)],
+            status=CollectionStatus.READY,
+            indexing_pending=0,
+        )
+        result = actor.search(SearchQuery(query="Alice", top_k=10, mode="hybrid"))
         alice_hits = [h for h in result.hits if h.ref_id == alice_id]
         assert len(alice_hits) == 1, "Alice should appear exactly once (deduplication)"
 
     def test_hybrid_combined_hits_rank_higher_than_vector_only(self) -> None:
-        actor, mock_svc = self._setup_actor_with_known_vectors()
+        actor, mock_proxy = self._setup_actor_with_known_vectors()
         entities = actor.get_graph().entities
         alice_id = str(next(e for e in entities if e.name == "Alice").id)
         bob_id = str(next(e for e in entities if e.name == "Bob").id)
-        # Alice matches keyword "login" AND vector; Bob matches vector only
-        with patch.object(
-            actor._vector_index,  # noqa: SLF001
-            "search_cosine",
-            return_value=[(alice_id, 0.8), (bob_id, 0.9)],
-        ):
-            mock_svc.embed.return_value = [_FAKE_VECTOR]
-            result = actor.search(SearchQuery(query="login", top_k=5, mode="hybrid"))
-        # Alice: vector(0.8) + keyword_boost(0.5) = 1.3; Bob: vector only = 0.9
+        mock_proxy.embed.return_value = [_FAKE_VECTOR]
+        mock_proxy.search.return_value = VsSearchResult(
+            hits=[
+                VsSearchHit(ref_type="entity", ref_id=alice_id, text="", score=0.8),
+                VsSearchHit(ref_type="entity", ref_id=bob_id, text="", score=0.9),
+            ],
+            status=CollectionStatus.READY,
+            indexing_pending=0,
+        )
+        result = actor.search(SearchQuery(query="login", top_k=5, mode="hybrid"))
         ref_ids = [h.ref_id for h in result.hits]
         assert ref_ids[0] == alice_id, "Alice (vector+keyword) should rank above Bob (vector-only)"
 
     def test_hybrid_top_k_limits_results(self) -> None:
-        actor, mock_svc = _actor_with_mock_embed()
+        actor, mock_proxy = _actor_with_mock_embed()
         actor.update_graph(
             ManageGraph(
                 create_entities=[
@@ -966,13 +1036,16 @@ class TestHybridSearch:
             )
         )
         entity_ids = [str(e.id) for e in actor.get_graph().entities]
-        with patch.object(
-            actor._vector_index,  # noqa: SLF001
-            "search_cosine",
-            return_value=[(eid, 0.5) for eid in entity_ids],
-        ):
-            mock_svc.embed.return_value = [_FAKE_VECTOR]
-            result = actor.search(SearchQuery(query="desc", top_k=3, mode="hybrid"))
+        mock_proxy.embed.return_value = [_FAKE_VECTOR]
+        mock_proxy.search.return_value = VsSearchResult(
+            hits=[
+                VsSearchHit(ref_type="entity", ref_id=eid, text="", score=0.5)
+                for eid in entity_ids
+            ],
+            status=CollectionStatus.READY,
+            indexing_pending=0,
+        )
+        result = actor.search(SearchQuery(query="desc", top_k=3, mode="hybrid"))
         assert len(result.hits) <= 3
 
 

--- a/tests/test_kg_actor.py
+++ b/tests/test_kg_actor.py
@@ -950,6 +950,14 @@ class TestVectorSearch:
         result = actor.search(SearchQuery(query="Alice", top_k=5, mode="vector"))
         assert result.hits == []
 
+    def test_vector_search_returns_empty_when_search_call_fails(self) -> None:
+        """Graceful empty result when vs_proxy.search() raises during vector search."""
+        actor, mock_proxy = _actor_with_mock_embed()
+        mock_proxy.embed.return_value = [_FAKE_VECTOR]
+        mock_proxy.search.side_effect = RuntimeError("Connection refused")
+        result = actor.search(SearchQuery(query="Alice", top_k=5, mode="vector"))
+        assert result.hits == []
+
 
 # ---------------------------------------------------------------------------
 # Hybrid search (Story 2.2 Task 2, ACs 2, 4)

--- a/tests/test_kg_imports.py
+++ b/tests/test_kg_imports.py
@@ -42,6 +42,14 @@ class TestPackageImports:
         for name in expected:
             assert hasattr(knowledge_graph, name), f"Missing export: {name}"
 
+    def test_removed_exports_not_in_all(self) -> None:
+        """EmbeddingService, VectorIndex, VectorEntry no longer exported from KG."""
+        from akgentic.tool import knowledge_graph
+
+        removed = ["EmbeddingService", "VectorIndex", "VectorEntry"]
+        for name in removed:
+            assert name not in knowledge_graph.__all__, f"{name} should not be in __all__"
+
     def test_tool_import_does_not_trigger_kg_import(self) -> None:
         """Importing akgentic.tool does NOT eagerly import knowledge_graph."""
         # Remove knowledge_graph from cache if present

--- a/tests/test_kg_integration.py
+++ b/tests/test_kg_integration.py
@@ -88,12 +88,19 @@ class IntegrationObserver:
     """Mock observer wiring a real KnowledgeGraphActor for integration testing."""
 
     def __init__(self) -> None:
+        from akgentic.tool.knowledge_graph.models import KnowledgeGraphState
+        from akgentic.tool.vector_store.actor import VS_ACTOR_NAME
+
         self.events: list[object] = []
         self._address = MockActorAddress("test-agent")
         self._orchestrator_addr = MockActorAddress("orchestrator")
         self._kg_actor = KnowledgeGraphActor()
-        self._kg_actor.on_start()
+        # Manually init without orchestrator dependency
+        self._kg_actor.state = KnowledgeGraphState()
+        self._kg_actor.state.observer(self._kg_actor)
+        self._kg_actor._vs_proxy = None
         self._kg_addr = MockActorAddress(KG_ACTOR_NAME, KG_ACTOR_ROLE)
+        self._vs_addr = MockActorAddress(VS_ACTOR_NAME, "ToolActor")
 
     @property
     def myAddress(self) -> ActorAddress:  # noqa: N802
@@ -112,20 +119,29 @@ class IntegrationObserver:
         actor_type: type[AkgentType] | None = None,
         timeout: int | None = None,
     ) -> Any:
+        from unittest.mock import MagicMock
+
         if actor == self._orchestrator_addr:
-            return _OrchestratorStub(self._kg_addr)
+            return _OrchestratorStub(self._kg_addr, self._vs_addr)
+        if actor == self._vs_addr:
+            return MagicMock()  # mock VectorStoreActor proxy
         return self._kg_actor
 
 
 class _OrchestratorStub:
-    """Minimal orchestrator stub that returns a known KG address."""
+    """Minimal orchestrator stub that returns known actor addresses."""
 
-    def __init__(self, kg_addr: MockActorAddress) -> None:
+    def __init__(self, kg_addr: MockActorAddress, vs_addr: MockActorAddress) -> None:
         self._kg_addr = kg_addr
+        self._vs_addr = vs_addr
 
     def get_team_member(self, name: str) -> ActorAddress | None:
+        from akgentic.tool.vector_store.actor import VS_ACTOR_NAME
+
         if name == KG_ACTOR_NAME:
             return self._kg_addr
+        if name == VS_ACTOR_NAME:
+            return self._vs_addr
         return None
 
     def createActor(self, *args: Any, **kwargs: Any) -> ActorAddress:  # noqa: N802

--- a/tests/test_kg_tool.py
+++ b/tests/test_kg_tool.py
@@ -99,6 +99,7 @@ class MockActorToolObserver:
         self._orchestrator = MockActorAddress("orchestrator")
         self._kg_actor: KnowledgeGraphActor | None = None
         self._orchestrator_proxy = MagicMock(spec=Orchestrator)
+        self._vs_addr = MockActorAddress("#VectorStore", "ToolActor")
 
     @property
     def myAddress(self) -> ActorAddress:  # noqa: N802
@@ -119,6 +120,9 @@ class MockActorToolObserver:
     ) -> Any:
         if actor == self._orchestrator:
             return self._orchestrator_proxy
+        # Return mock VectorStoreActor proxy for VS address
+        if actor == self._vs_addr:
+            return MagicMock()
         # Return the real KG actor for KG actor address
         if self._kg_actor is not None:
             return self._kg_actor
@@ -126,11 +130,26 @@ class MockActorToolObserver:
 
     def setup_kg_actor(self) -> KnowledgeGraphActor:
         """Create a real KG actor and wire it for proxy_ask."""
+        from akgentic.tool.knowledge_graph.models import KnowledgeGraphState
+        from akgentic.tool.vector_store.actor import VS_ACTOR_NAME
+
         actor = KnowledgeGraphActor()
-        actor.on_start()
+        # Manually init without orchestrator dependency
+        actor.state = KnowledgeGraphState()
+        actor.state.observer(actor)
+        actor._vs_proxy = None
         self._kg_actor = actor
         kg_addr = MockActorAddress(KG_ACTOR_NAME, KG_ACTOR_ROLE)
-        self._orchestrator_proxy.get_team_member.return_value = kg_addr
+
+        # get_team_member returns VS addr for #VectorStore, KG addr for #KnowledgeGraphTool
+        def _get_team_member(name: str) -> MockActorAddress | None:
+            if name == VS_ACTOR_NAME:
+                return self._vs_addr
+            if name == KG_ACTOR_NAME:
+                return kg_addr
+            return None
+
+        self._orchestrator_proxy.get_team_member.side_effect = _get_team_member
         return actor
 
 
@@ -243,28 +262,45 @@ class TestKnowledgeGraphToolObserver:
         with pytest.raises(ValueError, match="orchestrator"):
             tool.observer(observer)
 
-    def test_observer_creates_actor_when_none(self) -> None:
+    def test_observer_creates_actors_when_none(self) -> None:
+        from akgentic.tool.vector_store.actor import VS_ACTOR_NAME
+
         tool = KnowledgeGraphTool()
         observer = MockActorToolObserver()
-        # get_team_member returns None → must createActor
+        # get_team_member returns None → must createActor for both VS and KG
         observer._orchestrator_proxy.get_team_member.return_value = None
-        kg_addr = MockActorAddress(KG_ACTOR_NAME, KG_ACTOR_ROLE)
-        observer._orchestrator_proxy.createActor.return_value = kg_addr
+        addr = MockActorAddress(KG_ACTOR_NAME, KG_ACTOR_ROLE)
+        observer._orchestrator_proxy.createActor.return_value = addr
 
         tool.observer(observer)
 
-        observer._orchestrator_proxy.get_team_member.assert_called_once_with(KG_ACTOR_NAME)
-        observer._orchestrator_proxy.createActor.assert_called_once()
+        # Should check for both VectorStore and KG actors
+        calls = observer._orchestrator_proxy.get_team_member.call_args_list
+        called_names = [c[0][0] for c in calls]
+        assert VS_ACTOR_NAME in called_names
+        assert KG_ACTOR_NAME in called_names
+        # createActor called for both
+        assert observer._orchestrator_proxy.createActor.call_count == 2
 
-    def test_observer_reuses_existing_actor(self) -> None:
+    def test_observer_reuses_existing_actors(self) -> None:
+        from akgentic.tool.vector_store.actor import VS_ACTOR_NAME
+
         tool = KnowledgeGraphTool()
         observer = MockActorToolObserver()
-        existing_addr = MockActorAddress(KG_ACTOR_NAME, KG_ACTOR_ROLE)
-        observer._orchestrator_proxy.get_team_member.return_value = existing_addr
+        vs_addr = MockActorAddress("#VectorStore", "ToolActor")
+        kg_addr = MockActorAddress(KG_ACTOR_NAME, KG_ACTOR_ROLE)
+
+        def _get_team_member(name: str) -> MockActorAddress | None:
+            if name == VS_ACTOR_NAME:
+                return vs_addr
+            if name == KG_ACTOR_NAME:
+                return kg_addr
+            return None
+
+        observer._orchestrator_proxy.get_team_member.side_effect = _get_team_member
 
         tool.observer(observer)
 
-        observer._orchestrator_proxy.get_team_member.assert_called_once_with(KG_ACTOR_NAME)
         observer._orchestrator_proxy.createActor.assert_not_called()
 
 

--- a/tests/test_kg_vector_index.py
+++ b/tests/test_kg_vector_index.py
@@ -260,26 +260,7 @@ class TestVectorIndexPerformance:
 
 
 # ---------------------------------------------------------------------------
-# Backward-compat shim (AC-5: old import paths must still work)
+# Backward-compat shim removed (Story 11.1 AC-9)
+# vector_index.py shim and KG re-exports of VectorEntry/EmbeddingService are deleted.
+# VectorEntry and EmbeddingService should be imported from akgentic.tool.vector directly.
 # ---------------------------------------------------------------------------
-
-
-class TestBackwardCompatImports:
-    """Verify that importing from deprecated paths still works."""
-
-    def test_vector_index_shim_exports_embedding_service(self) -> None:
-        from akgentic.tool.knowledge_graph.vector_index import (
-            EmbeddingService as ShimEmbeddingService,
-        )
-
-        assert ShimEmbeddingService is EmbeddingService
-
-    def test_vector_index_shim_exports_vector_index(self) -> None:
-        from akgentic.tool.knowledge_graph.vector_index import VectorIndex as ShimVectorIndex
-
-        assert ShimVectorIndex is VectorIndex
-
-    def test_knowledge_graph_package_exports_vector_entry(self) -> None:
-        from akgentic.tool.knowledge_graph import VectorEntry as KgVectorEntry
-
-        assert KgVectorEntry is VectorEntry

--- a/tests/test_planning_search.py
+++ b/tests/test_planning_search.py
@@ -5,7 +5,7 @@ Covers AC#2–#12 from Story 4.3: search_planning Filtered Search Capability.
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -258,15 +258,13 @@ class TestSearchPlanningQueryKeyword:
         assert result == []
 
     def test_keyword_with_semantic_search_disabled(self) -> None:
-        """Keyword-only mode when semantic_search=False — embedding svc returns None."""
+        """Keyword-only mode when semantic_search=False — _vs_proxy is None."""
         actor = _make_actor(semantic_search=False)
         _add_task(actor, 1, "auth flow")
         _add_task(actor, 2, "payment gateway")
 
-        # Patch returns None to simulate the svc-unavailable path explicitly.
-        # _vector_index is also None because semantic_search=False.
-        with patch.object(actor, "_get_or_create_embedding_svc", return_value=None):
-            result = actor.search_planning(query="auth")
+        # _vs_proxy is None because semantic_search=False — keyword-only path.
+        result = actor.search_planning(query="auth")
 
         assert len(result) == 1
         assert result[0].id == 1
@@ -278,7 +276,28 @@ class TestSearchPlanningQueryKeyword:
 
 
 class TestSearchPlanningQuerySemantic:
-    """AC6: query with mocked vector deps — union of keyword + semantic, dedup, cosine ≥ 0.5."""
+    """AC6: query with mocked VectorStoreActor proxy — union of keyword + semantic, dedup, cosine ≥ 0.5."""
+
+    def _make_vs_proxy_mock(
+        self, embed_return: list[list[float]], search_hits: list[tuple[str, float]]
+    ) -> MagicMock:
+        """Build a mock VectorStoreActor proxy with embed and search stubs."""
+        from akgentic.tool.vector_store.protocol import (
+            CollectionStatus,
+            SearchHit,
+            SearchResult,
+        )
+
+        mock = MagicMock()
+        mock.embed.return_value = embed_return
+        mock.search.return_value = SearchResult(
+            hits=[
+                SearchHit(ref_type="task", ref_id=ref_id, text="", score=score)
+                for ref_id, score in search_hits
+            ],
+            status=CollectionStatus.READY,
+        )
+        return mock
 
     def test_semantic_union_with_keyword(self) -> None:
         """Semantic hits union with keyword hits; tasks with score ≥ 0.5 included."""
@@ -287,19 +306,13 @@ class TestSearchPlanningQuerySemantic:
         _add_task(actor, 2, "database schema")  # semantic match only
         _add_task(actor, 3, "deployment pipeline")  # no match
 
-        # Mock embedding service
-        mock_svc = MagicMock()
-        mock_svc.embed.return_value = [[0.1, 0.2, 0.3]]
-
-        # Mock vector index with non-zero size
-        mock_index = MagicMock()
-        mock_index.__len__ = MagicMock(return_value=3)
         # Task 2 has cosine score ≥ 0.5, task 3 has score < 0.5
-        mock_index.search_cosine.return_value = [("2", 0.75), ("3", 0.3)]
-        actor._vector_index = mock_index
+        actor._vs_proxy = self._make_vs_proxy_mock(
+            embed_return=[[0.1, 0.2, 0.3]],
+            search_hits=[("2", 0.75), ("3", 0.3)],
+        )
 
-        with patch.object(actor, "_get_or_create_embedding_svc", return_value=mock_svc):
-            result = actor.search_planning(query="auth flow")
+        result = actor.search_planning(query="auth flow")
 
         # task 1 via keyword, task 2 via semantic (score 0.75 ≥ 0.5)
         # task 3 excluded (score 0.3 < 0.5)
@@ -310,17 +323,13 @@ class TestSearchPlanningQuerySemantic:
         actor = _make_actor(semantic_search=True)
         _add_task(actor, 1, "auth module")
 
-        mock_svc = MagicMock()
-        mock_svc.embed.return_value = [[0.1, 0.2, 0.3]]
-
-        mock_index = MagicMock()
-        mock_index.__len__ = MagicMock(return_value=1)
         # Task 1 is both a keyword match AND semantic match
-        mock_index.search_cosine.return_value = [("1", 0.9)]
-        actor._vector_index = mock_index
+        actor._vs_proxy = self._make_vs_proxy_mock(
+            embed_return=[[0.1, 0.2, 0.3]],
+            search_hits=[("1", 0.9)],
+        )
 
-        with patch.object(actor, "_get_or_create_embedding_svc", return_value=mock_svc):
-            result = actor.search_planning(query="auth")
+        result = actor.search_planning(query="auth")
 
         # Deduplicated: only one entry for task 1
         assert len(result) == 1
@@ -331,16 +340,12 @@ class TestSearchPlanningQuerySemantic:
         actor = _make_actor(semantic_search=True)
         _add_task(actor, 1, "database task")
 
-        mock_svc = MagicMock()
-        mock_svc.embed.return_value = [[0.1, 0.2]]
+        actor._vs_proxy = self._make_vs_proxy_mock(
+            embed_return=[[0.1, 0.2]],
+            search_hits=[("1", 0.5)],
+        )
 
-        mock_index = MagicMock()
-        mock_index.__len__ = MagicMock(return_value=1)
-        mock_index.search_cosine.return_value = [("1", 0.5)]
-        actor._vector_index = mock_index
-
-        with patch.object(actor, "_get_or_create_embedding_svc", return_value=mock_svc):
-            result = actor.search_planning(query="db")
+        result = actor.search_planning(query="db")
 
         assert len(result) == 1
         assert result[0].id == 1
@@ -350,36 +355,31 @@ class TestSearchPlanningQuerySemantic:
         actor = _make_actor(semantic_search=True)
         _add_task(actor, 1, "database task")
 
-        mock_svc = MagicMock()
-        mock_svc.embed.return_value = [[0.1, 0.2]]
+        actor._vs_proxy = self._make_vs_proxy_mock(
+            embed_return=[[0.1, 0.2]],
+            search_hits=[("1", 0.49)],
+        )
 
-        mock_index = MagicMock()
-        mock_index.__len__ = MagicMock(return_value=1)
-        mock_index.search_cosine.return_value = [("1", 0.49)]
-        actor._vector_index = mock_index
-
-        with patch.object(actor, "_get_or_create_embedding_svc", return_value=mock_svc):
-            result = actor.search_planning(query="completely different topic")
+        result = actor.search_planning(query="completely different topic")
 
         # Not a keyword match AND cosine < 0.5 → excluded
         assert result == []
 
-    def test_empty_vector_index_falls_back_to_keyword(self) -> None:
-        """When vector index is empty (len=0), semantic phase is skipped."""
+    def test_empty_embed_result_falls_back_to_keyword(self) -> None:
+        """When embed returns empty list, semantic phase is skipped."""
         actor = _make_actor(semantic_search=True)
         _add_task(actor, 1, "auth flow setup")
 
-        mock_svc = MagicMock()
+        # Embed returns empty list (no vectors) — semantic skipped
+        actor._vs_proxy = self._make_vs_proxy_mock(
+            embed_return=[],
+            search_hits=[],
+        )
 
-        mock_index = MagicMock()
-        mock_index.__len__ = MagicMock(return_value=0)
-        actor._vector_index = mock_index
+        result = actor.search_planning(query="auth")
 
-        with patch.object(actor, "_get_or_create_embedding_svc", return_value=mock_svc):
-            result = actor.search_planning(query="auth")
-
-        # Keyword match only; search_cosine should not be called (index is empty)
-        mock_index.search_cosine.assert_not_called()
+        # Keyword match only; search should not be called (embed returned empty)
+        actor._vs_proxy.search.assert_not_called()
         assert len(result) == 1
         assert result[0].id == 1
 
@@ -436,50 +436,45 @@ class TestSearchPlanningCombinedFilters:
 
 
 class TestSearchPlanningVectorFallback:
-    """AC5/AC6: when _get_or_create_embedding_svc returns None, degrades to keyword-only."""
+    """AC5/AC6: when _vs_proxy is None or raises, degrades to keyword-only."""
 
-    def test_no_exception_when_svc_returns_none(self) -> None:
-        """When embedding svc unavailable, search_planning works via keyword only."""
+    def test_no_exception_when_vs_proxy_is_none(self) -> None:
+        """When VectorStoreActor proxy unavailable, search_planning works via keyword only."""
         actor = _make_actor(semantic_search=True)
         _add_task(actor, 1, "auth service")
         _add_task(actor, 2, "payment service")
 
-        with patch.object(actor, "_get_or_create_embedding_svc", return_value=None):
-            result = actor.search_planning(query="auth")
+        # _vs_proxy is None (degraded mode) — keyword-only
+        assert actor._vs_proxy is None
+        result = actor.search_planning(query="auth")
 
         # Falls back to keyword-only, no exception raised
         assert len(result) == 1
         assert result[0].id == 1
 
-    def test_no_exception_when_vector_index_is_none(self) -> None:
-        """When _vector_index is None (semantic_search=False), keyword fallback works."""
+    def test_no_exception_when_semantic_search_disabled(self) -> None:
+        """When semantic_search=False, _vs_proxy is None and keyword fallback works."""
         actor = _make_actor(semantic_search=False)
         _add_task(actor, 1, "auth service")
 
-        mock_svc = MagicMock()
-        # Even if svc somehow returned non-None, _vector_index being None skips semantic
-        with patch.object(actor, "_get_or_create_embedding_svc", return_value=mock_svc):
-            # _vector_index is None because semantic_search=False
-            result = actor.search_planning(query="auth")
+        # _vs_proxy is None because semantic_search=False
+        assert actor._vs_proxy is None
+        result = actor.search_planning(query="auth")
 
         assert len(result) == 1
         assert result[0].id == 1
 
     def test_semantic_exception_falls_back_to_keyword(self) -> None:
-        """When semantic search raises an exception, keyword results still returned."""
+        """When VectorStoreActor proxy raises an exception, keyword results still returned."""
         actor = _make_actor(semantic_search=True)
         _add_task(actor, 1, "auth service")
 
-        mock_svc = MagicMock()
-        mock_svc.embed.side_effect = RuntimeError("embedding API error")
+        mock_proxy = MagicMock()
+        mock_proxy.embed.side_effect = RuntimeError("embedding API error")
+        actor._vs_proxy = mock_proxy
 
-        mock_index = MagicMock()
-        mock_index.__len__ = MagicMock(return_value=1)
-        actor._vector_index = mock_index
-
-        with patch.object(actor, "_get_or_create_embedding_svc", return_value=mock_svc):
-            # Should not raise; falls back to keyword
-            result = actor.search_planning(query="auth")
+        # Should not raise; falls back to keyword
+        result = actor.search_planning(query="auth")
 
         assert len(result) == 1
         assert result[0].id == 1

--- a/tests/test_planning_semantic.py
+++ b/tests/test_planning_semantic.py
@@ -165,4 +165,4 @@ class TestPlanningToolObserverWiring:
         # Second: PlanConfig without embedding fields
         plan_config = captured_configs[1]
         assert isinstance(plan_config, PlanConfig)
-        assert not hasattr(plan_config, "embedding_model") or "embedding_model" not in PlanConfig.model_fields
+        assert "embedding_model" not in PlanConfig.model_fields

--- a/tests/test_planning_semantic.py
+++ b/tests/test_planning_semantic.py
@@ -6,7 +6,7 @@ Also covers AC#8–#9 (PlanningTool embedding field wiring).
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from akgentic.tool.planning.planning_actor import (
     PlanActor,
@@ -59,13 +59,11 @@ class TestGetPlanningTaskIntFound:
         actor = _make_actor()
         _add_task(actor, task_id=3, description="Auth module")
 
-        with patch.object(actor, "_get_or_create_embedding_svc") as mock_svc:
-            result = actor.get_planning_task(3)
+        result = actor.get_planning_task(3)
 
         assert isinstance(result, Task)
         assert result.id == 3
         assert result.description == "Auth module"
-        mock_svc.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -124,25 +122,27 @@ class TestPlanningToolFields:
 
 
 class TestPlanningToolObserverWiring:
-    """AC9: observer() wires PlanConfig(embedding_model, embedding_provider) to PlanActor."""
+    """AC9/AC10: observer() creates VectorStoreActor and PlanActor with correct configs."""
 
-    def test_observer_creates_plan_actor_with_plan_config(self) -> None:
-        """observer() must pass PlanConfig (not BaseConfig) with embedding fields to PlanActor."""
+    def test_observer_creates_vectorstore_and_plan_actors(self) -> None:
+        """observer() must create VectorStoreActor with embedding fields, then PlanActor."""
         from akgentic.tool.planning.planning import PlanningTool
+        from akgentic.tool.vector_store.actor import VectorStoreActor
+        from akgentic.tool.vector_store.protocol import VectorStoreConfig
 
         tool = PlanningTool(
             embedding_model="text-embedding-ada-002",
             embedding_provider="azure",
         )
 
-        # Capture the config passed to createActor
-        captured_config: list[PlanConfig] = []
+        # Capture configs passed to createActor calls
+        captured_configs: list[object] = []
 
         mock_proxy_ask = MagicMock()
         mock_proxy_ask.get_team_member.return_value = None  # Force actor creation path
 
-        def capture_create_actor(actor_cls: type, config: PlanConfig) -> MagicMock:
-            captured_config.append(config)
+        def capture_create_actor(actor_cls: type, config: object) -> MagicMock:
+            captured_configs.append(config)
             return MagicMock()
 
         mock_proxy_ask.createActor.side_effect = capture_create_actor
@@ -153,11 +153,16 @@ class TestPlanningToolObserverWiring:
 
         tool.observer(mock_observer)
 
-        assert len(captured_config) == 1
-        config = captured_config[0]
-        assert isinstance(config, PlanConfig), (
-            f"Expected PlanConfig, got {type(config).__name__}. "
-            "observer() must not pass a plain BaseConfig."
-        )
-        assert config.embedding_model == "text-embedding-ada-002"
-        assert config.embedding_provider == "azure"
+        # Two actors created: VectorStoreActor first, PlanActor second
+        assert len(captured_configs) == 2
+
+        # First: VectorStoreConfig with embedding fields
+        vs_config = captured_configs[0]
+        assert isinstance(vs_config, VectorStoreConfig)
+        assert vs_config.embedding_model == "text-embedding-ada-002"
+        assert vs_config.embedding_provider == "azure"
+
+        # Second: PlanConfig without embedding fields
+        plan_config = captured_configs[1]
+        assert isinstance(plan_config, PlanConfig)
+        assert not hasattr(plan_config, "embedding_model") or "embedding_model" not in PlanConfig.model_fields

--- a/tests/vector_store/test_actor.py
+++ b/tests/vector_store/test_actor.py
@@ -101,6 +101,28 @@ class TestVectorStoreState:
         assert restored.backend_state == state.backend_state
         assert restored.collection_statuses == state.collection_statuses
 
+    def test_collection_configs_round_trip(self) -> None:
+        """collection_configs survives Pydantic serialisation."""
+        state = VectorStoreState(
+            collection_configs={
+                "c1": {
+                    "dimension": 128,
+                    "backend": "inmemory",
+                    "persistence": "workspace",
+                    "workspace_path": "/tmp/ws",
+                }
+            },
+        )
+        data = state.model_dump()
+        restored = VectorStoreState.model_validate(data)
+        assert restored.collection_configs == state.collection_configs
+        assert restored.collection_configs["c1"]["persistence"] == "workspace"
+
+    def test_collection_configs_defaults_empty(self) -> None:
+        """collection_configs defaults to empty dict."""
+        state = VectorStoreState()
+        assert state.collection_configs == {}
+
 
 # ---------------------------------------------------------------------------
 # Actor lifecycle (AC1, AC2, AC3, AC10)
@@ -160,6 +182,21 @@ class TestCreateCollection:
 
         actor.create_collection("test_col", CollectionConfig())
         assert actor.state.collection_statuses["test_col"] == CollectionStatus.READY
+
+    def test_populates_collection_configs(self) -> None:
+        """create_collection stores config dict in state.collection_configs."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        actor._backend = backend
+
+        config = CollectionConfig(dimension=128, persistence="workspace", workspace_path="/ws")
+        actor.create_collection("test_col", config)
+        assert "test_col" in actor.state.collection_configs
+        cfg = actor.state.collection_configs["test_col"]
+        assert cfg["dimension"] == 128
+        assert cfg["persistence"] == "workspace"
+        assert cfg["workspace_path"] == "/ws"
+        assert cfg["backend"] == "inmemory"
 
     def test_notifies_state_change(self) -> None:
         """AC12: state.notify_state_change() called after creation."""
@@ -892,6 +929,54 @@ class TestLazyBackend:
             assert result is None
         finally:
             vector_mod.EmbeddingService = original_cls  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# _save_workspace_collection error handling
+# ---------------------------------------------------------------------------
+
+
+class TestSaveWorkspaceCollection:
+    """Workspace save error handling: logs warning and does not raise."""
+
+    def test_save_logs_warning_on_backend_error(self) -> None:
+        """_save_workspace_collection catches and logs backend save failure."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        backend.save_collection.side_effect = OSError("disk full")
+        actor._backend = backend
+        actor.state.collection_configs["col1"] = {
+            "dimension": 3,
+            "backend": "inmemory",
+            "persistence": "workspace",
+            "workspace_path": "/tmp/ws",
+        }
+        # Should not raise
+        actor._save_workspace_collection("col1")
+        backend.save_collection.assert_called_once_with("col1", "/tmp/ws")
+
+    def test_save_skipped_for_actor_state_persistence(self) -> None:
+        """_save_workspace_collection is a no-op for actor_state persistence."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        actor._backend = backend
+        actor.state.collection_configs["col1"] = {
+            "dimension": 3,
+            "backend": "inmemory",
+            "persistence": "actor_state",
+            "workspace_path": None,
+        }
+        actor._save_workspace_collection("col1")
+        backend.save_collection.assert_not_called()
+
+    def test_save_skipped_for_unknown_collection(self) -> None:
+        """_save_workspace_collection is a no-op for unknown collection."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        actor._backend = backend
+        # No collection_configs entry
+        actor._save_workspace_collection("unknown_col")
+        backend.save_collection.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/vector_store/test_actor.py
+++ b/tests/vector_store/test_actor.py
@@ -1022,3 +1022,132 @@ class TestPublicApiExports:
         assert hasattr(vs, "EmbeddingRequest")
         assert hasattr(vs, "EmbeddingResult")
         assert hasattr(vs, "EmbeddingError")
+
+
+# ---------------------------------------------------------------------------
+# Weaviate backend routing (AC11 — Story 12.1)
+# ---------------------------------------------------------------------------
+
+
+class TestWeaviateRouting:
+    """AC11: VectorStoreActor routes weaviate collections to WeaviateBackend."""
+
+    def test_create_collection_routes_to_weaviate(self) -> None:
+        """create_collection with backend='weaviate' uses WeaviateBackend."""
+        actor = _make_actor()
+        actor.config = VectorStoreConfig(
+            name=VS_ACTOR_NAME,
+            role=VS_ACTOR_ROLE,
+            weaviate_url="http://localhost:8080",
+        )
+        mock_wb = MagicMock()
+        actor._weaviate_backend = mock_wb
+
+        config = CollectionConfig(backend="weaviate", dimension=384)
+        actor.create_collection("wv_col", config)
+
+        mock_wb.create_collection.assert_called_once_with("wv_col", config)
+        assert actor.state.collection_configs["wv_col"]["backend"] == "weaviate"
+        assert actor.state.collection_statuses["wv_col"] == CollectionStatus.READY
+
+    def test_create_collection_inmemory_still_works(self) -> None:
+        """create_collection with backend='inmemory' still routes to InMemoryBackend."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        actor._backend = backend
+
+        config = CollectionConfig(backend="inmemory")
+        actor.create_collection("im_col", config)
+
+        backend.create_collection.assert_called_once_with("im_col", config)
+        assert actor.state.collection_configs["im_col"]["backend"] == "inmemory"
+
+    def test_add_routes_to_weaviate_backend(self) -> None:
+        """add() for a weaviate collection routes to WeaviateBackend."""
+        actor = _make_actor()
+        mock_wb = MagicMock()
+        actor._weaviate_backend = mock_wb
+        actor.state.collection_configs["wv_col"] = {"backend": "weaviate"}
+
+        entry = _mock_entry(vector=[0.1, 0.2])
+        actor.add("wv_col", [entry])
+
+        mock_wb.add.assert_called_once_with("wv_col", [entry])
+
+    def test_remove_routes_to_weaviate_backend(self) -> None:
+        """remove() for a weaviate collection routes to WeaviateBackend."""
+        actor = _make_actor()
+        mock_wb = MagicMock()
+        actor._weaviate_backend = mock_wb
+        actor.state.collection_configs["wv_col"] = {"backend": "weaviate"}
+
+        actor.remove("wv_col", ["id1"])
+
+        mock_wb.remove.assert_called_once_with("wv_col", ["id1"])
+
+    def test_search_routes_to_weaviate_backend(self) -> None:
+        """search() for a weaviate collection routes to WeaviateBackend."""
+        actor = _make_actor()
+        mock_wb = MagicMock()
+        expected = SearchResult(hits=[], status=CollectionStatus.READY, indexing_pending=0)
+        mock_wb.search.return_value = expected
+        actor._weaviate_backend = mock_wb
+        actor.state.collection_configs["wv_col"] = {"backend": "weaviate"}
+
+        result = actor.search("wv_col", [0.1], 5)
+
+        mock_wb.search.assert_called_once_with("wv_col", [0.1], 5)
+        assert result == expected
+
+    def test_inmemory_collection_not_routed_to_weaviate(self) -> None:
+        """inmemory collections still go to InMemoryBackend even when weaviate is available."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        actor._backend = backend
+        mock_wb = MagicMock()
+        actor._weaviate_backend = mock_wb
+        actor.state.collection_configs["im_col"] = {"backend": "inmemory"}
+
+        entry = _mock_entry(vector=[0.1])
+        actor.add("im_col", [entry])
+
+        backend.add.assert_called_once()
+        mock_wb.add.assert_not_called()
+
+    def test_weaviate_backend_unavailable_logs_warning(self) -> None:
+        """create_collection logs warning when weaviate backend is unavailable."""
+        actor = _make_actor()
+        actor.config = VectorStoreConfig(name=VS_ACTOR_NAME, role=VS_ACTOR_ROLE)
+        # No weaviate_url => _get_or_create_weaviate_backend returns None
+
+        config = CollectionConfig(backend="weaviate")
+        actor.create_collection("wv_col", config)
+
+        # Should not crash, just skip
+        assert "wv_col" not in actor.state.collection_statuses
+
+    def test_weaviate_no_sync_backend_state(self) -> None:
+        """Weaviate collections should NOT call _sync_backend_state."""
+        actor = _make_actor()
+        mock_wb = MagicMock()
+        actor._weaviate_backend = mock_wb
+        actor.config = VectorStoreConfig(
+            name=VS_ACTOR_NAME,
+            role=VS_ACTOR_ROLE,
+            weaviate_url="http://localhost:8080",
+        )
+
+        config = CollectionConfig(backend="weaviate")
+        actor.create_collection("wv_col", config)
+
+        # backend_state should still be empty (not synced for weaviate)
+        assert actor.state.backend_state == {}
+
+    def test_get_backend_for_collection_defaults_to_inmemory(self) -> None:
+        """Unknown collections default to inmemory backend."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        actor._backend = backend
+
+        result = actor._get_backend_for_collection("unknown")
+        assert result is backend

--- a/tests/vector_store/test_actor.py
+++ b/tests/vector_store/test_actor.py
@@ -23,6 +23,10 @@ from akgentic.tool.vector_store.actor import (
     VectorStoreActor,
     VectorStoreState,
 )
+from akgentic.tool.vector_store.embedding_actor import (
+    EmbeddingError,
+    EmbeddingResult,
+)
 from akgentic.tool.vector_store.protocol import (
     CollectionConfig,
     CollectionStatus,
@@ -48,6 +52,28 @@ def _mock_backend() -> MagicMock:
     backend = MagicMock()
     backend.get_state.return_value = {"collections": {}}
     return backend
+
+
+def _mock_entry(
+    ref_id: str = "e1",
+    ref_type: str = "entity",
+    text: str = "hello",
+    vector: list[float] | None = None,
+) -> MagicMock:
+    """Return a MagicMock that mimics VectorEntry.
+
+    Args:
+        ref_id: Entry reference ID.
+        ref_type: Entry reference type.
+        text: Entry text.
+        vector: Embedding vector; empty list means needs-embedding.
+    """
+    entry = MagicMock()
+    entry.ref_id = ref_id
+    entry.ref_type = ref_type
+    entry.text = text
+    entry.vector = vector if vector is not None else []
+    return entry
 
 
 # ---------------------------------------------------------------------------
@@ -183,45 +209,389 @@ class TestCreateCollection:
 class TestAdd:
     """AC5: add delegates to backend with state notification."""
 
-    def test_delegates_to_backend(self) -> None:
-        """AC5: Delegation to InMemoryBackend.add."""
+    def test_pre_embedded_delegates_to_backend(self) -> None:
+        """AC9: Pre-embedded entries go directly to backend.add()."""
         actor = _make_actor()
         backend = _mock_backend()
         actor._backend = backend
-        entries = [MagicMock()]
+        entry = _mock_entry(vector=[0.1, 0.2])
 
-        actor.add("col1", entries)
-        backend.add.assert_called_once_with("col1", entries)
+        actor.add("col1", [entry])
+        backend.add.assert_called_once_with("col1", [entry])
 
-    def test_notifies_state_change(self) -> None:
-        """AC12: state.notify_state_change() called after add."""
+    def test_pre_embedded_notifies_state_change(self) -> None:
+        """AC12: state.notify_state_change() called after pre-embedded add."""
         actor = _make_actor()
         backend = _mock_backend()
         actor._backend = backend
+        entry = _mock_entry(vector=[0.1])
 
         with patch.object(VectorStoreState, "notify_state_change") as mock_notify:
-            actor.add("col1", [])
+            actor.add("col1", [entry])
             mock_notify.assert_called_once()
 
-    def test_nonexistent_collection_raises_retriable(self) -> None:
+    def test_pre_embedded_nonexistent_collection_raises_retriable(self) -> None:
         """AC9: ValueError from backend becomes RetriableError."""
         actor = _make_actor()
         backend = _mock_backend()
         backend.add.side_effect = ValueError("Collection 'col1' does not exist")
         actor._backend = backend
+        entry = _mock_entry(vector=[0.1])
 
         with pytest.raises(RetriableError, match="does not exist"):
-            actor.add("col1", [])
+            actor.add("col1", [entry])
 
-    def test_unexpected_error_swallowed(self) -> None:
+    def test_pre_embedded_unexpected_error_swallowed(self) -> None:
         """AC9: Unexpected errors caught/logged/swallowed."""
         actor = _make_actor()
         backend = _mock_backend()
         backend.add.side_effect = RuntimeError("unexpected")
         actor._backend = backend
+        entry = _mock_entry(vector=[0.1])
 
         # Should not raise
+        actor.add("col1", [entry])
+
+    def test_empty_entries_no_op(self) -> None:
+        """Empty entries list is a no-op."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        actor._backend = backend
+
         actor.add("col1", [])
+        backend.add.assert_not_called()
+
+    def test_backend_unavailable_skips(self) -> None:
+        """When backend is None, add() logs and returns."""
+        actor = _make_actor()
+        with patch.object(actor, "_get_or_create_backend", return_value=None):
+            actor.add("col1", [_mock_entry(vector=[0.1])])
+
+
+# ---------------------------------------------------------------------------
+# Non-blocking add — needs embedding (AC2, AC3, AC8)
+# ---------------------------------------------------------------------------
+
+
+class TestAddNeedsEmbedding:
+    """AC2/AC3: Entries without vectors spawn EmbeddingActor."""
+
+    def test_spawns_embedding_actor(self) -> None:
+        """AC2: add() with vectorless entries spawns EmbeddingActor."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        actor._backend = backend
+        entry = _mock_entry(vector=[])
+
+        mock_addr = MagicMock()
+        mock_proxy = MagicMock()
+        with (
+            patch.object(actor, "createActor", return_value=mock_addr) as mock_create,
+            patch.object(actor, "proxy_tell", return_value=mock_proxy),
+        ):
+            actor.add("col1", [entry])
+            mock_create.assert_called_once()
+            mock_proxy.receiveMsg_EmbeddingRequest.assert_called_once()
+
+    def test_sets_status_indexing(self) -> None:
+        """AC3: Collection status transitions to INDEXING on add."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        actor._backend = backend
+        entry = _mock_entry(vector=[])
+
+        with (
+            patch.object(actor, "createActor", return_value=MagicMock()),
+            patch.object(actor, "proxy_tell", return_value=MagicMock()),
+        ):
+            actor.add("col1", [entry])
+
+        assert actor.state.collection_statuses["col1"] == CollectionStatus.INDEXING
+
+    def test_tracks_indexing_pending_count(self) -> None:
+        """AC3: indexing_pending incremented by number of entries."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        actor._backend = backend
+        entries = [_mock_entry(ref_id="e1"), _mock_entry(ref_id="e2")]
+
+        with (
+            patch.object(actor, "createActor", return_value=MagicMock()),
+            patch.object(actor, "proxy_tell", return_value=MagicMock()),
+        ):
+            actor.add("col1", entries)
+
+        assert actor.state.indexing_pending["col1"] == 2
+
+    def test_stores_pending_entries(self) -> None:
+        """Pending entry metadata stored in state."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        actor._backend = backend
+        entry = _mock_entry(ref_id="e1", text="hello")
+
+        with (
+            patch.object(actor, "createActor", return_value=MagicMock()),
+            patch.object(actor, "proxy_tell", return_value=MagicMock()),
+        ):
+            actor.add("col1", [entry])
+
+        assert len(actor.state.pending_entries["col1"]) == 1
+        assert actor.state.pending_entries["col1"][0]["ref_id"] == "e1"
+
+    def test_does_not_call_backend_add(self) -> None:
+        """AC2: Vectorless entries do NOT call backend.add() directly."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        actor._backend = backend
+        entry = _mock_entry(vector=[])
+
+        with (
+            patch.object(actor, "createActor", return_value=MagicMock()),
+            patch.object(actor, "proxy_tell", return_value=MagicMock()),
+        ):
+            actor.add("col1", [entry])
+
+        backend.add.assert_not_called()
+
+    def test_retry_from_error_resets_to_indexing(self) -> None:
+        """AC8: add() on ERROR collection transitions to INDEXING."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        actor._backend = backend
+        actor.state.collection_statuses["col1"] = CollectionStatus.ERROR
+
+        entry = _mock_entry(vector=[])
+        with (
+            patch.object(actor, "createActor", return_value=MagicMock()),
+            patch.object(actor, "proxy_tell", return_value=MagicMock()),
+        ):
+            actor.add("col1", [entry])
+
+        assert actor.state.collection_statuses["col1"] == CollectionStatus.INDEXING
+
+    def test_mixed_entries_partitioned(self) -> None:
+        """AC9: Mixed entries: pre-embedded go to backend, vectorless to actor."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        actor._backend = backend
+
+        pre = _mock_entry(ref_id="pre1", vector=[0.1, 0.2])
+        needs = _mock_entry(ref_id="needs1", vector=[])
+
+        with (
+            patch.object(actor, "createActor", return_value=MagicMock()),
+            patch.object(actor, "proxy_tell", return_value=MagicMock()),
+        ):
+            actor.add("col1", [pre, needs])
+
+        # Pre-embedded goes to backend
+        backend.add.assert_called_once_with("col1", [pre])
+        # Needs-embedding tracked in pending
+        assert actor.state.indexing_pending["col1"] == 1
+
+
+# ---------------------------------------------------------------------------
+# receiveMsg_EmbeddingResult (AC5)
+# ---------------------------------------------------------------------------
+
+
+class TestReceiveEmbeddingResult:
+    """AC5: VectorStoreActor handles embedding results."""
+
+    def _make_result(self, collection: str = "col1") -> EmbeddingResult:
+        """Create a mock EmbeddingResult with VectorEntry objects."""
+        from akgentic.tool.vector import VectorEntry
+
+        entries = [
+            VectorEntry(ref_type="entity", ref_id="e1", text="hi", vector=[0.1]),
+            VectorEntry(ref_type="entity", ref_id="e2", text="bye", vector=[0.2]),
+        ]
+        return EmbeddingResult(
+            collection=collection, entries=entries, request_id="req-1"
+        )
+
+    def test_inserts_into_backend(self) -> None:
+        """AC5: Entries are inserted into backend on result delivery."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        actor._backend = backend
+        actor.state.collection_statuses["col1"] = CollectionStatus.INDEXING
+        actor.state.indexing_pending["col1"] = 2
+        actor.state.pending_entries["col1"] = [
+            {"ref_type": "entity", "ref_id": "e1", "text": "hi"},
+            {"ref_type": "entity", "ref_id": "e2", "text": "bye"},
+        ]
+
+        result = self._make_result()
+        actor.receiveMsg_EmbeddingResult(result)
+
+        backend.add.assert_called_once_with("col1", result.entries)
+
+    def test_transitions_to_ready(self) -> None:
+        """AC5: Status returns to READY when all pending complete."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        actor._backend = backend
+        actor.state.collection_statuses["col1"] = CollectionStatus.INDEXING
+        actor.state.indexing_pending["col1"] = 2
+        actor.state.pending_entries["col1"] = [
+            {"ref_type": "entity", "ref_id": "e1", "text": "hi"},
+            {"ref_type": "entity", "ref_id": "e2", "text": "bye"},
+        ]
+
+        actor.receiveMsg_EmbeddingResult(self._make_result())
+
+        assert actor.state.collection_statuses["col1"] == CollectionStatus.READY
+        assert actor.state.indexing_pending.get("col1") is None
+
+    def test_decrements_pending_count(self) -> None:
+        """AC5: indexing_pending decremented by result entry count."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        actor._backend = backend
+        # Simulate 4 pending, result delivers 2
+        actor.state.collection_statuses["col1"] = CollectionStatus.INDEXING
+        actor.state.indexing_pending["col1"] = 4
+        actor.state.pending_entries["col1"] = [
+            {"ref_type": "entity", "ref_id": f"e{i}", "text": f"t{i}"}
+            for i in range(4)
+        ]
+
+        actor.receiveMsg_EmbeddingResult(self._make_result())
+
+        assert actor.state.indexing_pending["col1"] == 2
+        assert actor.state.collection_statuses["col1"] == CollectionStatus.INDEXING
+
+    def test_notifies_state_change(self) -> None:
+        """state.notify_state_change() called after result delivery."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        actor._backend = backend
+        actor.state.collection_statuses["col1"] = CollectionStatus.INDEXING
+        actor.state.indexing_pending["col1"] = 2
+        actor.state.pending_entries["col1"] = [
+            {"ref_type": "entity", "ref_id": "e1", "text": "hi"},
+            {"ref_type": "entity", "ref_id": "e2", "text": "bye"},
+        ]
+
+        with patch.object(VectorStoreState, "notify_state_change") as mock_notify:
+            actor.receiveMsg_EmbeddingResult(self._make_result())
+            assert mock_notify.call_count >= 1
+
+
+# ---------------------------------------------------------------------------
+# receiveMsg_EmbeddingError (AC7)
+# ---------------------------------------------------------------------------
+
+
+class TestReceiveEmbeddingError:
+    """AC7: VectorStoreActor handles embedding errors."""
+
+    def test_sets_error_status(self) -> None:
+        """AC7: Collection status set to ERROR."""
+        actor = _make_actor()
+        actor.state.collection_statuses["col1"] = CollectionStatus.INDEXING
+        actor.state.indexing_pending["col1"] = 2
+        actor.state.pending_entries["col1"] = [
+            {"ref_type": "entity", "ref_id": "e1", "text": "hi"},
+        ]
+
+        err = EmbeddingError(collection="col1", error="API failed", request_id="r1")
+        actor.receiveMsg_EmbeddingError(err)
+
+        assert actor.state.collection_statuses["col1"] == CollectionStatus.ERROR
+
+    def test_discards_pending_entries(self) -> None:
+        """AC7: Pending entries discarded on error."""
+        actor = _make_actor()
+        actor.state.collection_statuses["col1"] = CollectionStatus.INDEXING
+        actor.state.indexing_pending["col1"] = 2
+        actor.state.pending_entries["col1"] = [
+            {"ref_type": "entity", "ref_id": "e1", "text": "hi"},
+        ]
+
+        err = EmbeddingError(collection="col1", error="API failed", request_id="r1")
+        actor.receiveMsg_EmbeddingError(err)
+
+        assert actor.state.indexing_pending["col1"] == 0
+        assert "col1" not in actor.state.pending_entries
+
+    def test_notifies_state_change(self) -> None:
+        """state.notify_state_change() called after error."""
+        actor = _make_actor()
+        actor.state.collection_statuses["col1"] = CollectionStatus.INDEXING
+
+        with patch.object(VectorStoreState, "notify_state_change") as mock_notify:
+            err = EmbeddingError(
+                collection="col1", error="fail", request_id="r1"
+            )
+            actor.receiveMsg_EmbeddingError(err)
+            assert mock_notify.call_count >= 1
+
+
+# ---------------------------------------------------------------------------
+# Search during INDEXING (AC6)
+# ---------------------------------------------------------------------------
+
+
+class TestSearchDuringIndexing:
+    """AC6: search() returns partial results with INDEXING status."""
+
+    def test_returns_indexing_status(self) -> None:
+        """AC6: Search returns status=INDEXING when collection is indexing."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        backend.search.return_value = SearchResult(
+            hits=[], status=CollectionStatus.READY, indexing_pending=0
+        )
+        actor._backend = backend
+        actor.state.collection_statuses["col1"] = CollectionStatus.INDEXING
+        actor.state.indexing_pending["col1"] = 3
+
+        result = actor.search("col1", [0.1], 5)
+        assert result.status == CollectionStatus.INDEXING
+        assert result.indexing_pending == 3
+
+    def test_returns_ready_when_not_indexing(self) -> None:
+        """Search returns READY status when no indexing."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        backend.search.return_value = SearchResult(
+            hits=[], status=CollectionStatus.READY, indexing_pending=0
+        )
+        actor._backend = backend
+        actor.state.collection_statuses["col1"] = CollectionStatus.READY
+
+        result = actor.search("col1", [0.1], 5)
+        assert result.status == CollectionStatus.READY
+        assert result.indexing_pending == 0
+
+
+# ---------------------------------------------------------------------------
+# State serialisation with new fields
+# ---------------------------------------------------------------------------
+
+
+class TestVectorStoreStateNewFields:
+    """Pending entries and indexing_pending serialise correctly."""
+
+    def test_pending_entries_round_trip(self) -> None:
+        """pending_entries survives serialisation."""
+        state = VectorStoreState(
+            pending_entries={"c1": [{"ref_type": "t", "ref_id": "1", "text": "hi"}]},
+            indexing_pending={"c1": 1},
+        )
+        data = state.model_dump()
+        restored = VectorStoreState.model_validate(data)
+        assert restored.pending_entries == state.pending_entries
+        assert restored.indexing_pending == state.indexing_pending
+
+    def test_defaults_empty(self) -> None:
+        """New fields default to empty dicts."""
+        state = VectorStoreState()
+        assert state.pending_entries == {}
+        assert state.indexing_pending == {}
 
 
 # ---------------------------------------------------------------------------
@@ -535,3 +905,16 @@ class TestPublicApiExports:
         assert "VS_ACTOR_ROLE" in vs.__all__
         assert vs.VS_ACTOR_NAME == "#VectorStore"
         assert vs.VS_ACTOR_ROLE == "ToolActor"
+
+    def test_embedding_actor_exported(self) -> None:
+        """EmbeddingActor and message models in __all__."""
+        import akgentic.tool.vector_store as vs
+
+        assert "EmbeddingActor" in vs.__all__
+        assert "EmbeddingRequest" in vs.__all__
+        assert "EmbeddingResult" in vs.__all__
+        assert "EmbeddingError" in vs.__all__
+        assert hasattr(vs, "EmbeddingActor")
+        assert hasattr(vs, "EmbeddingRequest")
+        assert hasattr(vs, "EmbeddingResult")
+        assert hasattr(vs, "EmbeddingError")

--- a/tests/vector_store/test_actor.py
+++ b/tests/vector_store/test_actor.py
@@ -479,6 +479,25 @@ class TestReceiveEmbeddingResult:
             actor.receiveMsg_EmbeddingResult(self._make_result())
             assert mock_notify.call_count >= 1
 
+    def test_backend_add_failure_transitions_to_error(self) -> None:
+        """When backend.add() fails, collection moves to ERROR (not stuck in INDEXING)."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        backend.add.side_effect = RuntimeError("disk full")
+        actor._backend = backend
+        actor.state.collection_statuses["col1"] = CollectionStatus.INDEXING
+        actor.state.indexing_pending["col1"] = 2
+        actor.state.pending_entries["col1"] = [
+            {"ref_type": "entity", "ref_id": "e1", "text": "hi"},
+            {"ref_type": "entity", "ref_id": "e2", "text": "bye"},
+        ]
+
+        actor.receiveMsg_EmbeddingResult(self._make_result())
+
+        assert actor.state.collection_statuses["col1"] == CollectionStatus.ERROR
+        assert actor.state.indexing_pending["col1"] == 0
+        assert "col1" not in actor.state.pending_entries
+
 
 # ---------------------------------------------------------------------------
 # receiveMsg_EmbeddingError (AC7)

--- a/tests/vector_store/test_actor.py
+++ b/tests/vector_store/test_actor.py
@@ -1,0 +1,537 @@
+"""Unit tests for VectorStoreActor.
+
+Covers: actor lifecycle (on_start), all proxy method delegation, error
+handling (RetriableError, catch/log/swallow), state persistence round-trip,
+collection status tracking, and graceful degradation when backend is
+unavailable.
+
+Pattern: Instantiate VectorStoreActor() directly, set config, call
+on_start(). Same approach as test_kg_actor.py and test_planning_actor.py.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from akgentic.tool.errors import RetriableError
+from akgentic.tool.vector_store.actor import (
+    VS_ACTOR_NAME,
+    VS_ACTOR_ROLE,
+    VectorStoreActor,
+    VectorStoreState,
+)
+from akgentic.tool.vector_store.protocol import (
+    CollectionConfig,
+    CollectionStatus,
+    SearchResult,
+    VectorStoreConfig,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_actor() -> VectorStoreActor:
+    """Create and initialise a VectorStoreActor for testing."""
+    actor = VectorStoreActor()
+    actor.config = VectorStoreConfig(name=VS_ACTOR_NAME, role=VS_ACTOR_ROLE)
+    actor.on_start()
+    return actor
+
+
+def _mock_backend() -> MagicMock:
+    """Return a MagicMock that mimics InMemoryBackend."""
+    backend = MagicMock()
+    backend.get_state.return_value = {"collections": {}}
+    return backend
+
+
+# ---------------------------------------------------------------------------
+# VectorStoreState (AC11)
+# ---------------------------------------------------------------------------
+
+
+class TestVectorStoreState:
+    """AC11: VectorStoreState(BaseState) construction and serialisation."""
+
+    def test_construction_defaults(self) -> None:
+        """State has empty defaults."""
+        state = VectorStoreState()
+        assert state.backend_state == {}
+        assert state.collection_statuses == {}
+
+    def test_serialisation_round_trip(self) -> None:
+        """State round-trips through Pydantic serialisation."""
+        state = VectorStoreState(
+            backend_state={"collections": {"c1": {"config": {}, "entries": []}}},
+            collection_statuses={"c1": CollectionStatus.READY},
+        )
+        data = state.model_dump()
+        restored = VectorStoreState.model_validate(data)
+        assert restored.backend_state == state.backend_state
+        assert restored.collection_statuses == state.collection_statuses
+
+
+# ---------------------------------------------------------------------------
+# Actor lifecycle (AC1, AC2, AC3, AC10)
+# ---------------------------------------------------------------------------
+
+
+class TestActorLifecycle:
+    """AC1-3, AC10: Actor class, constants, on_start, runtime state."""
+
+    def test_on_start_initialises_state_with_observer(self) -> None:
+        """AC3: on_start sets state with observer wired."""
+        actor = _make_actor()
+        assert isinstance(actor.state, VectorStoreState)
+        # Observer is wired — notify_state_change should not raise
+        actor.state.notify_state_change()
+
+    def test_on_start_backend_is_none(self) -> None:
+        """AC10: Backend starts as None (lazy)."""
+        actor = _make_actor()
+        assert actor._backend is None
+
+    def test_on_start_embedding_svc_is_none(self) -> None:
+        """AC10: Embedding service starts as None (lazy)."""
+        actor = _make_actor()
+        assert actor._embedding_svc is None
+
+    def test_singleton_constants(self) -> None:
+        """AC2: Constants have expected values."""
+        assert VS_ACTOR_NAME == "#VectorStore"
+        assert VS_ACTOR_ROLE == "ToolActor"
+
+
+# ---------------------------------------------------------------------------
+# create_collection (AC4, AC9, AC12)
+# ---------------------------------------------------------------------------
+
+
+class TestCreateCollection:
+    """AC4: create_collection delegates to backend and sets status."""
+
+    def test_delegates_to_backend(self) -> None:
+        """AC4: Delegation to InMemoryBackend.create_collection."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        actor._backend = backend
+
+        config = CollectionConfig()
+        actor.create_collection("test_col", config)
+
+        backend.create_collection.assert_called_once_with("test_col", config)
+
+    def test_sets_status_ready(self) -> None:
+        """AC4: Collection status is READY after creation."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        actor._backend = backend
+
+        actor.create_collection("test_col", CollectionConfig())
+        assert actor.state.collection_statuses["test_col"] == CollectionStatus.READY
+
+    def test_notifies_state_change(self) -> None:
+        """AC12: state.notify_state_change() called after creation."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        actor._backend = backend
+
+        with patch.object(VectorStoreState, "notify_state_change") as mock_notify:
+            actor.create_collection("test_col", CollectionConfig())
+            mock_notify.assert_called_once()
+
+    def test_syncs_backend_state(self) -> None:
+        """AC11: _sync_backend_state called after creation."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        backend.get_state.return_value = {"collections": {"test_col": {}}}
+        actor._backend = backend
+
+        actor.create_collection("test_col", CollectionConfig())
+        assert actor.state.backend_state == {"collections": {"test_col": {}}}
+
+    def test_idempotent_second_call(self) -> None:
+        """AC4: Second create_collection for same name is no-op (via backend)."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        actor._backend = backend
+
+        actor.create_collection("test_col", CollectionConfig())
+        actor.create_collection("test_col", CollectionConfig())
+        assert backend.create_collection.call_count == 2
+        # Backend itself handles idempotency (no-op on existing collection)
+
+    def test_graceful_when_backend_unavailable(self) -> None:
+        """AC9: Logs warning when backend cannot be created."""
+        actor = _make_actor()
+        with patch.object(actor, "_get_or_create_backend", return_value=None):
+            # Should not raise
+            actor.create_collection("test_col", CollectionConfig())
+            assert "test_col" not in actor.state.collection_statuses
+
+
+# ---------------------------------------------------------------------------
+# add (AC5, AC9, AC12)
+# ---------------------------------------------------------------------------
+
+
+class TestAdd:
+    """AC5: add delegates to backend with state notification."""
+
+    def test_delegates_to_backend(self) -> None:
+        """AC5: Delegation to InMemoryBackend.add."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        actor._backend = backend
+        entries = [MagicMock()]
+
+        actor.add("col1", entries)
+        backend.add.assert_called_once_with("col1", entries)
+
+    def test_notifies_state_change(self) -> None:
+        """AC12: state.notify_state_change() called after add."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        actor._backend = backend
+
+        with patch.object(VectorStoreState, "notify_state_change") as mock_notify:
+            actor.add("col1", [])
+            mock_notify.assert_called_once()
+
+    def test_nonexistent_collection_raises_retriable(self) -> None:
+        """AC9: ValueError from backend becomes RetriableError."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        backend.add.side_effect = ValueError("Collection 'col1' does not exist")
+        actor._backend = backend
+
+        with pytest.raises(RetriableError, match="does not exist"):
+            actor.add("col1", [])
+
+    def test_unexpected_error_swallowed(self) -> None:
+        """AC9: Unexpected errors caught/logged/swallowed."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        backend.add.side_effect = RuntimeError("unexpected")
+        actor._backend = backend
+
+        # Should not raise
+        actor.add("col1", [])
+
+
+# ---------------------------------------------------------------------------
+# remove (AC6, AC9, AC12)
+# ---------------------------------------------------------------------------
+
+
+class TestRemove:
+    """AC6: remove delegates to backend with state notification."""
+
+    def test_delegates_to_backend(self) -> None:
+        """AC6: Delegation to InMemoryBackend.remove."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        actor._backend = backend
+
+        actor.remove("col1", ["id1", "id2"])
+        backend.remove.assert_called_once_with("col1", ["id1", "id2"])
+
+    def test_notifies_state_change(self) -> None:
+        """AC12: state.notify_state_change() called after remove."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        actor._backend = backend
+
+        with patch.object(VectorStoreState, "notify_state_change") as mock_notify:
+            actor.remove("col1", ["id1"])
+            mock_notify.assert_called_once()
+
+    def test_nonexistent_collection_raises_retriable(self) -> None:
+        """AC9: ValueError from backend becomes RetriableError."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        backend.remove.side_effect = ValueError("Collection 'col1' does not exist")
+        actor._backend = backend
+
+        with pytest.raises(RetriableError, match="does not exist"):
+            actor.remove("col1", ["id1"])
+
+    def test_unexpected_error_swallowed(self) -> None:
+        """AC9: Unexpected errors caught/logged/swallowed."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        backend.remove.side_effect = RuntimeError("unexpected")
+        actor._backend = backend
+
+        actor.remove("col1", ["id1"])
+
+
+# ---------------------------------------------------------------------------
+# search (AC7, AC9)
+# ---------------------------------------------------------------------------
+
+
+class TestSearch:
+    """AC7: search delegates to backend and returns SearchResult."""
+
+    def test_delegates_to_backend(self) -> None:
+        """AC7: Delegation to InMemoryBackend.search."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        expected = SearchResult(
+            hits=[],
+            status=CollectionStatus.READY,
+            indexing_pending=0,
+        )
+        backend.search.return_value = expected
+        actor._backend = backend
+
+        result = actor.search("col1", [0.1, 0.2], 5)
+        backend.search.assert_called_once_with("col1", [0.1, 0.2], 5)
+        assert result == expected
+
+    def test_nonexistent_collection_raises_retriable(self) -> None:
+        """AC9: ValueError from backend becomes RetriableError."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        backend.search.side_effect = ValueError("Collection 'col1' does not exist")
+        actor._backend = backend
+
+        with pytest.raises(RetriableError, match="does not exist"):
+            actor.search("col1", [0.1], 5)
+
+    def test_unexpected_error_returns_empty(self) -> None:
+        """AC9: Unexpected errors return empty SearchResult."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        backend.search.side_effect = RuntimeError("unexpected")
+        actor._backend = backend
+
+        result = actor.search("col1", [0.1], 5)
+        assert result.hits == []
+
+    def test_backend_unavailable_returns_empty(self) -> None:
+        """AC9: No backend returns empty SearchResult."""
+        actor = _make_actor()
+        with patch.object(actor, "_get_or_create_backend", return_value=None):
+            result = actor.search("col1", [0.1], 5)
+            assert result.hits == []
+
+
+# ---------------------------------------------------------------------------
+# embed (AC8, AC9)
+# ---------------------------------------------------------------------------
+
+
+class TestEmbed:
+    """AC8: embed delegates to EmbeddingService and returns vectors."""
+
+    def test_delegates_to_embedding_service(self) -> None:
+        """AC8: Delegation to EmbeddingService.embed."""
+        actor = _make_actor()
+        mock_svc = MagicMock()
+        mock_svc.embed.return_value = [[0.1, 0.2, 0.3]]
+        actor._embedding_svc = mock_svc
+
+        result = actor.embed(["hello"])
+        mock_svc.embed.assert_called_once_with(["hello"])
+        assert result == [[0.1, 0.2, 0.3]]
+
+    def test_returns_empty_when_service_unavailable(self) -> None:
+        """AC8: Returns [] when embedding service is None."""
+        actor = _make_actor()
+        with patch.object(actor, "_get_or_create_embedding_svc", return_value=None):
+            result = actor.embed(["hello"])
+            assert result == []
+
+    def test_returns_empty_on_failure(self) -> None:
+        """AC9: Catch/log/swallow on embed failure."""
+        actor = _make_actor()
+        mock_svc = MagicMock()
+        mock_svc.embed.side_effect = RuntimeError("API error")
+        actor._embedding_svc = mock_svc
+
+        result = actor.embed(["hello"])
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# State persistence round-trip (AC11)
+# ---------------------------------------------------------------------------
+
+
+class TestStatePersistence:
+    """AC11: Backend state persistence round-trip via actor state."""
+
+    def test_round_trip_through_actor_state(self) -> None:
+        """Create collection, add entries, verify state round-trip."""
+        actor = _make_actor()
+
+        # Use a real-ish backend mock that tracks state
+        backend = _mock_backend()
+        state_snapshot: dict[str, Any] = {
+            "collections": {
+                "test_col": {
+                    "config": CollectionConfig().model_dump(),
+                    "entries": [
+                        {
+                            "ref_type": "test",
+                            "ref_id": "e1",
+                            "text": "hello",
+                            "vector": [0.1, 0.2],
+                        }
+                    ],
+                }
+            }
+        }
+        backend.get_state.return_value = state_snapshot
+        actor._backend = backend
+
+        # Trigger a mutation to sync state
+        actor.create_collection("test_col", CollectionConfig())
+
+        # Verify actor state has the snapshot
+        assert actor.state.backend_state == state_snapshot
+
+        # Now create a new actor and verify restore
+        actor2 = _make_actor()
+        actor2.state.backend_state = state_snapshot
+
+        # The lazy init should restore from state
+        import akgentic.tool.vector_store.inmemory as inmemory_mod
+
+        mock_backend2 = _mock_backend()
+        original_cls = inmemory_mod.InMemoryBackend
+        inmemory_mod.InMemoryBackend = MagicMock(return_value=mock_backend2)  # type: ignore[misc]
+        try:
+            result = actor2._get_or_create_backend()
+            assert result is not None
+            mock_backend2.restore_state.assert_called_once_with(state_snapshot)
+        finally:
+            inmemory_mod.InMemoryBackend = original_cls  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# collection_statuses (AC11, AC12)
+# ---------------------------------------------------------------------------
+
+
+class TestCollectionStatuses:
+    """AC11: collection_statuses tracks per-collection status."""
+
+    def test_tracks_multiple_collections(self) -> None:
+        """Multiple collections tracked independently."""
+        actor = _make_actor()
+        backend = _mock_backend()
+        actor._backend = backend
+
+        actor.create_collection("col_a", CollectionConfig())
+        actor.create_collection("col_b", CollectionConfig())
+
+        assert actor.state.collection_statuses["col_a"] == CollectionStatus.READY
+        assert actor.state.collection_statuses["col_b"] == CollectionStatus.READY
+
+    def test_status_in_serialised_state(self) -> None:
+        """Collection statuses survive serialisation."""
+        state = VectorStoreState(
+            collection_statuses={"c1": CollectionStatus.READY, "c2": CollectionStatus.INDEXING}
+        )
+        data = state.model_dump()
+        restored = VectorStoreState.model_validate(data)
+        assert restored.collection_statuses["c1"] == CollectionStatus.READY
+        assert restored.collection_statuses["c2"] == CollectionStatus.INDEXING
+
+
+# ---------------------------------------------------------------------------
+# Lazy backend initialisation (AC3, AC10)
+# ---------------------------------------------------------------------------
+
+
+class TestLazyBackend:
+    """AC3/AC10: Lazy backend and embedding service initialisation."""
+
+    def test_get_or_create_backend_caches(self) -> None:
+        """Backend is cached after first creation."""
+        actor = _make_actor()
+        mock_backend = _mock_backend()
+        actor._backend = mock_backend
+
+        result = actor._get_or_create_backend()
+        assert result is mock_backend
+
+    def test_get_or_create_backend_returns_none_on_import_error(self) -> None:
+        """Returns None when vector_search deps missing."""
+        actor = _make_actor()
+        # Patch the inmemory module so importing InMemoryBackend raises
+        import akgentic.tool.vector_store.inmemory as inmemory_mod
+
+        original_cls = inmemory_mod.InMemoryBackend
+        inmemory_mod.InMemoryBackend = MagicMock(  # type: ignore[misc]
+            side_effect=ImportError("no numpy"),
+        )
+        try:
+            result = actor._get_or_create_backend()
+            assert result is None
+        finally:
+            inmemory_mod.InMemoryBackend = original_cls  # type: ignore[misc]
+
+    def test_get_or_create_embedding_svc_caches(self) -> None:
+        """Embedding service is cached after first creation."""
+        actor = _make_actor()
+        mock_svc = MagicMock()
+        actor._embedding_svc = mock_svc
+
+        result = actor._get_or_create_embedding_svc()
+        assert result is mock_svc
+
+    def test_get_or_create_embedding_svc_returns_none_on_failure(self) -> None:
+        """Returns None when EmbeddingService creation fails."""
+        actor = _make_actor()
+        import akgentic.tool.vector as vector_mod
+
+        original_cls = vector_mod.EmbeddingService
+        vector_mod.EmbeddingService = MagicMock(  # type: ignore[misc]
+            side_effect=Exception("no API key"),
+        )
+        try:
+            result = actor._get_or_create_embedding_svc()
+            assert result is None
+        finally:
+            vector_mod.EmbeddingService = original_cls  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Public API exports (AC13)
+# ---------------------------------------------------------------------------
+
+
+class TestPublicApiExports:
+    """AC13: vector_store/__init__.py re-exports actor symbols."""
+
+    def test_actor_exported(self) -> None:
+        """VectorStoreActor in __all__."""
+        import akgentic.tool.vector_store as vs
+
+        assert "VectorStoreActor" in vs.__all__
+        assert hasattr(vs, "VectorStoreActor")
+
+    def test_state_exported(self) -> None:
+        """VectorStoreState in __all__."""
+        import akgentic.tool.vector_store as vs
+
+        assert "VectorStoreState" in vs.__all__
+        assert hasattr(vs, "VectorStoreState")
+
+    def test_constants_exported(self) -> None:
+        """VS_ACTOR_NAME and VS_ACTOR_ROLE in __all__."""
+        import akgentic.tool.vector_store as vs
+
+        assert "VS_ACTOR_NAME" in vs.__all__
+        assert "VS_ACTOR_ROLE" in vs.__all__
+        assert vs.VS_ACTOR_NAME == "#VectorStore"
+        assert vs.VS_ACTOR_ROLE == "ToolActor"

--- a/tests/vector_store/test_embedding_actor.py
+++ b/tests/vector_store/test_embedding_actor.py
@@ -1,0 +1,263 @@
+"""Unit tests for EmbeddingActor.
+
+Covers: actor lifecycle (on_start), receiveMsg_EmbeddingRequest success
+and failure paths, result/error delivery to parent, and self-stop.
+
+Pattern: Instantiate EmbeddingActor() directly, set config, call
+on_start(). Mock parent address and proxy_tell to capture messages.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from akgentic.core.agent_config import BaseConfig
+
+from akgentic.tool.vector_store.embedding_actor import (
+    EmbeddingActor,
+    EmbeddingError,
+    EmbeddingRequest,
+    EmbeddingResult,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_actor() -> EmbeddingActor:
+    """Create and initialise an EmbeddingActor for testing."""
+    actor = EmbeddingActor()
+    actor.config = BaseConfig(name="test-embed-actor", role="EmbeddingActor")
+    actor._parent = MagicMock()
+    actor.on_start()
+    return actor
+
+
+def _make_request(
+    collection: str = "test_col",
+    entries: list[dict[str, str]] | None = None,
+) -> EmbeddingRequest:
+    """Create a test EmbeddingRequest."""
+    if entries is None:
+        entries = [
+            {"ref_type": "entity", "ref_id": "e1", "text": "hello world"},
+            {"ref_type": "entity", "ref_id": "e2", "text": "goodbye"},
+        ]
+    return EmbeddingRequest(
+        collection=collection,
+        entries=entries,
+        request_id="test-req-1",
+        embedding_model="text-embedding-3-small",
+        embedding_provider="openai",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Construction and on_start (AC1)
+# ---------------------------------------------------------------------------
+
+
+class TestEmbeddingActorLifecycle:
+    """AC1: EmbeddingActor construction and on_start."""
+
+    def test_on_start_initialises_state(self) -> None:
+        """on_start sets state with observer."""
+        actor = _make_actor()
+        assert actor.state is not None
+        actor.state.notify_state_change()
+
+    def test_on_start_embedding_svc_is_none(self) -> None:
+        """Embedding service starts as None (lazy)."""
+        actor = _make_actor()
+        assert actor._embedding_svc is None
+
+
+# ---------------------------------------------------------------------------
+# receiveMsg_EmbeddingRequest — success path (AC4)
+# ---------------------------------------------------------------------------
+
+
+class TestEmbeddingRequestSuccess:
+    """AC4: EmbeddingActor embeds and delivers results to parent."""
+
+    def test_sends_embedding_result_to_parent(self) -> None:
+        """On success, EmbeddingResult is sent to parent via proxy_tell."""
+        actor = _make_actor()
+        mock_svc = MagicMock()
+        mock_svc.embed.return_value = [[0.1, 0.2], [0.3, 0.4]]
+        actor._embedding_svc = mock_svc
+
+        mock_proxy = MagicMock()
+        captured_results: list[EmbeddingResult] = []
+
+        def capture_result(msg: EmbeddingResult) -> None:
+            captured_results.append(msg)
+
+        mock_proxy.receiveMsg_EmbeddingResult = capture_result
+
+        with (
+            patch.object(actor, "proxy_tell", return_value=mock_proxy),
+            patch.object(actor, "stop"),
+        ):
+            actor.receiveMsg_EmbeddingRequest(_make_request())
+
+        assert len(captured_results) == 1
+        result = captured_results[0]
+        assert result.collection == "test_col"
+        assert result.request_id == "test-req-1"
+        assert len(result.entries) == 2
+        assert result.entries[0].ref_id == "e1"
+        assert result.entries[0].vector == [0.1, 0.2]
+        assert result.entries[1].ref_id == "e2"
+        assert result.entries[1].vector == [0.3, 0.4]
+
+    def test_calls_embedding_service_with_texts(self) -> None:
+        """EmbeddingService.embed() is called with the entry texts."""
+        actor = _make_actor()
+        mock_svc = MagicMock()
+        mock_svc.embed.return_value = [[0.1], [0.2]]
+        actor._embedding_svc = mock_svc
+
+        with (
+            patch.object(actor, "proxy_tell", return_value=MagicMock()),
+            patch.object(actor, "stop"),
+        ):
+            actor.receiveMsg_EmbeddingRequest(_make_request())
+
+        mock_svc.embed.assert_called_once_with(["hello world", "goodbye"])
+
+
+# ---------------------------------------------------------------------------
+# receiveMsg_EmbeddingRequest — failure path (AC4, AC7)
+# ---------------------------------------------------------------------------
+
+
+class TestEmbeddingRequestFailure:
+    """AC4/AC7: EmbeddingActor sends error on embedding failure."""
+
+    def test_sends_embedding_error_on_exception(self) -> None:
+        """On embed failure, EmbeddingError is sent to parent."""
+        actor = _make_actor()
+        mock_svc = MagicMock()
+        mock_svc.embed.side_effect = RuntimeError("API timeout")
+        actor._embedding_svc = mock_svc
+
+        mock_proxy = MagicMock()
+        captured_errors: list[EmbeddingError] = []
+
+        def capture_error(msg: EmbeddingError) -> None:
+            captured_errors.append(msg)
+
+        mock_proxy.receiveMsg_EmbeddingError = capture_error
+
+        with (
+            patch.object(actor, "proxy_tell", return_value=mock_proxy),
+            patch.object(actor, "stop"),
+        ):
+            actor.receiveMsg_EmbeddingRequest(_make_request())
+
+        assert len(captured_errors) == 1
+        err = captured_errors[0]
+        assert err.collection == "test_col"
+        assert "API timeout" in err.error
+        assert err.request_id == "test-req-1"
+
+    def test_sends_error_when_svc_unavailable(self) -> None:
+        """When EmbeddingService cannot be created, sends error."""
+        actor = _make_actor()
+
+        mock_proxy = MagicMock()
+        captured_errors: list[EmbeddingError] = []
+
+        def capture_error(msg: EmbeddingError) -> None:
+            captured_errors.append(msg)
+
+        mock_proxy.receiveMsg_EmbeddingError = capture_error
+
+        with (
+            patch.object(
+                actor,
+                "_get_or_create_embedding_svc",
+                return_value=None,
+            ),
+            patch.object(actor, "proxy_tell", return_value=mock_proxy),
+            patch.object(actor, "stop"),
+        ):
+            actor.receiveMsg_EmbeddingRequest(_make_request())
+
+        assert len(captured_errors) == 1
+        assert "unavailable" in captured_errors[0].error.lower()
+
+
+# ---------------------------------------------------------------------------
+# Actor stops itself after delivery (AC4)
+# ---------------------------------------------------------------------------
+
+
+class TestEmbeddingActorStopsSelf:
+    """AC4: EmbeddingActor stops itself after result or error delivery."""
+
+    def test_stops_after_success(self) -> None:
+        """Actor calls self.stop() after sending result."""
+        actor = _make_actor()
+        mock_svc = MagicMock()
+        mock_svc.embed.return_value = [[0.1], [0.2]]
+        actor._embedding_svc = mock_svc
+
+        with (
+            patch.object(actor, "proxy_tell", return_value=MagicMock()),
+            patch.object(actor, "stop") as mock_stop,
+        ):
+            actor.receiveMsg_EmbeddingRequest(_make_request())
+            mock_stop.assert_called_once()
+
+    def test_stops_after_failure(self) -> None:
+        """Actor calls self.stop() after sending error."""
+        actor = _make_actor()
+        mock_svc = MagicMock()
+        mock_svc.embed.side_effect = RuntimeError("fail")
+        actor._embedding_svc = mock_svc
+
+        with (
+            patch.object(actor, "proxy_tell", return_value=MagicMock()),
+            patch.object(actor, "stop") as mock_stop,
+        ):
+            actor.receiveMsg_EmbeddingRequest(_make_request())
+            mock_stop.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Message model construction
+# ---------------------------------------------------------------------------
+
+
+class TestMessageModels:
+    """Validate EmbeddingRequest/Result/Error construction and serialisation."""
+
+    def test_embedding_request_defaults(self) -> None:
+        """EmbeddingRequest has sensible defaults."""
+        req = EmbeddingRequest(
+            collection="c1",
+            entries=[{"ref_type": "t", "ref_id": "1", "text": "hi"}],
+        )
+        assert req.collection == "c1"
+        assert req.request_id  # auto-generated UUID
+        assert req.embedding_model == "text-embedding-3-small"
+
+    def test_embedding_request_round_trip(self) -> None:
+        """EmbeddingRequest round-trips through serialisation."""
+        req = _make_request()
+        data = req.model_dump()
+        restored = EmbeddingRequest.model_validate(data)
+        assert restored.collection == req.collection
+        assert restored.entries == req.entries
+
+    def test_embedding_error_round_trip(self) -> None:
+        """EmbeddingError round-trips through serialisation."""
+        err = EmbeddingError(
+            collection="c1", error="test error", request_id="r1"
+        )
+        data = err.model_dump()
+        restored = EmbeddingError.model_validate(data)
+        assert restored.error == "test error"

--- a/tests/vector_store/test_embedding_actor.py
+++ b/tests/vector_store/test_embedding_actor.py
@@ -228,6 +228,36 @@ class TestEmbeddingActorStopsSelf:
 
 
 # ---------------------------------------------------------------------------
+# No-parent guard (null safety)
+# ---------------------------------------------------------------------------
+
+
+class TestNoParentGuard:
+    """Verify EmbeddingActor handles missing parent gracefully."""
+
+    def test_no_parent_on_success_path(self) -> None:
+        """When _parent is None, result delivery is skipped without error."""
+        actor = _make_actor()
+        actor._parent = None
+        mock_svc = MagicMock()
+        mock_svc.embed.return_value = [[0.1], [0.2]]
+        actor._embedding_svc = mock_svc
+
+        with patch.object(actor, "stop"):
+            # Should not raise
+            actor.receiveMsg_EmbeddingRequest(_make_request())
+
+    def test_no_parent_on_error_path(self) -> None:
+        """When _parent is None, _send_error logs and returns without error."""
+        actor = _make_actor()
+        actor._parent = None
+
+        with patch.object(actor, "stop"):
+            # _send_error should not raise
+            actor._send_error(_make_request(), "test error")
+
+
+# ---------------------------------------------------------------------------
 # Message model construction
 # ---------------------------------------------------------------------------
 

--- a/tests/vector_store/test_inmemory.py
+++ b/tests/vector_store/test_inmemory.py
@@ -1,0 +1,341 @@
+"""Unit tests for InMemoryBackend."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from akgentic.tool.vector import VectorEntry
+from akgentic.tool.vector_store.inmemory import InMemoryBackend
+from akgentic.tool.vector_store.protocol import CollectionConfig, CollectionStatus
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def backend() -> InMemoryBackend:
+    """Return a fresh InMemoryBackend instance."""
+    return InMemoryBackend()
+
+
+@pytest.fixture()
+def config() -> CollectionConfig:
+    """Return a default CollectionConfig."""
+    return CollectionConfig()
+
+
+def _make_entry(ref_id: str, vector: list[float], text: str = "test") -> VectorEntry:
+    """Helper to create a VectorEntry."""
+    return VectorEntry(ref_type="test", ref_id=ref_id, text=text, vector=vector)
+
+
+# ---------------------------------------------------------------------------
+# create_collection
+# ---------------------------------------------------------------------------
+
+
+class TestCreateCollection:
+    """Tests for create_collection."""
+
+    def test_creates_new_collection(
+        self, backend: InMemoryBackend, config: CollectionConfig
+    ) -> None:
+        """AC3: create_collection creates a new collection."""
+        backend.create_collection("col1", config)
+        # Verify collection exists by searching (should return empty results)
+        result = backend.search("col1", [0.0, 0.0, 0.0], top_k=5)
+        assert result.hits == []
+        assert result.status == CollectionStatus.READY
+
+    def test_idempotent(self, backend: InMemoryBackend, config: CollectionConfig) -> None:
+        """AC3: second call with same name is no-op, does not reset data."""
+        backend.create_collection("col1", config)
+        backend.add("col1", [_make_entry("e1", [1.0, 0.0, 0.0])])
+
+        # Second create_collection should be a no-op
+        backend.create_collection("col1", config)
+
+        result = backend.search("col1", [1.0, 0.0, 0.0], top_k=5)
+        assert len(result.hits) == 1
+        assert result.hits[0].ref_id == "e1"
+
+
+# ---------------------------------------------------------------------------
+# add
+# ---------------------------------------------------------------------------
+
+
+class TestAdd:
+    """Tests for add."""
+
+    def test_inserts_entries_searchable(
+        self, backend: InMemoryBackend, config: CollectionConfig
+    ) -> None:
+        """AC4: add inserts entries and they are searchable."""
+        backend.create_collection("col1", config)
+        entries = [
+            _make_entry("e1", [1.0, 0.0, 0.0], text="hello"),
+            _make_entry("e2", [0.0, 1.0, 0.0], text="world"),
+        ]
+        backend.add("col1", entries)
+        result = backend.search("col1", [1.0, 0.0, 0.0], top_k=5)
+        assert len(result.hits) == 2
+        assert result.hits[0].ref_id == "e1"
+
+    def test_nonexistent_collection_raises(self, backend: InMemoryBackend) -> None:
+        """AC12: add to non-existent collection raises ValueError."""
+        with pytest.raises(ValueError, match="does not exist"):
+            backend.add("missing", [_make_entry("e1", [1.0])])
+
+
+# ---------------------------------------------------------------------------
+# remove
+# ---------------------------------------------------------------------------
+
+
+class TestRemove:
+    """Tests for remove."""
+
+    def test_removes_entries(
+        self, backend: InMemoryBackend, config: CollectionConfig
+    ) -> None:
+        """AC5: remove deletes entries by ref_ids."""
+        backend.create_collection("col1", config)
+        backend.add("col1", [
+            _make_entry("e1", [1.0, 0.0]),
+            _make_entry("e2", [0.0, 1.0]),
+        ])
+        backend.remove("col1", ["e1"])
+        result = backend.search("col1", [1.0, 0.0], top_k=5)
+        assert len(result.hits) == 1
+        assert result.hits[0].ref_id == "e2"
+
+    def test_nonexistent_collection_raises(self, backend: InMemoryBackend) -> None:
+        """AC12: remove from non-existent collection raises ValueError."""
+        with pytest.raises(ValueError, match="does not exist"):
+            backend.remove("missing", ["e1"])
+
+
+# ---------------------------------------------------------------------------
+# search
+# ---------------------------------------------------------------------------
+
+
+class TestSearch:
+    """Tests for search."""
+
+    def test_returns_search_result_with_correct_fields(
+        self, backend: InMemoryBackend, config: CollectionConfig
+    ) -> None:
+        """AC6: search returns SearchResult with correct SearchHit fields."""
+        backend.create_collection("col1", config)
+        backend.add("col1", [_make_entry("e1", [1.0, 0.0], text="hello")])
+        result = backend.search("col1", [1.0, 0.0], top_k=5)
+        assert len(result.hits) == 1
+        hit = result.hits[0]
+        assert hit.ref_type == "test"
+        assert hit.ref_id == "e1"
+        assert hit.text == "hello"
+        assert isinstance(hit.score, float)
+        assert result.status == CollectionStatus.READY
+        assert result.indexing_pending == 0
+
+    def test_ranked_by_cosine_similarity(
+        self, backend: InMemoryBackend, config: CollectionConfig
+    ) -> None:
+        """AC6: results ranked by cosine similarity (highest first)."""
+        backend.create_collection("col1", config)
+        backend.add("col1", [
+            _make_entry("far", [0.0, 1.0, 0.0]),
+            _make_entry("close", [1.0, 0.0, 0.0]),
+            _make_entry("mid", [0.7, 0.7, 0.0]),
+        ])
+        result = backend.search("col1", [1.0, 0.0, 0.0], top_k=3)
+        scores = [h.score for h in result.hits]
+        assert scores == sorted(scores, reverse=True)
+        assert result.hits[0].ref_id == "close"
+
+    def test_empty_collection_returns_empty_hits(
+        self, backend: InMemoryBackend, config: CollectionConfig
+    ) -> None:
+        """search on empty collection returns empty hits with READY status."""
+        backend.create_collection("col1", config)
+        result = backend.search("col1", [1.0, 0.0], top_k=5)
+        assert result.hits == []
+        assert result.status == CollectionStatus.READY
+
+    def test_nonexistent_collection_raises(self, backend: InMemoryBackend) -> None:
+        """AC12: search on non-existent collection raises ValueError."""
+        with pytest.raises(ValueError, match="does not exist"):
+            backend.search("missing", [1.0], top_k=5)
+
+    def test_respects_top_k(
+        self, backend: InMemoryBackend, config: CollectionConfig
+    ) -> None:
+        """search respects top_k limit."""
+        backend.create_collection("col1", config)
+        backend.add("col1", [
+            _make_entry("e1", [1.0, 0.0]),
+            _make_entry("e2", [0.9, 0.1]),
+            _make_entry("e3", [0.8, 0.2]),
+        ])
+        result = backend.search("col1", [1.0, 0.0], top_k=2)
+        assert len(result.hits) == 2
+
+
+# ---------------------------------------------------------------------------
+# actor_state persistence
+# ---------------------------------------------------------------------------
+
+
+class TestActorStatePersistence:
+    """Tests for get_state / restore_state round-trip."""
+
+    def test_round_trip(
+        self, backend: InMemoryBackend, config: CollectionConfig
+    ) -> None:
+        """AC8: get_state / restore_state round-trip preserves data."""
+        backend.create_collection("col1", config)
+        backend.add("col1", [
+            _make_entry("e1", [1.0, 0.0, 0.0], text="alpha"),
+            _make_entry("e2", [0.0, 1.0, 0.0], text="beta"),
+        ])
+
+        state = backend.get_state()
+
+        restored = InMemoryBackend()
+        restored.restore_state(state)
+
+        result = restored.search("col1", [1.0, 0.0, 0.0], top_k=5)
+        assert len(result.hits) == 2
+        assert result.hits[0].ref_id == "e1"
+        assert result.hits[0].text == "alpha"
+
+    def test_state_includes_config(
+        self, backend: InMemoryBackend
+    ) -> None:
+        """get_state includes collection config."""
+        cfg = CollectionConfig(dimension=768, persistence="workspace")
+        backend.create_collection("col1", cfg)
+
+        state = backend.get_state()
+        assert state["collections"]["col1"]["config"]["dimension"] == 768
+        assert state["collections"]["col1"]["config"]["persistence"] == "workspace"
+
+
+# ---------------------------------------------------------------------------
+# workspace persistence
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspacePersistence:
+    """Tests for save_collection / load_collection."""
+
+    def test_round_trip(
+        self, backend: InMemoryBackend, config: CollectionConfig, tmp_path: str
+    ) -> None:
+        """AC9: save_collection / load_collection round-trip."""
+        backend.create_collection("col1", config)
+        backend.add("col1", [
+            _make_entry("e1", [1.0, 0.0, 0.0], text="saved"),
+            _make_entry("e2", [0.0, 1.0, 0.0], text="also saved"),
+        ])
+        backend.save_collection("col1", str(tmp_path))
+
+        restored = InMemoryBackend()
+        restored.load_collection("col1", config, str(tmp_path))
+
+        result = restored.search("col1", [1.0, 0.0, 0.0], top_k=5)
+        assert len(result.hits) == 2
+        assert result.hits[0].ref_id == "e1"
+        assert result.hits[0].text == "saved"
+
+    def test_creates_vector_store_directory(
+        self, backend: InMemoryBackend, config: CollectionConfig, tmp_path: str
+    ) -> None:
+        """AC9: save_collection creates .vector_store/ directory."""
+        from pathlib import Path
+
+        backend.create_collection("col1", config)
+        backend.add("col1", [_make_entry("e1", [1.0, 0.0])])
+        backend.save_collection("col1", str(tmp_path))
+
+        assert (Path(str(tmp_path)) / ".vector_store").is_dir()
+        assert (Path(str(tmp_path)) / ".vector_store" / "col1.npz").exists()
+        assert (Path(str(tmp_path)) / ".vector_store" / "col1.json").exists()
+
+    def test_missing_file_starts_empty(
+        self, config: CollectionConfig, tmp_path: str
+    ) -> None:
+        """AC9: loading from missing file starts empty collection."""
+        backend = InMemoryBackend()
+        backend.load_collection("col1", config, str(tmp_path))
+
+        result = backend.search("col1", [1.0, 0.0], top_k=5)
+        assert result.hits == []
+        assert result.status == CollectionStatus.READY
+
+    def test_save_nonexistent_collection_raises(
+        self, backend: InMemoryBackend, tmp_path: str
+    ) -> None:
+        """save_collection on non-existent collection raises ValueError."""
+        with pytest.raises(ValueError, match="does not exist"):
+            backend.save_collection("missing", str(tmp_path))
+
+
+# ---------------------------------------------------------------------------
+# Multi-collection independence
+# ---------------------------------------------------------------------------
+
+
+class TestMultipleCollections:
+    """Tests for collection independence."""
+
+    def test_collections_are_independent(
+        self, backend: InMemoryBackend, config: CollectionConfig
+    ) -> None:
+        """Adding to one collection does not affect another."""
+        backend.create_collection("col1", config)
+        backend.create_collection("col2", config)
+
+        backend.add("col1", [_make_entry("e1", [1.0, 0.0])])
+        backend.add("col2", [_make_entry("e2", [0.0, 1.0])])
+
+        result1 = backend.search("col1", [1.0, 0.0], top_k=5)
+        result2 = backend.search("col2", [0.0, 1.0], top_k=5)
+
+        assert len(result1.hits) == 1
+        assert result1.hits[0].ref_id == "e1"
+        assert len(result2.hits) == 1
+        assert result2.hits[0].ref_id == "e2"
+
+
+# ---------------------------------------------------------------------------
+# Cosine similarity correctness
+# ---------------------------------------------------------------------------
+
+
+class TestCosineCorrectness:
+    """Verify cosine similarity scores are mathematically correct."""
+
+    def test_identical_vectors_score_one(
+        self, backend: InMemoryBackend, config: CollectionConfig
+    ) -> None:
+        """Identical vectors should have cosine similarity ~1.0."""
+        backend.create_collection("col1", config)
+        backend.add("col1", [_make_entry("e1", [1.0, 0.0, 0.0])])
+        result = backend.search("col1", [1.0, 0.0, 0.0], top_k=1)
+        assert math.isclose(result.hits[0].score, 1.0, abs_tol=1e-9)
+
+    def test_orthogonal_vectors_score_zero(
+        self, backend: InMemoryBackend, config: CollectionConfig
+    ) -> None:
+        """Orthogonal vectors should have cosine similarity ~0.0."""
+        backend.create_collection("col1", config)
+        backend.add("col1", [_make_entry("e1", [0.0, 1.0, 0.0])])
+        result = backend.search("col1", [1.0, 0.0, 0.0], top_k=1)
+        assert math.isclose(result.hits[0].score, 0.0, abs_tol=1e-9)

--- a/tests/vector_store/test_inmemory.py
+++ b/tests/vector_store/test_inmemory.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import math
+from pathlib import Path
 
 import pytest
 
 from akgentic.tool.vector import VectorEntry
 from akgentic.tool.vector_store.inmemory import InMemoryBackend
 from akgentic.tool.vector_store.protocol import CollectionConfig, CollectionStatus
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -236,7 +236,7 @@ class TestWorkspacePersistence:
     """Tests for save_collection / load_collection."""
 
     def test_round_trip(
-        self, backend: InMemoryBackend, config: CollectionConfig, tmp_path: str
+        self, backend: InMemoryBackend, config: CollectionConfig, tmp_path: Path
     ) -> None:
         """AC9: save_collection / load_collection round-trip."""
         backend.create_collection("col1", config)
@@ -255,21 +255,19 @@ class TestWorkspacePersistence:
         assert result.hits[0].text == "saved"
 
     def test_creates_vector_store_directory(
-        self, backend: InMemoryBackend, config: CollectionConfig, tmp_path: str
+        self, backend: InMemoryBackend, config: CollectionConfig, tmp_path: Path
     ) -> None:
         """AC9: save_collection creates .vector_store/ directory."""
-        from pathlib import Path
-
         backend.create_collection("col1", config)
         backend.add("col1", [_make_entry("e1", [1.0, 0.0])])
         backend.save_collection("col1", str(tmp_path))
 
-        assert (Path(str(tmp_path)) / ".vector_store").is_dir()
-        assert (Path(str(tmp_path)) / ".vector_store" / "col1.npz").exists()
-        assert (Path(str(tmp_path)) / ".vector_store" / "col1.json").exists()
+        assert (tmp_path / ".vector_store").is_dir()
+        assert (tmp_path / ".vector_store" / "col1.npz").exists()
+        assert (tmp_path / ".vector_store" / "col1.json").exists()
 
     def test_missing_file_starts_empty(
-        self, config: CollectionConfig, tmp_path: str
+        self, config: CollectionConfig, tmp_path: Path
     ) -> None:
         """AC9: loading from missing file starts empty collection."""
         backend = InMemoryBackend()
@@ -280,7 +278,7 @@ class TestWorkspacePersistence:
         assert result.status == CollectionStatus.READY
 
     def test_save_nonexistent_collection_raises(
-        self, backend: InMemoryBackend, tmp_path: str
+        self, backend: InMemoryBackend, tmp_path: Path
     ) -> None:
         """save_collection on non-existent collection raises ValueError."""
         with pytest.raises(ValueError, match="does not exist"):
@@ -317,6 +315,42 @@ class TestMultipleCollections:
 # ---------------------------------------------------------------------------
 # Cosine similarity correctness
 # ---------------------------------------------------------------------------
+
+
+class TestProtocolConformance:
+    """Verify InMemoryBackend satisfies VectorStoreService structurally."""
+
+    def test_satisfies_vector_store_service_protocol(self) -> None:
+        """AC1: InMemoryBackend structurally implements VectorStoreService."""
+        from akgentic.tool.vector_store.protocol import VectorStoreService
+
+        backend = InMemoryBackend()
+        # Structural subtyping check: assign to protocol-typed variable
+        svc: VectorStoreService = backend
+        assert svc is backend
+
+
+class TestRestoreStateEdgeCases:
+    """Edge case tests for restore_state."""
+
+    def test_restore_empty_state(self, backend: InMemoryBackend) -> None:
+        """restore_state with empty collections dict clears existing data."""
+        config = CollectionConfig()
+        backend.create_collection("col1", config)
+        backend.add("col1", [_make_entry("e1", [1.0, 0.0])])
+
+        backend.restore_state({"collections": {}})
+
+        with pytest.raises(ValueError, match="does not exist"):
+            backend.search("col1", [1.0, 0.0], top_k=5)
+
+    def test_restore_state_missing_collections_key(self) -> None:
+        """restore_state with empty dict treats it as no collections."""
+        backend = InMemoryBackend()
+        backend.restore_state({})
+        # Backend should be empty — no collections at all
+        with pytest.raises(ValueError, match="does not exist"):
+            backend.search("anything", [1.0], top_k=1)
 
 
 class TestCosineCorrectness:

--- a/tests/vector_store/test_integration.py
+++ b/tests/vector_store/test_integration.py
@@ -1,0 +1,403 @@
+"""Integration tests for VectorStoreActor — end-to-end lifecycle validation.
+
+Covers: full lifecycle (create/add/search/remove), INDEXING-to-READY transition,
+multiple collection independence, embed delegation, idempotent create_collection,
+remove verification, and workspace npz save/load round-trip.
+
+Pattern: Direct instantiation of VectorStoreActor (no Pykka actor system),
+same approach as test_actor.py.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from akgentic.tool.vector import VectorEntry
+from akgentic.tool.vector_store.actor import (
+    VS_ACTOR_NAME,
+    VS_ACTOR_ROLE,
+    VectorStoreActor,
+)
+from akgentic.tool.vector_store.embedding_actor import EmbeddingResult
+from akgentic.tool.vector_store.protocol import (
+    CollectionConfig,
+    CollectionStatus,
+    VectorStoreConfig,
+)
+
+# Resolve forward reference for VectorEntry in EmbeddingResult
+EmbeddingResult.model_rebuild()
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_actor() -> VectorStoreActor:
+    """Instantiate a VectorStoreActor directly — no Pykka actor system."""
+    actor = VectorStoreActor()
+    actor.config = VectorStoreConfig(name=VS_ACTOR_NAME, role=VS_ACTOR_ROLE)
+    actor.on_start()
+    actor.createActor = MagicMock()  # type: ignore[assignment]
+    actor.proxy_tell = MagicMock()  # type: ignore[assignment]
+    return actor
+
+
+@pytest.fixture()
+def actor() -> VectorStoreActor:
+    """Provide a fresh VectorStoreActor for each test."""
+    return _make_actor()
+
+
+def _entry(
+    ref_id: str,
+    ref_type: str = "entity",
+    text: str = "sample",
+    vector: list[float] | None = None,
+) -> VectorEntry:
+    """Create a VectorEntry with an optional pre-populated vector."""
+    return VectorEntry(
+        ref_type=ref_type,
+        ref_id=ref_id,
+        text=text,
+        vector=vector or [],
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC3: Integration Test — Full Lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestFullLifecycle:
+    """AC3: create -> add pre-embedded -> search -> remove -> search."""
+
+    def test_full_lifecycle_create_add_search_remove(
+        self, actor: VectorStoreActor
+    ) -> None:
+        """End-to-end: create collection, add, search, remove, verify."""
+        config = CollectionConfig(dimension=3)
+        actor.create_collection("test_col", config)
+        assert actor.state.collection_statuses["test_col"] == CollectionStatus.READY
+
+        # Add pre-embedded entries
+        entries = [
+            _entry("e1", text="hello", vector=[1.0, 0.0, 0.0]),
+            _entry("e2", text="world", vector=[0.0, 1.0, 0.0]),
+            _entry("e3", text="foo", vector=[0.0, 0.0, 1.0]),
+        ]
+        actor.add("test_col", entries)
+
+        # Search — query close to e1
+        result = actor.search("test_col", [0.9, 0.1, 0.0], top_k=3)
+        assert result.status == CollectionStatus.READY
+        assert len(result.hits) == 3
+        assert result.hits[0].ref_id == "e1"
+        assert result.hits[0].ref_type == "entity"
+        assert result.hits[0].text == "hello"
+        assert result.hits[0].score > 0.0
+
+        # Remove e1
+        actor.remove("test_col", ["e1"])
+
+        # Search again — e1 should be gone
+        result2 = actor.search("test_col", [0.9, 0.1, 0.0], top_k=3)
+        ref_ids = [h.ref_id for h in result2.hits]
+        assert "e1" not in ref_ids
+        assert len(result2.hits) == 2
+
+
+# ---------------------------------------------------------------------------
+# AC4: Integration Test — INDEXING to READY
+# ---------------------------------------------------------------------------
+
+
+class TestIndexingToReady:
+    """AC4: add without vectors -> INDEXING -> deliver EmbeddingResult -> READY."""
+
+    def test_indexing_to_ready_lifecycle(self, actor: VectorStoreActor) -> None:
+        """Async lifecycle: add needs-embedding -> INDEXING -> result -> READY."""
+        config = CollectionConfig(dimension=3)
+        actor.create_collection("async_col", config)
+
+        # Add entries without vectors (triggers embedding path)
+        entries = [
+            _entry("e1", text="hello"),
+            _entry("e2", text="world"),
+        ]
+        actor.add("async_col", entries)
+
+        # Verify INDEXING status
+        assert (
+            actor.state.collection_statuses["async_col"] == CollectionStatus.INDEXING
+        )
+        assert actor.state.indexing_pending["async_col"] == 2
+
+        # Deliver EmbeddingResult manually
+        embedded_entries = [
+            VectorEntry(
+                ref_type="entity", ref_id="e1", text="hello", vector=[1.0, 0.0, 0.0]
+            ),
+            VectorEntry(
+                ref_type="entity", ref_id="e2", text="world", vector=[0.0, 1.0, 0.0]
+            ),
+        ]
+        result_msg = EmbeddingResult(
+            collection="async_col", entries=embedded_entries, request_id="req-1"
+        )
+        actor.receiveMsg_EmbeddingResult(result_msg)
+
+        # Verify READY status
+        assert actor.state.collection_statuses["async_col"] == CollectionStatus.READY
+
+        # Search returns the newly-embedded entries
+        search_result = actor.search("async_col", [0.9, 0.1, 0.0], top_k=2)
+        assert len(search_result.hits) == 2
+        assert search_result.hits[0].ref_id == "e1"
+
+
+# ---------------------------------------------------------------------------
+# AC5: Integration Test — Multiple Collections
+# ---------------------------------------------------------------------------
+
+
+class TestMultipleCollections:
+    """AC5: Multiple collections with different configs are independent."""
+
+    def test_multiple_collections_independence(
+        self, actor: VectorStoreActor
+    ) -> None:
+        """Two collections with different dimensions stay independent."""
+        config_kg = CollectionConfig(dimension=3)
+        config_plan = CollectionConfig(dimension=4)
+
+        actor.create_collection("kg", config_kg)
+        actor.create_collection("planning", config_plan)
+
+        # Add entries to each
+        actor.add("kg", [_entry("kg1", text="knowledge", vector=[1.0, 0.0, 0.0])])
+        actor.add(
+            "planning",
+            [_entry("p1", text="plan", vector=[1.0, 0.0, 0.0, 0.0])],
+        )
+
+        # Search kg — should only find kg entries
+        kg_result = actor.search("kg", [1.0, 0.0, 0.0], top_k=5)
+        assert len(kg_result.hits) == 1
+        assert kg_result.hits[0].ref_id == "kg1"
+
+        # Search planning — should only find planning entries
+        plan_result = actor.search("planning", [1.0, 0.0, 0.0, 0.0], top_k=5)
+        assert len(plan_result.hits) == 1
+        assert plan_result.hits[0].ref_id == "p1"
+
+
+# ---------------------------------------------------------------------------
+# AC6: Integration Test — embed()
+# ---------------------------------------------------------------------------
+
+
+class TestEmbedReturnsVectors:
+    """AC6: embed() delegates to EmbeddingService and returns vectors."""
+
+    def test_embed_returns_vectors(self, actor: VectorStoreActor) -> None:
+        """Mock EmbeddingService.embed -> verify correct dimension vectors."""
+        mock_svc = MagicMock()
+        mock_svc.embed.return_value = [[0.1, 0.2, 0.3]]
+        actor._embedding_svc = mock_svc
+
+        result = actor.embed(["hello"])
+
+        mock_svc.embed.assert_called_once_with(["hello"])
+        assert len(result) == 1
+        assert len(result[0]) == 3
+        assert result[0] == [0.1, 0.2, 0.3]
+
+
+# ---------------------------------------------------------------------------
+# AC7: Integration Test — Idempotent create_collection
+# ---------------------------------------------------------------------------
+
+
+class TestIdempotentCreateCollection:
+    """AC7: Second create_collection is a no-op (data preserved)."""
+
+    def test_idempotent_create_collection(self, actor: VectorStoreActor) -> None:
+        """create_collection twice -> entries from first call preserved."""
+        config = CollectionConfig(dimension=3)
+        actor.create_collection("idem_col", config)
+
+        # Add entries
+        actor.add(
+            "idem_col", [_entry("e1", text="hello", vector=[1.0, 0.0, 0.0])]
+        )
+
+        # Call create_collection again with same name
+        actor.create_collection("idem_col", config)
+
+        # Entries should still be present
+        result = actor.search("idem_col", [1.0, 0.0, 0.0], top_k=5)
+        assert len(result.hits) == 1
+        assert result.hits[0].ref_id == "e1"
+
+
+# ---------------------------------------------------------------------------
+# AC8: Integration Test — remove
+# ---------------------------------------------------------------------------
+
+
+class TestRemoveEntries:
+    """AC8: Add entries, remove subset, verify only remaining returned."""
+
+    def test_remove_entries(self, actor: VectorStoreActor) -> None:
+        """Remove subset of entries and verify search results."""
+        config = CollectionConfig(dimension=3)
+        actor.create_collection("rm_col", config)
+
+        entries = [
+            _entry("e1", text="alpha", vector=[1.0, 0.0, 0.0]),
+            _entry("e2", text="beta", vector=[0.0, 1.0, 0.0]),
+            _entry("e3", text="gamma", vector=[0.0, 0.0, 1.0]),
+        ]
+        actor.add("rm_col", entries)
+
+        # Remove e1 and e3
+        actor.remove("rm_col", ["e1", "e3"])
+
+        # Search — only e2 should remain
+        result = actor.search("rm_col", [0.0, 1.0, 0.0], top_k=5)
+        assert len(result.hits) == 1
+        assert result.hits[0].ref_id == "e2"
+        assert result.hits[0].text == "beta"
+
+
+# ---------------------------------------------------------------------------
+# AC9: Integration Test — Workspace npz Save/Load
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspacePersistenceSaveLoad:
+    """AC9: Workspace persistence round-trip via npz/json on disk."""
+
+    def test_workspace_persistence_save_load(
+        self, tmp_path: Path
+    ) -> None:
+        """Create workspace collection, add entries, verify disk files, reload."""
+        actor = _make_actor()
+        config = CollectionConfig(
+            dimension=3,
+            persistence="workspace",
+            workspace_path=str(tmp_path),
+        )
+        actor.create_collection("ws_col", config)
+
+        # Add pre-embedded entries
+        entries = [
+            _entry("e1", text="hello", vector=[1.0, 0.0, 0.0]),
+            _entry("e2", text="world", vector=[0.0, 1.0, 0.0]),
+        ]
+        actor.add("ws_col", entries)
+
+        # Verify files on disk
+        vs_dir = tmp_path / ".vector_store"
+        assert (vs_dir / "ws_col.npz").exists()
+        assert (vs_dir / "ws_col.json").exists()
+
+        # Search original actor to confirm data
+        result1 = actor.search("ws_col", [1.0, 0.0, 0.0], top_k=5)
+        assert len(result1.hits) == 2
+        assert result1.hits[0].ref_id == "e1"
+
+        # Create a new actor and load from disk
+        actor2 = _make_actor()
+        config2 = CollectionConfig(
+            dimension=3,
+            persistence="workspace",
+            workspace_path=str(tmp_path),
+        )
+        actor2.create_collection("ws_col", config2)
+
+        # Search restored actor — all entries should be present
+        result2 = actor2.search("ws_col", [1.0, 0.0, 0.0], top_k=5)
+        assert len(result2.hits) == 2
+        assert result2.hits[0].ref_id == "e1"
+        assert result2.hits[0].text == "hello"
+        assert result2.hits[0].score > 0.0
+
+        # Verify scores match
+        assert abs(result1.hits[0].score - result2.hits[0].score) < 1e-6
+
+    def test_workspace_save_triggered_on_remove(
+        self, tmp_path: Path
+    ) -> None:
+        """Remove triggers save — verify updated files on disk."""
+        actor = _make_actor()
+        config = CollectionConfig(
+            dimension=3,
+            persistence="workspace",
+            workspace_path=str(tmp_path),
+        )
+        actor.create_collection("ws_rm", config)
+
+        entries = [
+            _entry("e1", text="hello", vector=[1.0, 0.0, 0.0]),
+            _entry("e2", text="world", vector=[0.0, 1.0, 0.0]),
+        ]
+        actor.add("ws_rm", entries)
+
+        # Remove one entry
+        actor.remove("ws_rm", ["e1"])
+
+        # Load from disk in new actor — only e2 should be present
+        actor2 = _make_actor()
+        config2 = CollectionConfig(
+            dimension=3,
+            persistence="workspace",
+            workspace_path=str(tmp_path),
+        )
+        actor2.create_collection("ws_rm", config2)
+
+        result = actor2.search("ws_rm", [0.0, 1.0, 0.0], top_k=5)
+        assert len(result.hits) == 1
+        assert result.hits[0].ref_id == "e2"
+
+    def test_workspace_save_on_embedding_result(
+        self, tmp_path: Path
+    ) -> None:
+        """EmbeddingResult delivery triggers workspace save."""
+        actor = _make_actor()
+        config = CollectionConfig(
+            dimension=3,
+            persistence="workspace",
+            workspace_path=str(tmp_path),
+        )
+        actor.create_collection("ws_embed", config)
+
+        # Simulate async add (needs embedding)
+        entries = [_entry("e1", text="hello")]
+        actor.add("ws_embed", entries)
+
+        # Deliver embedding result
+        embedded = [
+            VectorEntry(
+                ref_type="entity", ref_id="e1", text="hello", vector=[1.0, 0.0, 0.0]
+            ),
+        ]
+        result_msg = EmbeddingResult(
+            collection="ws_embed", entries=embedded, request_id="req-1"
+        )
+        actor.receiveMsg_EmbeddingResult(result_msg)
+
+        # Verify files exist
+        vs_dir = tmp_path / ".vector_store"
+        assert (vs_dir / "ws_embed.npz").exists()
+
+        # Load in new actor
+        actor2 = _make_actor()
+        actor2.create_collection("ws_embed", config)
+        result = actor2.search("ws_embed", [1.0, 0.0, 0.0], top_k=5)
+        assert len(result.hits) == 1
+        assert result.hits[0].ref_id == "e1"

--- a/tests/vector_store/test_public_api.py
+++ b/tests/vector_store/test_public_api.py
@@ -22,7 +22,11 @@ class TestPublicApi:
             "InMemoryBackend",
             "SearchHit",
             "SearchResult",
+            "VS_ACTOR_NAME",
+            "VS_ACTOR_ROLE",
+            "VectorStoreActor",
             "VectorStoreConfig",
             "VectorStoreService",
+            "VectorStoreState",
         }
         assert set(vs.__all__) == expected

--- a/tests/vector_store/test_public_api.py
+++ b/tests/vector_store/test_public_api.py
@@ -32,5 +32,6 @@ class TestPublicApi:
             "VectorStoreConfig",
             "VectorStoreService",
             "VectorStoreState",
+            "WeaviateBackend",
         }
         assert set(vs.__all__) == expected

--- a/tests/vector_store/test_public_api.py
+++ b/tests/vector_store/test_public_api.py
@@ -19,6 +19,7 @@ class TestPublicApi:
             "CollectionConfig",
             "CollectionStatus",
             "EmbeddingProvider",
+            "InMemoryBackend",
             "SearchHit",
             "SearchResult",
             "VectorStoreConfig",

--- a/tests/vector_store/test_public_api.py
+++ b/tests/vector_store/test_public_api.py
@@ -18,7 +18,11 @@ class TestPublicApi:
         expected = {
             "CollectionConfig",
             "CollectionStatus",
+            "EmbeddingActor",
+            "EmbeddingError",
             "EmbeddingProvider",
+            "EmbeddingRequest",
+            "EmbeddingResult",
             "InMemoryBackend",
             "SearchHit",
             "SearchResult",

--- a/tests/vector_store/test_weaviate.py
+++ b/tests/vector_store/test_weaviate.py
@@ -1,0 +1,449 @@
+"""Unit tests for WeaviateBackend with mocked Weaviate client.
+
+Covers: protocol compliance, create_collection (idempotent), add, remove,
+search, multi-tenancy, import guard, and close().
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_weaviate_module() -> MagicMock:
+    """Build a mock ``weaviate`` module tree that satisfies WeaviateBackend imports."""
+    mock_weaviate = MagicMock()
+
+    # weaviate.connect_to_custom returns a mock client
+    mock_client = MagicMock()
+    mock_weaviate.connect_to_custom.return_value = mock_client
+
+    # weaviate.auth.AuthApiKey
+    mock_weaviate.auth = MagicMock()
+    mock_weaviate.auth.AuthApiKey.return_value = MagicMock()
+
+    # weaviate.classes.config
+    mock_config = MagicMock()
+    mock_config.Configure.Vectorizer.none.return_value = "none_vectorizer"
+    mock_config.Configure.multi_tenancy.return_value = "multi_tenancy_config"
+    mock_config.DataType.TEXT = "TEXT"
+    mock_config.Property = MagicMock(side_effect=lambda **kw: kw)
+    mock_weaviate.classes = MagicMock()
+    mock_weaviate.classes.config = mock_config
+
+    # weaviate.classes.tenants
+    mock_tenants_mod = MagicMock()
+    mock_tenants_mod.Tenant = MagicMock(side_effect=lambda name: f"Tenant({name})")
+    mock_weaviate.classes.tenants = mock_tenants_mod
+
+    # weaviate.classes.query
+    mock_query_mod = MagicMock()
+    mock_query_mod.MetadataQuery.return_value = "metadata_query"
+    mock_filter = MagicMock()
+    mock_filter.by_property.return_value.contains_any.return_value = "filter_expr"
+    mock_query_mod.Filter = mock_filter
+    mock_weaviate.classes.query = mock_query_mod
+
+    return mock_weaviate
+
+
+def _install_mock_weaviate() -> tuple[MagicMock, MagicMock]:
+    """Patch sys.modules so ``import weaviate`` resolves to our mock.
+
+    Returns (mock_weaviate_module, mock_client).
+    """
+    mock_weaviate = _make_mock_weaviate_module()
+    mock_client = mock_weaviate.connect_to_custom.return_value
+
+    modules = {
+        "weaviate": mock_weaviate,
+        "weaviate.auth": mock_weaviate.auth,
+        "weaviate.classes": mock_weaviate.classes,
+        "weaviate.classes.config": mock_weaviate.classes.config,
+        "weaviate.classes.tenants": mock_weaviate.classes.tenants,
+        "weaviate.classes.query": mock_weaviate.classes.query,
+    }
+    for name, mod in modules.items():
+        sys.modules[name] = mod
+
+    return mock_weaviate, mock_client
+
+
+def _cleanup_weaviate_modules() -> None:
+    """Remove all weaviate-related modules from sys.modules."""
+    to_remove = [k for k in sys.modules if k.startswith("weaviate")]
+    for k in to_remove:
+        del sys.modules[k]
+    # Also force-reload our module so it picks up the mock state
+    backend_key = "akgentic.tool.vector_store.weaviate"
+    if backend_key in sys.modules:
+        del sys.modules[backend_key]
+
+
+def _make_entry(
+    ref_id: str = "e1",
+    ref_type: str = "entity",
+    text: str = "hello",
+    vector: list[float] | None = None,
+) -> MagicMock:
+    """Return a mock VectorEntry."""
+    entry = MagicMock()
+    entry.ref_id = ref_id
+    entry.ref_type = ref_type
+    entry.text = text
+    entry.vector = vector if vector is not None else [0.1, 0.2, 0.3]
+    return entry
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_modules() -> Any:
+    """Ensure weaviate mock modules are cleaned up before and after each test."""
+    _cleanup_weaviate_modules()
+    yield
+    _cleanup_weaviate_modules()
+
+
+# ---------------------------------------------------------------------------
+# Test: Import Guard (AC10)
+# ---------------------------------------------------------------------------
+
+
+class TestImportGuard:
+    """AC10: ImportError with install instructions when weaviate-client missing."""
+
+    def test_import_error_when_weaviate_missing(self) -> None:
+        """Instantiating WeaviateBackend without weaviate-client raises ImportError."""
+        # Ensure weaviate is NOT in sys.modules
+        _cleanup_weaviate_modules()
+
+        # Patch so that import weaviate fails
+        with patch.dict(sys.modules, {"weaviate": None}):
+            # Force reload to pick up the missing module
+            if "akgentic.tool.vector_store.weaviate" in sys.modules:
+                del sys.modules["akgentic.tool.vector_store.weaviate"]
+
+            from akgentic.tool.vector_store.weaviate import WeaviateBackend
+
+            with pytest.raises(ImportError, match="weaviate-client"):
+                WeaviateBackend(url="http://localhost:8080")
+
+
+# ---------------------------------------------------------------------------
+# Test: create_collection (AC1, AC3)
+# ---------------------------------------------------------------------------
+
+
+class TestCreateCollection:
+    """AC1, AC3: VectorStoreService compliance and idempotent creation."""
+
+    def test_creates_collection_with_correct_config(self) -> None:
+        """Collection created with cosine distance and no vectorizer."""
+        _mock_weaviate, mock_client = _install_mock_weaviate()
+        mock_client.collections.exists.return_value = False
+
+        from akgentic.tool.vector_store.protocol import CollectionConfig
+        from akgentic.tool.vector_store.weaviate import WeaviateBackend
+
+        backend = WeaviateBackend(url="http://localhost:8080")
+        config = CollectionConfig(dimension=384)
+        backend.create_collection("test_col", config)
+
+        mock_client.collections.create.assert_called_once()
+        call_kwargs = mock_client.collections.create.call_args
+        assert call_kwargs[1]["name"] == "test_col" or call_kwargs[0][0] == "test_col"
+
+    def test_idempotent_second_call(self) -> None:
+        """Second call with same name is a no-op."""
+        _mock_weaviate, mock_client = _install_mock_weaviate()
+        mock_client.collections.exists.return_value = False
+
+        from akgentic.tool.vector_store.protocol import CollectionConfig
+        from akgentic.tool.vector_store.weaviate import WeaviateBackend
+
+        backend = WeaviateBackend(url="http://localhost:8080")
+        config = CollectionConfig(dimension=384)
+        backend.create_collection("test_col", config)
+
+        # Now simulate exists=True
+        mock_client.collections.exists.return_value = True
+        mock_client.collections.create.reset_mock()
+        backend.create_collection("test_col", config)
+
+        mock_client.collections.create.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Test: add (AC4)
+# ---------------------------------------------------------------------------
+
+
+class TestAdd:
+    """AC4: add stores VectorEntry records with pre-populated vectors."""
+
+    def test_add_entries_with_batch(self) -> None:
+        """Entries are added via batch.dynamic() context manager."""
+        _mock_weaviate, mock_client = _install_mock_weaviate()
+        mock_client.collections.exists.return_value = False
+
+        mock_collection = MagicMock()
+        mock_client.collections.get.return_value = mock_collection
+        mock_batch = MagicMock()
+        mock_collection.batch.dynamic.return_value.__enter__ = MagicMock(return_value=mock_batch)
+        mock_collection.batch.dynamic.return_value.__exit__ = MagicMock(return_value=False)
+
+        from akgentic.tool.vector_store.protocol import CollectionConfig
+        from akgentic.tool.vector_store.weaviate import WeaviateBackend
+
+        backend = WeaviateBackend(url="http://localhost:8080")
+        backend.create_collection("col1", CollectionConfig())
+
+        entry = _make_entry(ref_id="r1", text="test text", vector=[0.1, 0.2])
+        backend.add("col1", [entry])
+
+        mock_batch.add_object.assert_called_once()
+        call_kwargs = mock_batch.add_object.call_args[1]
+        assert call_kwargs["properties"]["ref_id"] == "r1"
+        assert call_kwargs["vector"] == [0.1, 0.2]
+
+    def test_add_raises_on_unknown_collection(self) -> None:
+        """add raises ValueError for non-existent collection."""
+        _install_mock_weaviate()
+
+        from akgentic.tool.vector_store.weaviate import WeaviateBackend
+
+        backend = WeaviateBackend(url="http://localhost:8080")
+        entry = _make_entry()
+
+        with pytest.raises(ValueError, match="does not exist"):
+            backend.add("nonexistent", [entry])
+
+
+# ---------------------------------------------------------------------------
+# Test: remove (AC5)
+# ---------------------------------------------------------------------------
+
+
+class TestRemove:
+    """AC5: remove deletes entries by ref_id filter."""
+
+    def test_remove_by_ref_ids(self) -> None:
+        """delete_many called with correct filter."""
+        _mock_weaviate, mock_client = _install_mock_weaviate()
+        mock_client.collections.exists.return_value = False
+
+        mock_collection = MagicMock()
+        mock_client.collections.get.return_value = mock_collection
+
+        from akgentic.tool.vector_store.protocol import CollectionConfig
+        from akgentic.tool.vector_store.weaviate import WeaviateBackend
+
+        backend = WeaviateBackend(url="http://localhost:8080")
+        backend.create_collection("col1", CollectionConfig())
+        backend.remove("col1", ["id1", "id2"])
+
+        mock_collection.data.delete_many.assert_called_once()
+
+    def test_remove_raises_on_unknown_collection(self) -> None:
+        """remove raises ValueError for non-existent collection."""
+        _install_mock_weaviate()
+
+        from akgentic.tool.vector_store.weaviate import WeaviateBackend
+
+        backend = WeaviateBackend(url="http://localhost:8080")
+        with pytest.raises(ValueError, match="does not exist"):
+            backend.remove("nonexistent", ["id1"])
+
+
+# ---------------------------------------------------------------------------
+# Test: search (AC6)
+# ---------------------------------------------------------------------------
+
+
+class TestSearch:
+    """AC6: search performs cosine similarity search."""
+
+    def test_search_returns_search_result(self) -> None:
+        """near_vector query returns correctly-mapped SearchResult."""
+        _mock_weaviate, mock_client = _install_mock_weaviate()
+        mock_client.collections.exists.return_value = False
+
+        mock_collection = MagicMock()
+        mock_client.collections.get.return_value = mock_collection
+
+        # Mock search result objects
+        mock_obj = MagicMock()
+        mock_obj.properties = {"ref_type": "entity", "ref_id": "r1", "text": "hello"}
+        mock_obj.metadata.distance = 0.2
+        mock_result = MagicMock()
+        mock_result.objects = [mock_obj]
+        mock_collection.query.near_vector.return_value = mock_result
+
+        from akgentic.tool.vector_store.protocol import CollectionConfig
+        from akgentic.tool.vector_store.weaviate import WeaviateBackend
+
+        backend = WeaviateBackend(url="http://localhost:8080")
+        backend.create_collection("col1", CollectionConfig())
+        result = backend.search("col1", [0.1, 0.2, 0.3], top_k=5)
+
+        assert len(result.hits) == 1
+        assert result.hits[0].ref_id == "r1"
+        assert result.hits[0].score == pytest.approx(0.8)
+        mock_collection.query.near_vector.assert_called_once()
+
+    def test_search_raises_on_unknown_collection(self) -> None:
+        """search raises ValueError for non-existent collection."""
+        _install_mock_weaviate()
+
+        from akgentic.tool.vector_store.weaviate import WeaviateBackend
+
+        backend = WeaviateBackend(url="http://localhost:8080")
+        with pytest.raises(ValueError, match="does not exist"):
+            backend.search("nonexistent", [0.1], top_k=5)
+
+
+# ---------------------------------------------------------------------------
+# Test: Multi-tenancy (AC7)
+# ---------------------------------------------------------------------------
+
+
+class TestMultiTenancy:
+    """AC7: tenant is passed on all operations when configured."""
+
+    def test_collection_created_with_multi_tenancy(self) -> None:
+        """Multi-tenancy config passed when tenant is set."""
+        _mock_weaviate, mock_client = _install_mock_weaviate()
+        mock_client.collections.exists.return_value = False
+        mock_col = MagicMock()
+        mock_client.collections.get.return_value = mock_col
+
+        from akgentic.tool.vector_store.protocol import CollectionConfig
+        from akgentic.tool.vector_store.weaviate import WeaviateBackend
+
+        backend = WeaviateBackend(url="http://localhost:8080", tenant="team-42")
+        config = CollectionConfig(dimension=384)
+        backend.create_collection("col1", config)
+
+        create_kwargs = mock_client.collections.create.call_args[1]
+        assert "multi_tenancy_config" in create_kwargs
+        mock_col.tenants.create.assert_called_once()
+
+    def test_operations_scoped_to_tenant(self) -> None:
+        """get().with_tenant() is called for tenant-scoped backends."""
+        _mock_weaviate, mock_client = _install_mock_weaviate()
+        mock_client.collections.exists.return_value = False
+
+        mock_col = MagicMock()
+        mock_tenant_col = MagicMock()
+        mock_col.with_tenant.return_value = mock_tenant_col
+        mock_client.collections.get.return_value = mock_col
+
+        # Set up batch mock on tenant collection
+        mock_batch = MagicMock()
+        mock_tenant_col.batch.dynamic.return_value.__enter__ = MagicMock(return_value=mock_batch)
+        mock_tenant_col.batch.dynamic.return_value.__exit__ = MagicMock(return_value=False)
+
+        from akgentic.tool.vector_store.protocol import CollectionConfig
+        from akgentic.tool.vector_store.weaviate import WeaviateBackend
+
+        backend = WeaviateBackend(url="http://localhost:8080", tenant="team-42")
+        backend.create_collection("col1", CollectionConfig())
+
+        entry = _make_entry()
+        backend.add("col1", [entry])
+
+        mock_col.with_tenant.assert_called_with("team-42")
+        mock_batch.add_object.assert_called_once()
+
+    def test_tenant_from_collection_config(self) -> None:
+        """Tenant from CollectionConfig.tenant is used when backend tenant is None."""
+        _mock_weaviate, mock_client = _install_mock_weaviate()
+        mock_client.collections.exists.return_value = False
+        mock_col = MagicMock()
+        mock_client.collections.get.return_value = mock_col
+
+        from akgentic.tool.vector_store.protocol import CollectionConfig
+        from akgentic.tool.vector_store.weaviate import WeaviateBackend
+
+        backend = WeaviateBackend(url="http://localhost:8080")  # no tenant
+        config = CollectionConfig(dimension=384, tenant="workspace-99")
+        backend.create_collection("col1", config)
+
+        create_kwargs = mock_client.collections.create.call_args[1]
+        assert "multi_tenancy_config" in create_kwargs
+
+
+# ---------------------------------------------------------------------------
+# Test: close (AC2)
+# ---------------------------------------------------------------------------
+
+
+class TestClose:
+    """close() disconnects the Weaviate client."""
+
+    def test_close_calls_client_close(self) -> None:
+        """close() delegates to client.close()."""
+        _mock_weaviate, mock_client = _install_mock_weaviate()
+
+        from akgentic.tool.vector_store.weaviate import WeaviateBackend
+
+        backend = WeaviateBackend(url="http://localhost:8080")
+        backend.close()
+
+        mock_client.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Test: Connection config (AC8)
+# ---------------------------------------------------------------------------
+
+
+class TestConnectionConfig:
+    """AC8: Connection parameters from url and api_key."""
+
+    def test_connects_with_api_key(self) -> None:
+        """AuthApiKey is used when api_key is provided."""
+        mock_weaviate, mock_client = _install_mock_weaviate()
+
+        from akgentic.tool.vector_store.weaviate import WeaviateBackend
+
+        WeaviateBackend(url="http://localhost:8080", api_key="test-key")
+
+        mock_weaviate.connect_to_custom.assert_called_once()
+        call_kwargs = mock_weaviate.connect_to_custom.call_args[1]
+        assert call_kwargs["auth_credentials"] is not None
+
+    def test_connects_without_api_key(self) -> None:
+        """No auth when api_key is None."""
+        mock_weaviate, mock_client = _install_mock_weaviate()
+
+        from akgentic.tool.vector_store.weaviate import WeaviateBackend
+
+        WeaviateBackend(url="http://localhost:8080")
+
+        call_kwargs = mock_weaviate.connect_to_custom.call_args[1]
+        assert call_kwargs["auth_credentials"] is None
+
+    def test_https_url_parsed_correctly(self) -> None:
+        """HTTPS URL sets http_secure and grpc_secure to True."""
+        mock_weaviate, _mock_client = _install_mock_weaviate()
+
+        from akgentic.tool.vector_store.weaviate import WeaviateBackend
+
+        WeaviateBackend(url="https://my-cluster.weaviate.cloud:443")
+
+        call_kwargs = mock_weaviate.connect_to_custom.call_args[1]
+        assert call_kwargs["http_secure"] is True
+        assert call_kwargs["grpc_secure"] is True
+        assert call_kwargs["http_port"] == 443

--- a/tests/vector_store/test_weaviate.py
+++ b/tests/vector_store/test_weaviate.py
@@ -302,6 +302,30 @@ class TestSearch:
         assert result.hits[0].score == pytest.approx(0.8)
         mock_collection.query.near_vector.assert_called_once()
 
+    def test_search_clamps_negative_scores(self) -> None:
+        """Scores are clamped to [0, 1] when distance > 1.0."""
+        _mock_weaviate, mock_client = _install_mock_weaviate()
+        mock_client.collections.exists.return_value = False
+
+        mock_collection = MagicMock()
+        mock_client.collections.get.return_value = mock_collection
+
+        mock_obj = MagicMock()
+        mock_obj.properties = {"ref_type": "entity", "ref_id": "r1", "text": "hello"}
+        mock_obj.metadata.distance = 1.5  # distance > 1 => would produce negative score
+        mock_result = MagicMock()
+        mock_result.objects = [mock_obj]
+        mock_collection.query.near_vector.return_value = mock_result
+
+        from akgentic.tool.vector_store.protocol import CollectionConfig
+        from akgentic.tool.vector_store.weaviate import WeaviateBackend
+
+        backend = WeaviateBackend(url="http://localhost:8080")
+        backend.create_collection("col1", CollectionConfig())
+        result = backend.search("col1", [0.1, 0.2], top_k=5)
+
+        assert result.hits[0].score == 0.0
+
     def test_search_raises_on_unknown_collection(self) -> None:
         """search raises ValueError for non-existent collection."""
         _install_mock_weaviate()
@@ -382,6 +406,35 @@ class TestMultiTenancy:
 
         create_kwargs = mock_client.collections.create.call_args[1]
         assert "multi_tenancy_config" in create_kwargs
+        mock_col.tenants.create.assert_called_once()
+
+    def test_config_tenant_scoped_on_operations(self) -> None:
+        """Operations use per-collection tenant from CollectionConfig, not backend."""
+        _mock_weaviate, mock_client = _install_mock_weaviate()
+        mock_client.collections.exists.return_value = False
+
+        mock_col = MagicMock()
+        mock_tenant_col = MagicMock()
+        mock_col.with_tenant.return_value = mock_tenant_col
+        mock_client.collections.get.return_value = mock_col
+
+        # Set up batch mock on tenant collection
+        mock_batch = MagicMock()
+        mock_tenant_col.batch.dynamic.return_value.__enter__ = MagicMock(return_value=mock_batch)
+        mock_tenant_col.batch.dynamic.return_value.__exit__ = MagicMock(return_value=False)
+
+        from akgentic.tool.vector_store.protocol import CollectionConfig
+        from akgentic.tool.vector_store.weaviate import WeaviateBackend
+
+        backend = WeaviateBackend(url="http://localhost:8080")  # no backend tenant
+        config = CollectionConfig(tenant="workspace-99")
+        backend.create_collection("col1", config)
+
+        entry = _make_entry()
+        backend.add("col1", [entry])
+
+        mock_col.with_tenant.assert_called_with("workspace-99")
+        mock_batch.add_object.assert_called_once()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Implement `InMemoryBackend` with numpy-backed `VectorIndex` per collection (story 10-2)
- Implement singleton `VectorStoreActor` exposing `VectorStoreService` protocol via proxy (story 10-3)
- Implement `EmbeddingActor` non-blocking pattern for OpenAI embedding calls (story 10-4)
- Add workspace persistence mode and integration tests (story 10-5)
- Migrate `KnowledgeGraphActor` to use `VectorStoreActor` proxy (story 11-1)
- Migrate `PlanActor` to use `VectorStoreActor` proxy (story 11-2)
- Implement `WeaviateBackend` with multi-tenancy and actor routing (story 12-1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)