### PR TITLE
Centralize embedding config in VectorStoreConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,6 @@ Custom planning configuration with semantic search:
 
 ```python
 PlanningTool(
-    embedding_model="text-embedding-3-small",
-    embedding_provider="openai",
     get_planning=GetPlanning(filter_by_agent=False),  # show all tasks, not just own
 )
 ```

--- a/examples/planning_agent.py
+++ b/examples/planning_agent.py
@@ -291,8 +291,6 @@ def main() -> None:
         get_planning=GetPlanning(filter_by_agent=True),
         get_planning_task=GetPlanningTask(),
         update_planning=UpdatePlanning(),
-        embedding_model="text-embedding-3-small",
-        embedding_provider="openai",
     )
     tool.observer(observer)
     print(f"Tool: {tool.name} — {tool.description}")

--- a/src/akgentic/tool/knowledge_graph/kg_tool.py
+++ b/src/akgentic/tool/knowledge_graph/kg_tool.py
@@ -10,7 +10,7 @@ Follows the same pattern as ``PlanningTool`` in akgentic.tool.planning.
 from __future__ import annotations
 
 import logging
-from typing import Callable, Literal
+from typing import Callable
 
 from pydantic import Field
 
@@ -105,8 +105,6 @@ class KnowledgeGraphTool(ToolCard):
         description="Search graph — TOOL_CALL + COMMAND by default",
     )
 
-    embedding_model: str = "text-embedding-3-small"
-    embedding_provider: Literal["openai", "azure"] = "openai"
     read_only: bool = False
 
     # ------------------------------------------------------------------
@@ -135,8 +133,6 @@ class KnowledgeGraphTool(ToolCard):
             config=VectorStoreConfig(
                 name=VS_ACTOR_NAME,
                 role=VS_ACTOR_ROLE,
-                embedding_model=self.embedding_model,
-                embedding_provider=self.embedding_provider,
             ),
         )
 

--- a/src/akgentic/tool/planning/planning.py
+++ b/src/akgentic/tool/planning/planning.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Callable, Literal
+from typing import Callable
 
 from pydantic import Field
 
@@ -75,14 +75,6 @@ class PlanningTool(ToolCard):
     get_planning_task: GetPlanningTask | bool = True
     update_planning: UpdatePlanning | bool = True
     search_planning: SearchPlanning | bool = True
-    embedding_model: str = Field(
-        default="text-embedding-3-small",
-        description="Embedding model passed through to PlanConfig for semantic task search",
-    )
-    embedding_provider: Literal["openai", "azure"] = Field(
-        default="openai",
-        description="Embedding provider passed through to PlanConfig for semantic task search",
-    )
 
     def observer(self, observer: ActorToolObserver) -> None:  # type: ignore[override]
         """Attach observer and set up the planning actor proxy.
@@ -104,8 +96,6 @@ class PlanningTool(ToolCard):
             config=VectorStoreConfig(
                 name=VS_ACTOR_NAME,
                 role=VS_ACTOR_ROLE,
-                embedding_model=self.embedding_model,
-                embedding_provider=self.embedding_provider,
             ),
         )
 

--- a/tests/test_kg_tool.py
+++ b/tests/test_kg_tool.py
@@ -245,14 +245,6 @@ class TestKnowledgeGraphToolDefaults:
         tool = KnowledgeGraphTool()
         assert tool.read_only is False
 
-    def test_default_embedding_model(self) -> None:
-        tool = KnowledgeGraphTool()
-        assert tool.embedding_model == "text-embedding-3-small"
-
-    def test_default_embedding_provider(self) -> None:
-        tool = KnowledgeGraphTool()
-        assert tool.embedding_provider == "openai"
-
 
 class TestKnowledgeGraphToolObserver:
     """observer() wiring — singleton actor creation (2.2)."""

--- a/tests/test_kg_tool.py
+++ b/tests/test_kg_tool.py
@@ -291,6 +291,39 @@ class TestKnowledgeGraphToolObserver:
 
         assert observer._orchestrator_proxy.getChildrenOrCreate.call_count == 2
 
+    def test_observer_passes_default_vectorstore_config(self) -> None:
+        """VectorStoreConfig uses centralized defaults (no embedding fields on KG tool)."""
+        from unittest.mock import MagicMock
+
+        from akgentic.tool.vector_store.protocol import VectorStoreConfig
+
+        tool = KnowledgeGraphTool()
+
+        captured_configs: list[object] = []
+
+        mock_proxy_ask = MagicMock()
+
+        def capture_get_children_or_create(
+            actor_cls: type, config: object = None,
+        ) -> MagicMock:
+            captured_configs.append(config)
+            return MagicMock()
+
+        mock_proxy_ask.getChildrenOrCreate.side_effect = capture_get_children_or_create
+
+        mock_observer = MagicMock()
+        mock_observer.orchestrator = MagicMock()
+        mock_observer.proxy_ask.return_value = mock_proxy_ask
+
+        tool.observer(mock_observer)
+
+        assert len(captured_configs) == 2
+
+        vs_config = captured_configs[0]
+        assert isinstance(vs_config, VectorStoreConfig)
+        assert vs_config.embedding_model == "text-embedding-3-small"
+        assert vs_config.embedding_provider == "openai"
+
 
 class TestKnowledgeGraphToolReadOnly:
     """read_only=True disables update_graph (2.9)."""

--- a/tests/test_planning_semantic.py
+++ b/tests/test_planning_semantic.py
@@ -84,40 +84,7 @@ class TestGetPlanningTaskIntNotFound:
 
 
 # ---------------------------------------------------------------------------
-# AC#8 — PlanningTool has embedding_model and embedding_provider fields
-# ---------------------------------------------------------------------------
-
-
-class TestPlanningToolFields:
-    """AC8: PlanningTool exposes embedding_model and embedding_provider Pydantic fields."""
-
-    def test_default_embedding_model(self) -> None:
-        from akgentic.tool.planning.planning import PlanningTool
-
-        tool = PlanningTool()
-        assert tool.embedding_model == "text-embedding-3-small"
-
-    def test_default_embedding_provider(self) -> None:
-        from akgentic.tool.planning.planning import PlanningTool
-
-        tool = PlanningTool()
-        assert tool.embedding_provider == "openai"
-
-    def test_custom_embedding_model(self) -> None:
-        from akgentic.tool.planning.planning import PlanningTool
-
-        tool = PlanningTool(embedding_model="text-embedding-ada-002")
-        assert tool.embedding_model == "text-embedding-ada-002"
-
-    def test_custom_embedding_provider_azure(self) -> None:
-        from akgentic.tool.planning.planning import PlanningTool
-
-        tool = PlanningTool(embedding_provider="azure")
-        assert tool.embedding_provider == "azure"
-
-
-# ---------------------------------------------------------------------------
-# AC#9 — PlanningTool.observer() passes PlanConfig with embedding fields
+# AC#9 — PlanningTool.observer() creates VectorStoreActor with default config
 # ---------------------------------------------------------------------------
 
 
@@ -125,16 +92,13 @@ class TestPlanningToolObserverWiring:
     """AC9/AC10: observer() creates VectorStoreActor and PlanActor with correct configs."""
 
     def test_observer_creates_vectorstore_and_plan_actors(self) -> None:
-        """observer() must create VectorStoreActor with embedding fields, then PlanActor."""
+        """observer() must create VectorStoreActor with defaults, then PlanActor."""
         from akgentic.tool.planning.planning import PlanningTool
         from akgentic.tool.vector_store.protocol import VectorStoreConfig
 
-        tool = PlanningTool(
-            embedding_model="text-embedding-ada-002",
-            embedding_provider="azure",
-        )
+        tool = PlanningTool()
 
-        # Capture configs passed to createActor calls
+        # Capture configs passed to getChildrenOrCreate calls
         captured_configs: list[object] = []
 
         mock_proxy_ask = MagicMock()
@@ -156,11 +120,11 @@ class TestPlanningToolObserverWiring:
         # Two actors created: VectorStoreActor first, PlanActor second
         assert len(captured_configs) == 2
 
-        # First: VectorStoreConfig with embedding fields
+        # First: VectorStoreConfig with defaults (embedding config centralized here)
         vs_config = captured_configs[0]
         assert isinstance(vs_config, VectorStoreConfig)
-        assert vs_config.embedding_model == "text-embedding-ada-002"
-        assert vs_config.embedding_provider == "azure"
+        assert vs_config.embedding_model == "text-embedding-3-small"
+        assert vs_config.embedding_provider == "openai"
 
         # Second: PlanConfig without embedding fields
         plan_config = captured_configs[1]


### PR DESCRIPTION
## Summary

- Remove `embedding_model` and `embedding_provider` fields from `KnowledgeGraphTool` and `PlanningTool` — embedding config is now centralized in `VectorStoreConfig` defaults
- Update `observer()` in both tools to pass only `name` and `role` to `VectorStoreConfig`
- Remove unused `Literal` import from both source files
- Remove obsolete embedding default tests and update observer wiring tests to verify centralized defaults
- Fix stale embedding kwargs in example and README

Closes #147
