### PR TITLE
chore: bump version to 1.0.0-alpha.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akgentic-tool"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 description = "Tool interface and factory for Akgentic agent systems"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Bumps pyproject.toml version 1.0.0-alpha.1 → 1.0.0-alpha.2 in lockstep with the other 7 akgentic submodules.

Closes #165