### PR TITLE
Replace check-then-create with getChildrenOrCreate

### DIFF
--- a/examples/knowledge_agent.py
+++ b/examples/knowledge_agent.py
@@ -105,13 +105,16 @@ class _OrchestratorStub:
 
     def __init__(self, kg_addr: _MockAddress) -> None:
         self._kg_addr = kg_addr
+        self._vs_addr = _MockAddress("#VectorStore", "ToolActor")
 
-    def get_team_member(self, name: str) -> ActorAddress | None:
-        if name == KG_ACTOR_NAME:
-            return self._kg_addr
-        return None
+    def getChildrenOrCreate(  # noqa: N802
+        self, actor_class: type, config: object = None,
+    ) -> ActorAddress:
+        """Return KG addr for KG actors, VS addr for VectorStore actors."""
+        from akgentic.tool.vector_store.actor import VectorStoreActor
 
-    def createActor(self, *args: Any, **kwargs: Any) -> ActorAddress:  # noqa: N802, ANN401 — N802: Pykka actor convention; ANN401: generic stub accepting any actor args
+        if actor_class is VectorStoreActor:
+            return self._vs_addr
         return self._kg_addr
 
 
@@ -153,6 +156,11 @@ class _ExampleObserver:
         """Return the appropriate stub based on which actor is being asked."""
         if actor == self._orchestrator_addr:
             return _OrchestratorStub(self._kg_addr)
+        # Return mock for VectorStoreActor proxy
+        if hasattr(actor, 'name') and actor.name == "#VectorStore":
+            from unittest.mock import MagicMock
+
+            return MagicMock()
         return self._kg_actor
 
 

--- a/examples/planning_agent.py
+++ b/examples/planning_agent.py
@@ -103,13 +103,16 @@ class _OrchestratorStub:
 
     def __init__(self, plan_addr: _MockAddress) -> None:
         self._plan_addr = plan_addr
+        self._vs_addr = _MockAddress("#VectorStore", "ToolActor")
 
-    def get_team_member(self, name: str) -> ActorAddress | None:
-        if name == PLANNING_ACTOR_NAME:
-            return self._plan_addr
-        return None
+    def getChildrenOrCreate(  # noqa: N802
+        self, actor_class: type, config: object = None,
+    ) -> ActorAddress:
+        """Return plan addr for PlanActor, VS addr for VectorStore actors."""
+        from akgentic.tool.vector_store.actor import VectorStoreActor
 
-    def createActor(self, *args: Any, **kwargs: Any) -> ActorAddress:  # noqa: N802, ANN401 — N802: Pykka actor convention; ANN401: generic stub accepting any actor args
+        if actor_class is VectorStoreActor:
+            return self._vs_addr
         return self._plan_addr
 
 
@@ -154,6 +157,11 @@ class _ExampleObserver:
         """Return the appropriate stub based on which actor is being asked."""
         if actor == self._orchestrator_addr:
             return _OrchestratorStub(self._plan_addr)
+        # Return mock for VectorStoreActor proxy
+        if hasattr(actor, 'name') and actor.name == "#VectorStore":
+            from unittest.mock import MagicMock
+
+            return MagicMock()
         return self._plan_actor
 
 

--- a/src/akgentic/tool/knowledge_graph/kg_actor.py
+++ b/src/akgentic/tool/knowledge_graph/kg_actor.py
@@ -36,8 +36,8 @@ from akgentic.tool.knowledge_graph.models import (
     SearchResult,
 )
 from akgentic.tool.vector import VectorEntry
-from akgentic.tool.vector_store.actor import VS_ACTOR_NAME, VectorStoreActor
-from akgentic.tool.vector_store.protocol import CollectionConfig
+from akgentic.tool.vector_store.actor import VS_ACTOR_NAME, VS_ACTOR_ROLE, VectorStoreActor
+from akgentic.tool.vector_store.protocol import CollectionConfig, VectorStoreConfig
 from akgentic.tool.vector_store.protocol import SearchResult as VsSearchResult
 
 logger = logging.getLogger(__name__)
@@ -99,13 +99,10 @@ class KnowledgeGraphActor(Akgent[KnowledgeGraphConfig, KnowledgeGraphState]):
                 )
                 return
             orch_proxy = self.proxy_ask(self.orchestrator, Orchestrator)
-            vs_addr = orch_proxy.get_team_member(VS_ACTOR_NAME)
-            if vs_addr is None:
-                logger.warning(
-                    "[%s] VectorStoreActor not found; operating in degraded mode",
-                    self.config.name,
-                )
-                return
+            vs_addr = orch_proxy.getChildrenOrCreate(
+                VectorStoreActor,
+                config=VectorStoreConfig(name=VS_ACTOR_NAME, role=VS_ACTOR_ROLE),
+            )
             self._vs_proxy = self.proxy_ask(vs_addr, VectorStoreActor)
             self._vs_proxy.create_collection(KG_COLLECTION, CollectionConfig())
         except Exception as exc:  # noqa: BLE001

--- a/src/akgentic/tool/knowledge_graph/kg_tool.py
+++ b/src/akgentic/tool/knowledge_graph/kg_tool.py
@@ -38,7 +38,7 @@ from akgentic.tool.knowledge_graph.models import (
     SearchQuery,
     SearchResult,
 )
-from akgentic.tool.vector_store.actor import VS_ACTOR_NAME, VectorStoreActor
+from akgentic.tool.vector_store.actor import VS_ACTOR_NAME, VS_ACTOR_ROLE, VectorStoreActor
 from akgentic.tool.vector_store.protocol import VectorStoreConfig
 
 logger = logging.getLogger(__name__)
@@ -129,31 +129,25 @@ class KnowledgeGraphTool(ToolCard):
 
         orchestrator_proxy = observer.proxy_ask(observer.orchestrator, Orchestrator)
 
-        # Ensure VectorStoreActor singleton exists (AC10)
-        vs_addr = orchestrator_proxy.get_team_member(VS_ACTOR_NAME)
-        if vs_addr is None:
-            logger.info("KnowledgeGraphTool: creating singleton %s.", VS_ACTOR_NAME)
-            vs_addr = orchestrator_proxy.createActor(
-                VectorStoreActor,
-                config=VectorStoreConfig(
-                    name=VS_ACTOR_NAME,
-                    role="ToolActor",
-                    embedding_model=self.embedding_model,
-                    embedding_provider=self.embedding_provider,
-                ),
-            )
+        # Ensure VectorStoreActor singleton exists
+        orchestrator_proxy.getChildrenOrCreate(
+            VectorStoreActor,
+            config=VectorStoreConfig(
+                name=VS_ACTOR_NAME,
+                role=VS_ACTOR_ROLE,
+                embedding_model=self.embedding_model,
+                embedding_provider=self.embedding_provider,
+            ),
+        )
 
         # Create/retrieve KnowledgeGraphActor singleton
-        kg_addr = orchestrator_proxy.get_team_member(KG_ACTOR_NAME)
-        if kg_addr is None:
-            logger.info("KnowledgeGraphTool: creating singleton %s.", KG_ACTOR_NAME)
-            kg_addr = orchestrator_proxy.createActor(
-                KnowledgeGraphActor,
-                config=KnowledgeGraphConfig(
-                    name=KG_ACTOR_NAME,
-                    role=KG_ACTOR_ROLE,
-                ),
-            )
+        kg_addr = orchestrator_proxy.getChildrenOrCreate(
+            KnowledgeGraphActor,
+            config=KnowledgeGraphConfig(
+                name=KG_ACTOR_NAME,
+                role=KG_ACTOR_ROLE,
+            ),
+        )
 
         self._kg_proxy = observer.proxy_ask(kg_addr, KnowledgeGraphActor)
 

--- a/src/akgentic/tool/planning/planning.py
+++ b/src/akgentic/tool/planning/planning.py
@@ -96,32 +96,27 @@ class PlanningTool(ToolCard):
         if observer.orchestrator is None:
             raise ValueError("PlanningTool requires access to the orchestrator.")
 
-        orchestrator_proxy_ask = observer.proxy_ask(observer.orchestrator, Orchestrator)
+        orchestrator_proxy = observer.proxy_ask(observer.orchestrator, Orchestrator)
 
-        # Ensure VectorStoreActor singleton exists (AC10)
-        vs_addr = orchestrator_proxy_ask.get_team_member(VS_ACTOR_NAME)
-        if vs_addr is None:
-            logger.info("PlanningTool: creating singleton %s.", VS_ACTOR_NAME)
-            vs_addr = orchestrator_proxy_ask.createActor(
-                VectorStoreActor,
-                config=VectorStoreConfig(
-                    name=VS_ACTOR_NAME,
-                    role=VS_ACTOR_ROLE,
-                    embedding_model=self.embedding_model,
-                    embedding_provider=self.embedding_provider,
-                ),
-            )
+        # Ensure VectorStoreActor singleton exists
+        orchestrator_proxy.getChildrenOrCreate(
+            VectorStoreActor,
+            config=VectorStoreConfig(
+                name=VS_ACTOR_NAME,
+                role=VS_ACTOR_ROLE,
+                embedding_model=self.embedding_model,
+                embedding_provider=self.embedding_provider,
+            ),
+        )
 
         # Create/retrieve PlanActor singleton
-        planning_tool_addr = orchestrator_proxy_ask.get_team_member(PLANNING_ACTOR_NAME)
-
-        if planning_tool_addr is None:
-            logger.info("PlanningTool: creating %s.", PLANNING_ACTOR_NAME)
-            config = PlanConfig(
+        planning_tool_addr = orchestrator_proxy.getChildrenOrCreate(
+            PlanActor,
+            config=PlanConfig(
                 name=PLANNING_ACTOR_NAME,
                 role=PLANNING_ACTOR_ROLE,
-            )
-            planning_tool_addr = orchestrator_proxy_ask.createActor(PlanActor, config=config)
+            ),
+        )
 
         self._planning_proxy = observer.proxy_ask(planning_tool_addr, PlanActor)
 

--- a/src/akgentic/tool/planning/planning_actor.py
+++ b/src/akgentic/tool/planning/planning_actor.py
@@ -12,8 +12,8 @@ from akgentic.core.orchestrator import Orchestrator
 from akgentic.core.utils.serializer import SerializableBaseModel
 from akgentic.tool.errors import RetriableError
 from akgentic.tool.vector import VectorEntry
-from akgentic.tool.vector_store.actor import VS_ACTOR_NAME, VectorStoreActor
-from akgentic.tool.vector_store.protocol import CollectionConfig
+from akgentic.tool.vector_store.actor import VS_ACTOR_NAME, VS_ACTOR_ROLE, VectorStoreActor
+from akgentic.tool.vector_store.protocol import CollectionConfig, VectorStoreConfig
 
 logger = logging.getLogger(__name__)
 
@@ -142,13 +142,10 @@ class PlanActor(Akgent[PlanConfig, PlanManagerState]):
                 )
                 return
             orch_proxy = self.proxy_ask(self.orchestrator, Orchestrator)
-            vs_addr = orch_proxy.get_team_member(VS_ACTOR_NAME)
-            if vs_addr is None:
-                logger.warning(
-                    "[%s] VectorStoreActor not found; operating in degraded mode",
-                    self.config.name,
-                )
-                return
+            vs_addr = orch_proxy.getChildrenOrCreate(
+                VectorStoreActor,
+                config=VectorStoreConfig(name=VS_ACTOR_NAME, role=VS_ACTOR_ROLE),
+            )
             self._vs_proxy = self.proxy_ask(vs_addr, VectorStoreActor)
             self._vs_proxy.create_collection(PLAN_COLLECTION, CollectionConfig())
         except Exception as exc:  # noqa: BLE001

--- a/src/akgentic/tool/sandbox/tool.py
+++ b/src/akgentic/tool/sandbox/tool.py
@@ -141,31 +141,29 @@ class ExecTool(ToolCard):
         if observer.orchestrator is None:
             raise ValueError("ExecTool requires access to the orchestrator.")
 
-        orchestrator_proxy = observer.proxy_ask(observer.orchestrator, Orchestrator)
-        sandbox_addr = orchestrator_proxy.get_team_member(SANDBOX_ACTOR_NAME)
-
-        if sandbox_addr is None:
-            effective_mode = _resolve_auto_mode() if self.mode == "auto" else self.mode
-            if self.mode == "auto" and effective_mode == "local":
-                warnings.warn(
-                    "ExecTool mode='auto': no isolation backend found (bwrap, sandbox-exec, "
-                    "docker). Falling back to LocalSandboxActor — no filesystem isolation.",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-            # KeyError on unknown mode — intentional (fail-fast, NFR-SB-7)
-            actor_class = SANDBOX_ACTOR_CLASSES[effective_mode]
-            logger.info("ExecTool: create %s (%s).", SANDBOX_ACTOR_NAME, actor_class.__name__)
-            sandbox_addr = orchestrator_proxy.createActor(
-                actor_class,
-                config=SandboxConfig(
-                    name=SANDBOX_ACTOR_NAME,
-                    role="ToolActor",
-                    team_id=str(observer.team_id),
-                    workspace_id=self.workspace_id,
-                    mode=effective_mode,
-                ),
+        # Resolve mode and emit warnings before getChildrenOrCreate
+        effective_mode = _resolve_auto_mode() if self.mode == "auto" else self.mode
+        if self.mode == "auto" and effective_mode == "local":
+            warnings.warn(
+                "ExecTool mode='auto': no isolation backend found (bwrap, sandbox-exec, "
+                "docker). Falling back to LocalSandboxActor — no filesystem isolation.",
+                DeprecationWarning,
+                stacklevel=2,
             )
+        # KeyError on unknown mode — intentional (fail-fast, NFR-SB-7)
+        actor_class = SANDBOX_ACTOR_CLASSES[effective_mode]
+
+        orchestrator_proxy = observer.proxy_ask(observer.orchestrator, Orchestrator)
+        sandbox_addr = orchestrator_proxy.getChildrenOrCreate(
+            actor_class,
+            config=SandboxConfig(
+                name=SANDBOX_ACTOR_NAME,
+                role="ToolActor",
+                team_id=str(observer.team_id),
+                workspace_id=self.workspace_id,
+                mode=effective_mode,
+            ),
+        )
 
         self._sandbox_proxy = observer.proxy_ask(sandbox_addr, SandboxActor)
         return self

--- a/tests/sandbox/test_exec_tool.py
+++ b/tests/sandbox/test_exec_tool.py
@@ -54,10 +54,12 @@ class MockObserver:
 
         # Set up orchestrator proxy mock
         self._orch_proxy = MagicMock()
-        self._orch_proxy.get_team_member.return_value = existing_actor  # None = not found
-        new_addr = MagicMock(spec=ActorAddress)
-        self._orch_proxy.createActor.return_value = new_addr
-        self._new_actor_addr = new_addr
+        if existing_actor is not None:
+            self._orch_proxy.getChildrenOrCreate.return_value = existing_actor
+        else:
+            new_addr = MagicMock(spec=ActorAddress)
+            self._orch_proxy.getChildrenOrCreate.return_value = new_addr
+            self._new_actor_addr = new_addr
 
     def proxy_ask(
         self,
@@ -156,8 +158,8 @@ def test_observer_creates_local_sandbox_actor() -> None:
 
     tool.observer(observer)  # type: ignore[arg-type]
 
-    observer._orch_proxy.createActor.assert_called_once()
-    call_args = observer._orch_proxy.createActor.call_args
+    observer._orch_proxy.getChildrenOrCreate.assert_called_once()
+    call_args = observer._orch_proxy.getChildrenOrCreate.call_args
     assert call_args[0][0] is LocalSandboxActor
 
 
@@ -168,7 +170,7 @@ def test_observer_creates_actor_with_correct_config() -> None:
 
     tool.observer(observer)  # type: ignore[arg-type]
 
-    call_kwargs = observer._orch_proxy.createActor.call_args[1]
+    call_kwargs = observer._orch_proxy.getChildrenOrCreate.call_args[1]
     config: SandboxConfig = call_kwargs["config"]
     assert config.name == SANDBOX_ACTOR_NAME
     assert config.role == "ToolActor"
@@ -198,8 +200,8 @@ def test_observer_creates_docker_sandbox_actor() -> None:
 
     tool.observer(observer)  # type: ignore[arg-type]
 
-    observer._orch_proxy.createActor.assert_called_once()
-    call_args = observer._orch_proxy.createActor.call_args
+    observer._orch_proxy.getChildrenOrCreate.assert_called_once()
+    call_args = observer._orch_proxy.getChildrenOrCreate.call_args
     assert call_args[0][0] is DockerSandboxActor
 
 
@@ -210,7 +212,7 @@ def test_observer_creates_docker_actor_config_has_mode_docker() -> None:
 
     tool.observer(observer)  # type: ignore[arg-type]
 
-    call_kwargs = observer._orch_proxy.createActor.call_args[1]
+    call_kwargs = observer._orch_proxy.getChildrenOrCreate.call_args[1]
     config: SandboxConfig = call_kwargs["config"]
     assert config.mode == "docker"
 
@@ -221,30 +223,30 @@ def test_observer_creates_docker_actor_config_has_mode_docker() -> None:
 
 
 def test_observer_reuses_existing_actor() -> None:
-    """AC6: when #SandboxActor already exists, createActor is NOT called."""
+    """AC6: getChildrenOrCreate is called and returns the existing actor."""
     existing_addr = MagicMock(spec=ActorAddress)
     observer = MockObserver(existing_actor=existing_addr)
     tool = ExecTool()
 
     tool.observer(observer)  # type: ignore[arg-type]
 
-    observer._orch_proxy.createActor.assert_not_called()
+    observer._orch_proxy.getChildrenOrCreate.assert_called_once()
 
 
 def test_observer_second_call_reuses_actor() -> None:
-    """AC6: calling observer() a second time (actor already exists) does not create a new one."""
-    # First call: no existing actor → creates one
+    """AC6: calling observer() a second time still calls getChildrenOrCreate."""
+    # First call: no existing actor → getChildrenOrCreate creates one
     observer1 = MockObserver(existing_actor=None)
     tool = ExecTool()
     tool.observer(observer1)  # type: ignore[arg-type]
-    assert observer1._orch_proxy.createActor.call_count == 1
+    assert observer1._orch_proxy.getChildrenOrCreate.call_count == 1
 
-    # Second call: actor now exists
+    # Second call: actor now exists — getChildrenOrCreate returns existing
     existing_addr = MagicMock(spec=ActorAddress)
     observer2 = MockObserver(existing_actor=existing_addr)
     tool.observer(observer2)  # type: ignore[arg-type]
 
-    observer2._orch_proxy.createActor.assert_not_called()
+    observer2._orch_proxy.getChildrenOrCreate.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
@@ -446,7 +448,7 @@ def test_exec_tool_mode_not_affected_by_sandbox_mode_env(
 
     tool.observer(observer)  # type: ignore[arg-type]
 
-    call_args = observer._orch_proxy.createActor.call_args
+    call_args = observer._orch_proxy.getChildrenOrCreate.call_args
     # Despite env var, LocalSandboxActor must be chosen (mode="local")
     assert call_args[0][0] is LocalSandboxActor
 
@@ -475,7 +477,7 @@ def test_observer_passes_workspace_id_to_sandbox_config() -> None:
 
     tool.observer(observer)  # type: ignore[arg-type]
 
-    call_kwargs = observer._orch_proxy.createActor.call_args[1]
+    call_kwargs = observer._orch_proxy.getChildrenOrCreate.call_args[1]
     config: SandboxConfig = call_kwargs["config"]
     assert config.workspace_id == "test"
 
@@ -487,7 +489,7 @@ def test_observer_passes_workspace_id_none_to_sandbox_config() -> None:
 
     tool.observer(observer)  # type: ignore[arg-type]
 
-    call_kwargs = observer._orch_proxy.createActor.call_args[1]
+    call_kwargs = observer._orch_proxy.getChildrenOrCreate.call_args[1]
     config: SandboxConfig = call_kwargs["config"]
     assert config.workspace_id is None
 
@@ -500,7 +502,7 @@ def test_observer_config_has_team_id_and_workspace_id_independently() -> None:
 
     tool.observer(observer)  # type: ignore[arg-type]
 
-    call_kwargs = observer._orch_proxy.createActor.call_args[1]
+    call_kwargs = observer._orch_proxy.getChildrenOrCreate.call_args[1]
     config: SandboxConfig = call_kwargs["config"]
     assert config.team_id == "t1"
     assert config.workspace_id == "my-ws"
@@ -581,7 +583,7 @@ def test_observer_creates_bwrap_sandbox_actor() -> None:
 
     tool.observer(observer)  # type: ignore[arg-type]
 
-    call_args = observer._orch_proxy.createActor.call_args
+    call_args = observer._orch_proxy.getChildrenOrCreate.call_args
     assert call_args[0][0] is BwrapSandboxActor
 
 
@@ -592,7 +594,7 @@ def test_observer_creates_seatbelt_sandbox_actor() -> None:
 
     tool.observer(observer)  # type: ignore[arg-type]
 
-    call_args = observer._orch_proxy.createActor.call_args
+    call_args = observer._orch_proxy.getChildrenOrCreate.call_args
     assert call_args[0][0] is SeatbeltSandboxActor
 
 
@@ -689,7 +691,7 @@ def test_observer_auto_mode_creates_bwrap_actor() -> None:
     with patch("akgentic.tool.sandbox.tool._resolve_auto_mode", return_value="bwrap"):
         tool.observer(observer)  # type: ignore[arg-type]
 
-    call_args = observer._orch_proxy.createActor.call_args
+    call_args = observer._orch_proxy.getChildrenOrCreate.call_args
     assert call_args[0][0] is BwrapSandboxActor
 
 
@@ -701,7 +703,7 @@ def test_observer_auto_mode_creates_seatbelt_actor() -> None:
     with patch("akgentic.tool.sandbox.tool._resolve_auto_mode", return_value="seatbelt"):
         tool.observer(observer)  # type: ignore[arg-type]
 
-    call_args = observer._orch_proxy.createActor.call_args
+    call_args = observer._orch_proxy.getChildrenOrCreate.call_args
     assert call_args[0][0] is SeatbeltSandboxActor
 
 
@@ -716,7 +718,7 @@ def test_observer_auto_mode_fallback_to_local_emits_deprecation_warning() -> Non
     ):
         tool.observer(observer)  # type: ignore[arg-type]
 
-    call_args = observer._orch_proxy.createActor.call_args
+    call_args = observer._orch_proxy.getChildrenOrCreate.call_args
     assert call_args[0][0] is LocalSandboxActor
 
 
@@ -728,7 +730,7 @@ def test_observer_auto_mode_config_uses_resolved_mode() -> None:
     with patch("akgentic.tool.sandbox.tool._resolve_auto_mode", return_value="bwrap"):
         tool.observer(observer)  # type: ignore[arg-type]
 
-    call_kwargs = observer._orch_proxy.createActor.call_args[1]
+    call_kwargs = observer._orch_proxy.getChildrenOrCreate.call_args[1]
     config: SandboxConfig = call_kwargs["config"]
     assert config.mode == "bwrap"  # resolved mode stored, not "auto"
 
@@ -741,7 +743,7 @@ def test_observer_auto_mode_creates_docker_actor() -> None:
     with patch("akgentic.tool.sandbox.tool._resolve_auto_mode", return_value="docker"):
         tool.observer(observer)  # type: ignore[arg-type]
 
-    call_args = observer._orch_proxy.createActor.call_args
+    call_args = observer._orch_proxy.getChildrenOrCreate.call_args
     assert call_args[0][0] is DockerSandboxActor
 
 
@@ -760,5 +762,5 @@ def test_observer_local_mode_explicit_does_not_emit_deprecation_warning() -> Non
         warnings.simplefilter("error", DeprecationWarning)
         tool.observer(observer)  # type: ignore[arg-type]  # must not raise
 
-    call_args = observer._orch_proxy.createActor.call_args
+    call_args = observer._orch_proxy.getChildrenOrCreate.call_args
     assert call_args[0][0] is LocalSandboxActor

--- a/tests/test_kg_integration.py
+++ b/tests/test_kg_integration.py
@@ -136,6 +136,18 @@ class _OrchestratorStub:
         self._kg_addr = kg_addr
         self._vs_addr = vs_addr
 
+    def getChildrenOrCreate(  # noqa: N802
+        self, actor_class: type, config: object = None,
+    ) -> ActorAddress:
+        from akgentic.tool.knowledge_graph.kg_actor import KnowledgeGraphActor
+        from akgentic.tool.vector_store.actor import VectorStoreActor
+
+        if actor_class is VectorStoreActor:
+            return self._vs_addr
+        if actor_class is KnowledgeGraphActor:
+            return self._kg_addr
+        return self._kg_addr
+
     def get_team_member(self, name: str) -> ActorAddress | None:
         from akgentic.tool.vector_store.actor import VS_ACTOR_NAME
 

--- a/tests/test_kg_integration.py
+++ b/tests/test_kg_integration.py
@@ -11,7 +11,8 @@ from typing import Any
 
 from akgentic.core.actor_address import ActorAddress
 from akgentic.core.agent import AkgentType
-from akgentic.core.orchestrator import Orchestrator
+
+from akgentic.tool.core import TOOL_CALL
 from akgentic.tool.knowledge_graph.kg_actor import (
     KG_ACTOR_NAME,
     KG_ACTOR_ROLE,
@@ -21,7 +22,6 @@ from akgentic.tool.knowledge_graph.kg_tool import (
     GetGraph,
     KnowledgeGraphTool,
     SearchGraph,
-    UpdateGraph,
 )
 from akgentic.tool.knowledge_graph.models import (
     EntityCreate,
@@ -29,8 +29,6 @@ from akgentic.tool.knowledge_graph.models import (
     RelationCreate,
     SearchQuery,
 )
-from akgentic.tool.core import TOOL_CALL
-
 
 # ---------------------------------------------------------------------------
 # Shared mock infrastructure

--- a/tests/test_kg_tool.py
+++ b/tests/test_kg_tool.py
@@ -142,15 +142,17 @@ class MockActorToolObserver:
         self._kg_actor = actor
         kg_addr = MockActorAddress(KG_ACTOR_NAME, KG_ACTOR_ROLE)
 
-        # get_team_member returns VS addr for #VectorStore, KG addr for #KnowledgeGraphTool
-        def _get_team_member(name: str) -> MockActorAddress | None:
-            if name == VS_ACTOR_NAME:
-                return self._vs_addr
-            if name == KG_ACTOR_NAME:
-                return kg_addr
-            return None
+        # getChildrenOrCreate returns VS addr for #VectorStore, KG addr for #KnowledgeGraphTool
+        def _get_children_or_create(
+            actor_class: type, config: object = None,
+        ) -> MockActorAddress:
+            from akgentic.tool.vector_store.actor import VectorStoreActor as _VSActor
 
-        self._orchestrator_proxy.get_team_member.side_effect = _get_team_member
+            if actor_class is _VSActor:
+                return self._vs_addr
+            return kg_addr
+
+        self._orchestrator_proxy.getChildrenOrCreate.side_effect = _get_children_or_create
         return actor
 
 
@@ -263,46 +265,40 @@ class TestKnowledgeGraphToolObserver:
         with pytest.raises(ValueError, match="orchestrator"):
             tool.observer(observer)
 
-    def test_observer_creates_actors_when_none(self) -> None:
-        from akgentic.tool.vector_store.actor import VS_ACTOR_NAME
-
+    def test_observer_creates_actors_via_getChildrenOrCreate(self) -> None:
         tool = KnowledgeGraphTool()
         observer = MockActorToolObserver()
-        # get_team_member returns None → must createActor for both VS and KG
-        observer._orchestrator_proxy.get_team_member.return_value = None
         addr = MockActorAddress(KG_ACTOR_NAME, KG_ACTOR_ROLE)
-        observer._orchestrator_proxy.createActor.return_value = addr
+        observer._orchestrator_proxy.getChildrenOrCreate.return_value = addr
 
         tool.observer(observer)
 
-        # Should check for both VectorStore and KG actors
-        calls = observer._orchestrator_proxy.get_team_member.call_args_list
-        called_names = [c[0][0] for c in calls]
-        assert VS_ACTOR_NAME in called_names
-        assert KG_ACTOR_NAME in called_names
-        # createActor called for both
-        assert observer._orchestrator_proxy.createActor.call_count == 2
+        # getChildrenOrCreate called for both VectorStore and KG
+        assert observer._orchestrator_proxy.getChildrenOrCreate.call_count == 2
 
-    def test_observer_reuses_existing_actors(self) -> None:
-        from akgentic.tool.vector_store.actor import VS_ACTOR_NAME
-
+    def test_observer_uses_getChildrenOrCreate_for_both(self) -> None:
+        """getChildrenOrCreate is always called (it handles both create and reuse)."""
         tool = KnowledgeGraphTool()
         observer = MockActorToolObserver()
         vs_addr = MockActorAddress("#VectorStore", "ToolActor")
         kg_addr = MockActorAddress(KG_ACTOR_NAME, KG_ACTOR_ROLE)
 
-        def _get_team_member(name: str) -> MockActorAddress | None:
-            if name == VS_ACTOR_NAME:
-                return vs_addr
-            if name == KG_ACTOR_NAME:
-                return kg_addr
-            return None
+        from akgentic.tool.vector_store.actor import VectorStoreActor as _VSActor
 
-        observer._orchestrator_proxy.get_team_member.side_effect = _get_team_member
+        def _get_children_or_create(
+            actor_class: type, config: object = None,
+        ) -> MockActorAddress:
+            if actor_class is _VSActor:
+                return vs_addr
+            return kg_addr
+
+        observer._orchestrator_proxy.getChildrenOrCreate.side_effect = (
+            _get_children_or_create
+        )
 
         tool.observer(observer)
 
-        observer._orchestrator_proxy.createActor.assert_not_called()
+        assert observer._orchestrator_proxy.getChildrenOrCreate.call_count == 2
 
 
 class TestKnowledgeGraphToolReadOnly:

--- a/tests/test_kg_tool.py
+++ b/tests/test_kg_tool.py
@@ -131,7 +131,6 @@ class MockActorToolObserver:
     def setup_kg_actor(self) -> KnowledgeGraphActor:
         """Create a real KG actor and wire it for proxy_ask."""
         from akgentic.tool.knowledge_graph.models import KnowledgeGraphState
-        from akgentic.tool.vector_store.actor import VS_ACTOR_NAME
 
         actor = KnowledgeGraphActor()
         # Manually init without orchestrator dependency
@@ -265,7 +264,7 @@ class TestKnowledgeGraphToolObserver:
         with pytest.raises(ValueError, match="orchestrator"):
             tool.observer(observer)
 
-    def test_observer_creates_actors_via_getChildrenOrCreate(self) -> None:
+    def test_observer_creates_actors_via_get_children_or_create(self) -> None:
         tool = KnowledgeGraphTool()
         observer = MockActorToolObserver()
         addr = MockActorAddress(KG_ACTOR_NAME, KG_ACTOR_ROLE)
@@ -276,7 +275,7 @@ class TestKnowledgeGraphToolObserver:
         # getChildrenOrCreate called for both VectorStore and KG
         assert observer._orchestrator_proxy.getChildrenOrCreate.call_count == 2
 
-    def test_observer_uses_getChildrenOrCreate_for_both(self) -> None:
+    def test_observer_uses_get_children_or_create_for_both(self) -> None:
         """getChildrenOrCreate is always called (it handles both create and reuse)."""
         tool = KnowledgeGraphTool()
         observer = MockActorToolObserver()

--- a/tests/test_planning_semantic.py
+++ b/tests/test_planning_semantic.py
@@ -127,7 +127,6 @@ class TestPlanningToolObserverWiring:
     def test_observer_creates_vectorstore_and_plan_actors(self) -> None:
         """observer() must create VectorStoreActor with embedding fields, then PlanActor."""
         from akgentic.tool.planning.planning import PlanningTool
-        from akgentic.tool.vector_store.actor import VectorStoreActor
         from akgentic.tool.vector_store.protocol import VectorStoreConfig
 
         tool = PlanningTool(

--- a/tests/test_planning_semantic.py
+++ b/tests/test_planning_semantic.py
@@ -139,13 +139,14 @@ class TestPlanningToolObserverWiring:
         captured_configs: list[object] = []
 
         mock_proxy_ask = MagicMock()
-        mock_proxy_ask.get_team_member.return_value = None  # Force actor creation path
 
-        def capture_create_actor(actor_cls: type, config: object) -> MagicMock:
+        def capture_get_children_or_create(
+            actor_cls: type, config: object = None,
+        ) -> MagicMock:
             captured_configs.append(config)
             return MagicMock()
 
-        mock_proxy_ask.createActor.side_effect = capture_create_actor
+        mock_proxy_ask.getChildrenOrCreate.side_effect = capture_get_children_or_create
 
         mock_observer = MagicMock()
         mock_observer.orchestrator = MagicMock()


### PR DESCRIPTION
## Summary

Replace all check-then-create patterns (`get_team_member` + `createActor`) with the atomic `getChildrenOrCreate` method across 5 call sites in akgentic-tool:

- `KnowledgeGraphTool.observer()` -- VectorStoreActor and KnowledgeGraphActor creation
- `PlanningTool.observer()` -- VectorStoreActor and PlanActor creation (also renames `orchestrator_proxy_ask` to `orchestrator_proxy`)
- `ExecTool.observer()` -- SandboxActor creation (mode resolution moved before the call)
- `KnowledgeGraphActor._acquire_vs_proxy()` -- VectorStoreActor on-demand creation (eliminates timing-dependent degraded mode)
- `PlanActor._acquire_vs_proxy()` -- same pattern as KG actor

Updated 5 test files and 2 example files to use `getChildrenOrCreate` mock patterns. Code review fixes: removed unused imports (F401), fixed import sorting (I001), renamed test methods to snake_case (N802).

All 1145 tests pass. Ruff clean. Mypy clean (6 pre-existing weaviate stub errors excluded).

Closes #146
