### PR TITLE
refactor: drop unused ToolCard.name and description fields

### DIFF
--- a/examples/knowledge_agent.py
+++ b/examples/knowledge_agent.py
@@ -108,7 +108,9 @@ class _OrchestratorStub:
         self._vs_addr = _MockAddress("#VectorStore", "ToolActor")
 
     def getChildrenOrCreate(  # noqa: N802
-        self, actor_class: type, config: object = None,
+        self,
+        actor_class: type,
+        config: object = None,
     ) -> ActorAddress:
         """Return KG addr for KG actors, VS addr for VectorStore actors."""
         from akgentic.tool.vector_store.actor import VectorStoreActor
@@ -157,7 +159,7 @@ class _ExampleObserver:
         if actor == self._orchestrator_addr:
             return _OrchestratorStub(self._kg_addr)
         # Return mock for VectorStoreActor proxy
-        if hasattr(actor, 'name') and actor.name == "#VectorStore":
+        if hasattr(actor, "name") and actor.name == "#VectorStore":
             from unittest.mock import MagicMock
 
             return MagicMock()
@@ -363,7 +365,7 @@ def main() -> None:
         search=True,
     )
     tool.observer(observer)
-    print(f"Tool: {tool.name} — {tool.description}")
+    print(f"Tool: {type(tool).__name__}")
 
     # Access the underlying actor via observer for direct calls
     kg_actor = observer._kg_actor

--- a/examples/planning_agent.py
+++ b/examples/planning_agent.py
@@ -106,7 +106,9 @@ class _OrchestratorStub:
         self._vs_addr = _MockAddress("#VectorStore", "ToolActor")
 
     def getChildrenOrCreate(  # noqa: N802
-        self, actor_class: type, config: object = None,
+        self,
+        actor_class: type,
+        config: object = None,
     ) -> ActorAddress:
         """Return plan addr for PlanActor, VS addr for VectorStore actors."""
         from akgentic.tool.vector_store.actor import VectorStoreActor
@@ -127,10 +129,12 @@ class _ExampleObserver:
         self.events: list[object] = []
         self._address = _MockAddress("planning-agent")
         self._orchestrator_addr = _MockAddress("orchestrator")
-        self._plan_actor = PlanActor(config=PlanConfig(
-            name=PLANNING_ACTOR_NAME,
-            role=PLANNING_ACTOR_ROLE,
-        ))
+        self._plan_actor = PlanActor(
+            config=PlanConfig(
+                name=PLANNING_ACTOR_NAME,
+                role=PLANNING_ACTOR_ROLE,
+            )
+        )
         self._plan_actor.on_start()
         self._plan_addr = _MockAddress(PLANNING_ACTOR_NAME, PLANNING_ACTOR_ROLE)
 
@@ -158,7 +162,7 @@ class _ExampleObserver:
         if actor == self._orchestrator_addr:
             return _OrchestratorStub(self._plan_addr)
         # Return mock for VectorStoreActor proxy
-        if hasattr(actor, 'name') and actor.name == "#VectorStore":
+        if hasattr(actor, "name") and actor.name == "#VectorStore":
             from unittest.mock import MagicMock
 
             return MagicMock()
@@ -293,7 +297,7 @@ def main() -> None:
         update_planning=UpdatePlanning(),
     )
     tool.observer(observer)
-    print(f"Tool: {tool.name} — {tool.description}")
+    print(f"Tool: {type(tool).__name__}")
 
     # Access the underlying actor via observer for direct calls
     plan_actor = observer._plan_actor

--- a/src/akgentic/tool/core.py
+++ b/src/akgentic/tool/core.py
@@ -105,15 +105,10 @@ class ToolCard(SerializableBaseModel, ABC):
     """Abstract base: tool configuration + callable factory in one class.
 
     Subclasses define typed fields for their capabilities and implement
-    the factory methods that produce LLM-callable functions.
-
-    Attributes:
-        name: Human-readable tool provider name.
-        description: Natural-language description of tool capabilities.
+    the factory methods that produce LLM-callable functions. Identity and
+    human-readable description live on the catalog ``Entry`` envelope, not
+    on the card payload.
     """
-
-    name: str
-    description: str
 
     @property
     def depends_on(self) -> list[str]:
@@ -212,8 +207,7 @@ def _topological_sort(cards: list[ToolCard]) -> list[ToolCard]:
         for dep in card.depends_on:
             if dep not in by_name:
                 raise ValueError(
-                    f"{type(card).__name__} depends on {dep} but it was not "
-                    f"found in the tool list"
+                    f"{type(card).__name__} depends on {dep} but it was not found in the tool list"
                 )
 
     # Build in-degree map keyed by class name (not instance — duplicates collapse).
@@ -249,9 +243,7 @@ def _topological_sort(cards: list[ToolCard]) -> list[ToolCard]:
 
     if len(ordered_names) < len(by_name):
         remaining = sorted(set(by_name) - set(ordered_names))
-        raise ValueError(
-            f"ToolCard dependency cycle detected: {remaining}"
-        )
+        raise ValueError(f"ToolCard dependency cycle detected: {remaining}")
 
     # Map sorted names back to ToolCard instances. Preserve input order for
     # duplicate class names: emit instances in the order they appeared in the

--- a/src/akgentic/tool/knowledge_graph/kg_tool.py
+++ b/src/akgentic/tool/knowledge_graph/kg_tool.py
@@ -90,9 +90,6 @@ class KnowledgeGraphTool(ToolCard):
     this tool only looks it up at actor-start time.
     """
 
-    name: str = "KnowledgeGraph"
-    description: str = "Knowledge graph tool for structured knowledge with semantic search"
-
     vector_store: bool | str = Field(
         default=True,
         description=(

--- a/src/akgentic/tool/mcp/mcp.py
+++ b/src/akgentic/tool/mcp/mcp.py
@@ -230,11 +230,7 @@ async def list_mcp_tools(connection: MCPConnectionConfig) -> list[str]:
         ImportError: If pydantic-ai MCP extras are not installed.
         Exception: If connection fails or server is unreachable.
     """
-    tool = MCPTool(
-        name="mcp-probe",
-        description="Probe MCP endpoint",
-        connection=connection,
-    )
+    tool = MCPTool(connection=connection)
     print("## Creating MCP toolset for diagnostics...")
     toolsets = tool.get_toolsets()
     if not toolsets:

--- a/src/akgentic/tool/planning/planning.py
+++ b/src/akgentic/tool/planning/planning.py
@@ -70,9 +70,6 @@ class PlanningTool(ToolCard):
     time.
     """
 
-    name: str = "Planning"
-    description: str = "Planning tool to manage team plans and tasks"
-
     vector_store: bool | str = Field(
         default=True,
         description=(

--- a/src/akgentic/tool/sandbox/tool.py
+++ b/src/akgentic/tool/sandbox/tool.py
@@ -110,8 +110,6 @@ class ExecCommand(BaseToolParam):
 class ExecTool(ToolCard):
     """ToolCard proxy that routes shell commands to the team's SandboxActor."""
 
-    name: str = "Exec"
-    description: str = "Execute sandboxed shell commands in the team workspace"
     exec_command: ExecCommand | bool = True
     mode: Literal["local", "bwrap", "seatbelt", "docker", "auto"] = "auto"
     workspace_id: str | None = None

--- a/src/akgentic/tool/search/search.py
+++ b/src/akgentic/tool/search/search.py
@@ -60,9 +60,6 @@ class WebCrawl(BaseToolParam):
 class SearchTool(ToolCard):
     """Web search, fetch, and crawl capabilities via Tavily."""
 
-    name: str = "Web Search"
-    description: str = "Search the web for current information"
-
     web_search: WebSearch | bool = True
     web_crawl: WebCrawl | bool = True
     web_fetch: WebFetch | bool = True

--- a/src/akgentic/tool/team/team.py
+++ b/src/akgentic/tool/team/team.py
@@ -165,9 +165,6 @@ class TeamTool(ToolCard):
     - Role profiles system prompt: Available roles and descriptions
     """
 
-    name: str = "Team"
-    description: str = "Team management tool for hiring, firing, and team awareness"
-
     hire_team_members: HireTeamMember | bool = Field(
         default=True, description="Enable hiring team members (default: True)"
     )

--- a/src/akgentic/tool/vector_store/tool.py
+++ b/src/akgentic/tool/vector_store/tool.py
@@ -53,9 +53,6 @@ class VectorStoreTool(ToolCard):
         env vars.
     """
 
-    name: str = "VectorStore"
-    description: str = "Centralized vector storage and embedding service"
-
     vector_store_name: str = Field(
         default=VS_ACTOR_NAME,
         description="Singleton actor name (allows multiple named VectorStoreActor instances)",

--- a/src/akgentic/tool/workspace/tool.py
+++ b/src/akgentic/tool/workspace/tool.py
@@ -371,13 +371,6 @@ class WorkspaceTool(ToolCard):
     - ``DocumentReader(...)`` instance: custom extraction config (e.g. with LLM).
     """
 
-    name: str = "Workspace"
-    description: str = (
-        "Read, write, edit, and delete files in the team workspace. "
-        "Supports surgical find-and-replace, batch multi-edit, and unified diff patch. "
-        "For SWE agents with full file I/O access."
-    )
-
     # Read capability fields (formerly in WorkspaceReadTool)
     workspace_id: str | None = None
     workspace_read: WorkspaceRead | bool = True

--- a/tests/sandbox/test_exec_tool.py
+++ b/tests/sandbox/test_exec_tool.py
@@ -102,18 +102,6 @@ def test_sandbox_actor_classes_is_mutable_dict() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_exec_tool_name_default() -> None:
-    """AC2: ExecTool.name defaults to 'Exec'."""
-    tool = ExecTool()
-    assert tool.name == "Exec"
-
-
-def test_exec_tool_description_default() -> None:
-    """AC2: ExecTool.description is the expected string."""
-    tool = ExecTool()
-    assert tool.description == "Execute sandboxed shell commands in the team workspace"
-
-
 def test_exec_tool_exec_command_default_is_true() -> None:
     """AC2: ExecTool.exec_command defaults to True."""
     tool = ExecTool()
@@ -278,9 +266,7 @@ def test_exec_command_returns_formatted_output() -> None:
 
     # Replace proxy with a controlled mock
     mock_proxy = MagicMock(spec=SandboxActor)
-    mock_proxy.exec.return_value = ExecResult(
-        stdout="===== 5 passed =====", stderr="", exit_code=0
-    )
+    mock_proxy.exec.return_value = ExecResult(stdout="===== 5 passed =====", stderr="", exit_code=0)
     tool._sandbox_proxy = mock_proxy
 
     tools = tool.get_tools()

--- a/tests/test_kg_tool.py
+++ b/tests/test_kg_tool.py
@@ -150,7 +150,8 @@ class MockActorToolObserver:
 
         # getChildrenOrCreate returns VS addr for #VectorStore, KG addr for #KnowledgeGraphTool
         def _get_children_or_create(
-            actor_class: type, config: object = None,
+            actor_class: type,
+            config: object = None,
         ) -> MockActorAddress:
             from akgentic.tool.vector_store.actor import VectorStoreActor as _VSActor
 
@@ -227,14 +228,6 @@ class TestParamResolve:
 
 class TestKnowledgeGraphToolDefaults:
     """KnowledgeGraphTool field defaults (2.1)."""
-
-    def test_default_name(self) -> None:
-        tool = KnowledgeGraphTool()
-        assert tool.name == "KnowledgeGraph"
-
-    def test_default_description(self) -> None:
-        tool = KnowledgeGraphTool()
-        assert "knowledge graph" in tool.description.lower()
 
     def test_default_get_graph_is_true(self) -> None:
         tool = KnowledgeGraphTool()
@@ -630,7 +623,6 @@ class TestSearchFactory:
         assert "Alice" in result
 
 
-
 # ===========================================================================
 # Story 1.4 — _format_graph_summary and prompt config tests
 # ===========================================================================
@@ -642,29 +634,41 @@ def _build_summary_view() -> GraphView:
 
     entities = [
         Entity(
-            name="Product", entity_type="Component", description="Main product platform",
+            name="Product",
+            entity_type="Component",
+            description="Main product platform",
             is_root=True,
         ),
         Entity(
-            name="AuthService", entity_type="Service",
-            description="Central authentication service", is_root=True,
+            name="AuthService",
+            entity_type="Service",
+            description="Central authentication service",
+            is_root=True,
         ),
         Entity(
-            name="UserDB", entity_type="Database",
-            description="Primary user data store", is_root=True,
+            name="UserDB",
+            entity_type="Database",
+            description="Primary user data store",
+            is_root=True,
         ),
         Entity(name="Cache", entity_type="Component", description="Redis cache layer"),
         Entity(name="Logger", entity_type="Service", description="Logging service"),
     ]
     relations = [
         Relation(
-            from_entity="Product", to_entity="AuthService", relation_type="DEPENDS_ON",
+            from_entity="Product",
+            to_entity="AuthService",
+            relation_type="DEPENDS_ON",
         ),
         Relation(
-            from_entity="AuthService", to_entity="UserDB", relation_type="STORES_IN",
+            from_entity="AuthService",
+            to_entity="UserDB",
+            relation_type="STORES_IN",
         ),
         Relation(
-            from_entity="Product", to_entity="Cache", relation_type="CONNECTS_TO",
+            from_entity="Product",
+            to_entity="Cache",
+            relation_type="CONNECTS_TO",
         ),
     ]
     return GraphView(entities=entities, relations=relations)
@@ -692,9 +696,7 @@ class TestFormatGraphSummary:
 
     def test_schema_disabled(self) -> None:
         view = _build_summary_view()
-        result = KnowledgeGraphTool._format_graph_summary(
-            view, include_schema=False
-        )
+        result = KnowledgeGraphTool._format_graph_summary(view, include_schema=False)
         assert "Entity types:" not in result
         assert "Relation types:" not in result
         # Counts and roots still present
@@ -703,9 +705,7 @@ class TestFormatGraphSummary:
 
     def test_roots_disabled(self) -> None:
         view = _build_summary_view()
-        result = KnowledgeGraphTool._format_graph_summary(
-            view, include_roots=False
-        )
+        result = KnowledgeGraphTool._format_graph_summary(view, include_roots=False)
         assert "Root entities:" not in result
         assert "Product (Component)" not in result
         # Counts and schema still present
@@ -733,7 +733,8 @@ class TestFormatGraphSummary:
         # Build graph with many entities but few types
         entities = [
             Entity(
-                name=f"E{i}", entity_type="TypeA" if i % 2 == 0 else "TypeB",
+                name=f"E{i}",
+                entity_type="TypeA" if i % 2 == 0 else "TypeB",
                 description=f"Entity {i}",
             )
             for i in range(50)
@@ -741,7 +742,9 @@ class TestFormatGraphSummary:
         entities[0].is_root = True
         relations = [
             Relation(
-                from_entity=f"E{i}", to_entity=f"E{i+1}", relation_type="REL",
+                from_entity=f"E{i}",
+                to_entity=f"E{i + 1}",
+                relation_type="REL",
             )
             for i in range(49)
         ]
@@ -769,17 +772,13 @@ class TestSystemPromptConfig:
     """Story 1.4 Task 4.3/4.5: prompt config passed through to summary."""
 
     def test_prompt_schema_disabled(self) -> None:
-        tool = KnowledgeGraphTool(
-            get_graph=GetGraph(prompt_include_schema=False)
-        )
+        tool = KnowledgeGraphTool(get_graph=GetGraph(prompt_include_schema=False))
         observer = MockActorToolObserver()
         actor = observer.setup_kg_actor()
         actor.update_graph(
             ManageGraph(
                 create_entities=[
-                    EntityCreate(
-                        name="X", entity_type="T", description="d", is_root=True
-                    ),
+                    EntityCreate(name="X", entity_type="T", description="d", is_root=True),
                 ]
             )
         )
@@ -790,17 +789,13 @@ class TestSystemPromptConfig:
         assert "Entities: 1" in result
 
     def test_prompt_roots_disabled(self) -> None:
-        tool = KnowledgeGraphTool(
-            get_graph=GetGraph(prompt_include_roots=False)
-        )
+        tool = KnowledgeGraphTool(get_graph=GetGraph(prompt_include_roots=False))
         observer = MockActorToolObserver()
         actor = observer.setup_kg_actor()
         actor.update_graph(
             ManageGraph(
                 create_entities=[
-                    EntityCreate(
-                        name="X", entity_type="T", description="d", is_root=True
-                    ),
+                    EntityCreate(name="X", entity_type="T", description="d", is_root=True),
                 ]
             )
         )
@@ -871,9 +866,7 @@ class TestKnowledgeGraphToolCollectionField:
 class TestKnowledgeGraphToolObserverCollection:
     """AC-4: observer() propagates the exact ``collection`` into ``KnowledgeGraphConfig``."""
 
-    def _run_observer(
-        self, tool: KnowledgeGraphTool
-    ) -> list[KnowledgeGraphConfig]:
+    def _run_observer(self, tool: KnowledgeGraphTool) -> list[KnowledgeGraphConfig]:
         captured: list[KnowledgeGraphConfig] = []
         mock_proxy = MagicMock()
 
@@ -1031,7 +1024,8 @@ class TestKnowledgeGraphToolObserverSearchFields:
     """AC-2: observer() propagates search_top_k and search_score_threshold."""
 
     def _run_observer(
-        self, tool: KnowledgeGraphTool,
+        self,
+        tool: KnowledgeGraphTool,
     ) -> list[KnowledgeGraphConfig]:
         from unittest.mock import MagicMock
 
@@ -1063,5 +1057,3 @@ class TestKnowledgeGraphToolObserverSearchFields:
         assert len(captured) == 1
         assert captured[0].search_top_k == 15
         assert captured[0].search_score_threshold == 0.4
-
-

--- a/tests/vector_store/test_tool.py
+++ b/tests/vector_store/test_tool.py
@@ -88,8 +88,8 @@ class _MockActorToolObserver:
         self._orchestrator: ActorAddress | None = _MockActorAddress("orchestrator")
         self._orchestrator_proxy = MagicMock(spec=Orchestrator)
         # Default: return a fresh address whenever getChildrenOrCreate is called
-        self._orchestrator_proxy.getChildrenOrCreate.side_effect = (
-            lambda actor_cls, config=None: _MockActorAddress(
+        self._orchestrator_proxy.getChildrenOrCreate.side_effect = lambda actor_cls, config=None: (
+            _MockActorAddress(
                 getattr(config, "name", "unknown"),
                 getattr(config, "role", VS_ACTOR_ROLE),
             )
@@ -127,14 +127,6 @@ class TestVectorStoreToolDefaults:
 
     def test_is_tool_card(self) -> None:
         assert issubclass(VectorStoreTool, ToolCard)
-
-    def test_default_name(self) -> None:
-        tool = VectorStoreTool()
-        assert tool.name == "VectorStore"
-
-    def test_default_description(self) -> None:
-        tool = VectorStoreTool()
-        assert tool.description == "Centralized vector storage and embedding service"
 
     def test_default_vector_store_name_matches_singleton_constant(self) -> None:
         tool = VectorStoreTool()
@@ -377,8 +369,6 @@ class TestVectorStoreToolSerialization:
         assert restored.embedding_model == "text-embedding-3-large"
         assert restored.embedding_provider == "azure"
         assert restored.vector_store_name == "#VectorStore-RAG"
-        assert restored.name == original.name
-        assert restored.description == original.description
 
     def test_dumped_payload_contains_all_fields(self) -> None:
         original = VectorStoreTool(
@@ -387,8 +377,6 @@ class TestVectorStoreToolSerialization:
             vector_store_name="#VectorStore-RAG",
         )
         dumped = original.model_dump()
-        assert dumped["name"] == "VectorStore"
-        assert dumped["description"] == "Centralized vector storage and embedding service"
         assert dumped["vector_store_name"] == "#VectorStore-RAG"
         assert dumped["embedding_model"] == "text-embedding-3-large"
         assert dumped["embedding_provider"] == "azure"

--- a/tests/workspace/test_read_tool.py
+++ b/tests/workspace/test_read_tool.py
@@ -60,7 +60,6 @@ def make_tool(tmp_path: Path, team_id: uuid.UUID | None = None) -> WorkspaceTool
 class TestWorkspaceReadToolFields:
     def test_default_fields(self) -> None:
         tool = WorkspaceTool(read_only=True)
-        assert tool.name == "Workspace"
         assert tool.workspace_id is None
         assert tool.workspace_read is True
         assert tool.workspace_list is True
@@ -1165,7 +1164,10 @@ class TestWorkspaceToolSerialization:
 
     def test_document_reader_false_in_dump(self) -> None:
         """document_reader=False serializes as False."""
-        assert WorkspaceTool(read_only=True, document_reader=False).model_dump()["document_reader"] is False
+        assert (
+            WorkspaceTool(read_only=True, document_reader=False).model_dump()["document_reader"]
+            is False
+        )
 
     def test_document_reader_instance_in_dump(self) -> None:
         """DocumentReader instance serializes to its model_dump() dict."""
@@ -1177,7 +1179,9 @@ class TestWorkspaceToolSerialization:
 
     def test_model_validate_roundtrip_with_document_reader(self) -> None:
         """model_dump -> model_validate round-trips with DocumentReader."""
-        original = WorkspaceTool(read_only=True, document_reader=DocumentReader(llm_client="openai"))
+        original = WorkspaceTool(
+            read_only=True, document_reader=DocumentReader(llm_client="openai")
+        )
         restored = WorkspaceTool.model_validate(original.model_dump())
         assert isinstance(restored.document_reader, DocumentReader)
         assert restored.document_reader.llm_client == "openai"
@@ -1190,9 +1194,7 @@ class TestDocumentReaderLazyInit:
         """No llm_client -> _get_openai_client() returns None."""
         assert DocumentReader()._get_openai_client() is None
 
-    @pytest.mark.skipif(
-        not os.environ.get("OPENAI_API_KEY"), reason="requires OPENAI_API_KEY"
-    )
+    @pytest.mark.skipif(not os.environ.get("OPENAI_API_KEY"), reason="requires OPENAI_API_KEY")
     def test_get_openai_client_lazy_creation(self) -> None:
         """llm_client='openai' -> lazily constructs OpenAI() on first call."""
         reader = DocumentReader(llm_client="openai")
@@ -1204,9 +1206,7 @@ class TestDocumentReaderLazyInit:
         assert result is not None
         assert reader._openai_client is result
 
-    @pytest.mark.skipif(
-        not os.environ.get("OPENAI_API_KEY"), reason="requires OPENAI_API_KEY"
-    )
+    @pytest.mark.skipif(not os.environ.get("OPENAI_API_KEY"), reason="requires OPENAI_API_KEY")
     def test_get_openai_client_cached(self) -> None:
         """Second _get_openai_client() call reuses cached client."""
         reader = DocumentReader(llm_client="openai")

--- a/tests/workspace/test_workspace_tool.py
+++ b/tests/workspace/test_workspace_tool.py
@@ -79,7 +79,9 @@ class TestGetToolsDefault:
         """By default, get_tools() returns all 11 tool callables."""
         tool, _ = make_wired_tool(tmp_path)
         tools = tool.get_tools()
-        assert len(tools) == 11  # read, list, glob, grep, view, write, delete, edit, multi_edit, patch, mkdir
+        assert (
+            len(tools) == 11
+        )  # read, list, glob, grep, view, write, delete, edit, multi_edit, patch, mkdir
 
     def test_default_includes_all_read_tools(self, tmp_path: Path) -> None:
         tool, _ = make_wired_tool(tmp_path)
@@ -234,9 +236,7 @@ class TestCapabilityToggling:
         assert "workspace_delete" in names
         assert len(tools) == 10
 
-    def test_both_write_and_delete_disabled_returns_nine_tools(
-        self, tmp_path: Path
-    ) -> None:
+    def test_both_write_and_delete_disabled_returns_nine_tools(self, tmp_path: Path) -> None:
         """WorkspaceTool(workspace_write=False, workspace_delete=False) returns 9 tools."""
         observer, fs = make_observer(tmp_path)
         with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
@@ -368,10 +368,12 @@ class TestWorkspaceMultiEdit:
         fs.write("a.py", b"x = 1\n")
         fs.write("b.py", b"y = 2\n")
         multi_fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_multi_edit")
-        result = multi_fn([
-            EditItem(path="a.py", old_string="x = 1", new_string="x = 10"),
-            EditItem(path="b.py", old_string="y = 2", new_string="y = 20"),
-        ])
+        result = multi_fn(
+            [
+                EditItem(path="a.py", old_string="x = 1", new_string="x = 10"),
+                EditItem(path="b.py", old_string="y = 2", new_string="y = 20"),
+            ]
+        )
         assert b"x = 10" in fs.read("a.py")
         assert b"y = 20" in fs.read("b.py")
         assert isinstance(result, str)
@@ -386,14 +388,16 @@ class TestWorkspaceMultiEdit:
         fs.write("b.py", b"y = 2\n")
         fs.write("c.py", b"z = 3\n")
         multi_fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_multi_edit")
-        result = multi_fn([
-            EditItem(path="a.py", old_string="x = 1", new_string="x = 10"),
-            EditItem(path="b.py", old_string="DOES NOT EXIST", new_string="whatever"),
-            EditItem(path="c.py", old_string="z = 3", new_string="z = 30"),
-        ])
-        assert b"x = 10" in fs.read("a.py")   # first edit applied
-        assert b"y = 2" in fs.read("b.py")    # second not changed (just the error)
-        assert b"z = 3" in fs.read("c.py")    # third never reached
+        result = multi_fn(
+            [
+                EditItem(path="a.py", old_string="x = 1", new_string="x = 10"),
+                EditItem(path="b.py", old_string="DOES NOT EXIST", new_string="whatever"),
+                EditItem(path="c.py", old_string="z = 3", new_string="z = 30"),
+            ]
+        )
+        assert b"x = 10" in fs.read("a.py")  # first edit applied
+        assert b"y = 2" in fs.read("b.py")  # second not changed (just the error)
+        assert b"z = 3" in fs.read("c.py")  # third never reached
         assert result.startswith("[ERROR]")
 
     def test_multi_edit_replace_all_in_item(self, tmp_path: Path) -> None:
@@ -403,9 +407,11 @@ class TestWorkspaceMultiEdit:
         tool, fs = make_wired_tool(tmp_path)
         fs.write("a.py", b"foo\nfoo\nfoo\n")
         multi_fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_multi_edit")
-        result = multi_fn([
-            EditItem(path="a.py", old_string="foo", new_string="bar", replace_all=True),
-        ])
+        result = multi_fn(
+            [
+                EditItem(path="a.py", old_string="foo", new_string="bar", replace_all=True),
+            ]
+        )
         content = fs.read("a.py").decode("utf-8")
         assert content.count("bar") == 3
         assert "foo" not in content
@@ -419,9 +425,13 @@ class TestWorkspaceMultiEdit:
         tool, fs = make_wired_tool(tmp_path)
         fs.write("a.py", b"hello world\n")
         multi_fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_multi_edit")
-        result = multi_fn([
-            EditItem(path="a.py", old_string="xyz not here", new_string="anything", replace_all=True),  # noqa: E501
-        ])
+        result = multi_fn(
+            [
+                EditItem(
+                    path="a.py", old_string="xyz not here", new_string="anything", replace_all=True
+                ),  # noqa: E501
+            ]
+        )
         assert result.startswith("[ERROR]")
         assert "a.py" in result
 
@@ -452,13 +462,7 @@ class TestWorkspacePatch:
     def test_patch_add_new_file(self, tmp_path: Path) -> None:
         """workspace_patch creates a new file from --- /dev/null patch."""
         tool, fs = make_wired_tool(tmp_path)
-        patch_text = (
-            "--- /dev/null\n"
-            "+++ b/new_file.py\n"
-            "@@ -0,0 +1,2 @@\n"
-            "+line1\n"
-            "+line2\n"
-        )
+        patch_text = "--- /dev/null\n+++ b/new_file.py\n@@ -0,0 +1,2 @@\n+line1\n+line2\n"
         patch_fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_patch")
         result = patch_fn(patch_text)
         assert "created: new_file.py" in result
@@ -486,12 +490,7 @@ class TestWorkspacePatch:
         """workspace_patch deletes a file from +++ /dev/null patch."""
         tool, fs = make_wired_tool(tmp_path)
         fs.write("old_file.py", b"to be deleted\n")
-        patch_text = (
-            "--- a/old_file.py\n"
-            "+++ /dev/null\n"
-            "@@ -1 +0,0 @@\n"
-            "-to be deleted\n"
-        )
+        patch_text = "--- a/old_file.py\n+++ /dev/null\n@@ -1 +0,0 @@\n-to be deleted\n"
         patch_fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_patch")
         result = patch_fn(patch_text)
         assert "deleted: old_file.py" in result
@@ -501,13 +500,7 @@ class TestWorkspacePatch:
         """workspace_patch returns [ERROR] when apply_file_patch raises an exception."""
         tool, fs = make_wired_tool(tmp_path)
         # Patch references a non-existent file — apply_file_patch will raise FileNotFoundError
-        patch_text = (
-            "--- a/missing.py\n"
-            "+++ b/missing.py\n"
-            "@@ -1,1 +1,1 @@\n"
-            "-old line\n"
-            "+new line\n"
-        )
+        patch_text = "--- a/missing.py\n+++ b/missing.py\n@@ -1,1 +1,1 @@\n-old line\n+new line\n"
         patch_fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_patch")
         result = patch_fn(patch_text)
         assert result.startswith("[ERROR]")
@@ -720,14 +713,6 @@ class TestRetriableErrorWorkspaceTool:
 class TestReadOnlyParameter:
     """Tests for WorkspaceTool.read_only field (story 7.1 ACs 3, 4, 5, 6, 7)."""
 
-    def test_name_is_workspace(self) -> None:
-        """AC 6: WorkspaceTool(read_only=True).name == 'Workspace'."""
-        assert WorkspaceTool(read_only=True).name == "Workspace"
-
-    def test_name_default_is_workspace(self) -> None:
-        """AC 6: WorkspaceTool().name == 'Workspace'."""
-        assert WorkspaceTool().name == "Workspace"
-
     def test_read_only_default_is_false(self) -> None:
         """AC 1: Default read_only is False."""
         assert WorkspaceTool().read_only is False
@@ -780,7 +765,6 @@ class TestReadOnlyParameter:
         dumped = original.model_dump()
         restored = WorkspaceTool.model_validate(dumped)
         assert restored.read_only is True
-        assert restored.name == "Workspace"
 
     def test_model_dump_roundtrip_read_only_false(self) -> None:
         """AC 5: WorkspaceTool(read_only=False).model_dump() round-trips."""
@@ -788,7 +772,6 @@ class TestReadOnlyParameter:
         dumped = original.model_dump()
         restored = WorkspaceTool.model_validate(dumped)
         assert restored.read_only is False
-        assert restored.name == "Workspace"
 
     def test_read_only_in_model_dump(self) -> None:
         """AC 5: read_only field appears in model_dump() output."""
@@ -817,9 +800,9 @@ class TestReadOnlyParameter:
         observer, fs = make_observer(tmp_path)
         tool = WorkspaceTool(
             read_only=True,
-            workspace_write=True,   # explicitly enabled
+            workspace_write=True,  # explicitly enabled
             workspace_delete=True,  # explicitly enabled
-            workspace_edit=True,    # explicitly enabled
+            workspace_edit=True,  # explicitly enabled
         )
         with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
             tool.observer(observer)
@@ -900,9 +883,7 @@ class TestWorkspaceGlob:
         assert "src/foo.py" in result
         assert "src/bar.py" in result
 
-    def test_invalid_pattern_double_star_no_slash_does_not_raise(
-        self, tmp_path: Path
-    ) -> None:
+    def test_invalid_pattern_double_star_no_slash_does_not_raise(self, tmp_path: Path) -> None:
         """workspace_glob normalizes '**.py' instead of crashing with ValueError."""
         tool, fs = make_wired_tool(tmp_path)
         fs.write("src/foo.py", b"x")


### PR DESCRIPTION
## Summary

- Remove `name` and `description` from `ToolCard` and all 7 subclasses (search, workspace, planning, knowledge_graph, sandbox, vector_store, team).
- Drop the `name=`/`description=` kwargs at the MCP diagnostic helper site.
- Clean up test assertions and example prints that read these defaults.

These fields had no runtime consumer. The catalog `Entry` envelope already carries `description` (and `id`), which is what every consumer actually reads — CLI listing, search filter, namespace export, serialization. The duplication between card payload and catalog envelope is removed so the boundary stays clean: **card payloads carry behavior fields; the catalog envelope carries metadata**.

YAML catalog payloads under `data/catalog/global/tool/*.yaml` still carry stale `name:` keys; Pydantic's default `extra="ignore"` drops them silently, so loading is unaffected. Housekeeping for those lives in the root repo and will land separately.

Closes #167