### PR TITLE
ci: add release workflow + bump actions to Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout workspace
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: b12consulting/akgentic-quick-start
           submodules: recursive
@@ -27,7 +27,7 @@ jobs:
           git checkout FETCH_HEAD
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           version: "latest"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,69 @@
+name: Release
+
+# Manual release: reads version from pyproject.toml on master, tags master HEAD,
+# builds the wheel, and creates a GitHub Release with the wheel attached.
+#
+# Bumping the version is a separate maintainer action via a normal PR. This
+# workflow does NOT push commits to master — branch protection blocks that.
+# The release flow is therefore two-step:
+#   1. Open a "chore: bump version to X.Y.Z" PR; merge it.
+#   2. Trigger this workflow from the Actions tab.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout master
+        uses: actions/checkout@v6
+        with:
+          ref: master
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          version: "latest"
+
+      - name: Set up Python 3.12
+        run: uv python install 3.12
+
+      - name: Read version from pyproject.toml
+        id: version
+        run: |
+          VERSION=$(grep -E '^version = ' pyproject.toml | sed -E 's/version = "(.*)"/\1/')
+          echo "Releasing version: $VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Verify tag does not already exist
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          if git rev-parse "v$VERSION" >/dev/null 2>&1; then
+            echo "::error::Tag v$VERSION already exists. Bump the version in pyproject.toml first."
+            exit 1
+          fi
+
+      - name: Tag master HEAD
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag "v$VERSION"
+          git push origin "v$VERSION"
+
+      - name: Build wheel
+        run: uv build --wheel --out-dir dist/
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: "v${{ steps.version.outputs.version }}"
+          name: "v${{ steps.version.outputs.version }}"
+          files: dist/*.whl
+          generate_release_notes: true


### PR DESCRIPTION
## Summary

Two changes:
- Bump existing CI actions to Node 24-compatible versions (`actions/checkout@v4` -> `@v6`, `astral-sh/setup-uv@v4` -> `@v8.1.0`).
- Add `release.yml` — manual `workflow_dispatch` that reads the version from `pyproject.toml` on master, tags master HEAD with `vX.Y.Z`, builds the wheel, and creates a GitHub Release with the wheel attached.

Branch-protection-safe: the workflow does not commit to master. Bumping the version is a separate maintainer step via a normal PR.

Implements ADR-007 (wheel distribution via per-submodule GitHub releases). Pattern validated end-to-end on `akgentic-core` (release v1.0.0-alpha.1 published).

Closes #161