### PR TITLE
feat(akgentic-tool): epic 19 — Workspace Resource Seeding (19-1-resource-model-and-resourcetype-encoding → 19-3-seed-declared-resources-at-workspacetool-startup)

### DIFF
--- a/src/akgentic/tool/workspace/__init__.py
+++ b/src/akgentic/tool/workspace/__init__.py
@@ -19,6 +19,8 @@ from akgentic.tool.workspace.readers import (
 )
 from akgentic.tool.workspace.tool import (
     ExpandMediaRefs,
+    Resource,
+    ResourceType,
     WorkspaceDelete,
     WorkspaceEdit,
     WorkspaceGlob,
@@ -58,6 +60,8 @@ __all__ = [
     "Workspace",
     "get_workspace",
     "ExpandMediaRefs",
+    "Resource",
+    "ResourceType",
     "WorkspaceView",
     "WorkspaceRead",
     "WorkspaceList",

--- a/src/akgentic/tool/workspace/tool.py
+++ b/src/akgentic/tool/workspace/tool.py
@@ -437,6 +437,11 @@ class WorkspaceTool(ToolCard):
     workspace_patch: WorkspacePatch | bool = True
     workspace_mkdir: WorkspaceMkdir | bool = True
 
+    resources: list[Resource] = []
+    """Files seeded into the team workspace at observer() time, before the
+    agent's first turn. Each resource is written only if its path does not
+    already exist — restoring a team never clobbers edited files."""
+
     # Private runtime state — not part of the serialised config.
     # Default None sentinel lets the workspace property detect uninitialized state
     # reliably under both normal execution and coverage instrumentation.
@@ -461,7 +466,20 @@ class WorkspaceTool(ToolCard):
         self._observer = observer
         ws_name = self.workspace_id or str(observer.team_id)
         self._workspace = get_workspace(ws_name)
+        self._seed_resources()
         return self
+
+    def _seed_resources(self) -> None:
+        """Write each configured resource that is not already present.
+
+        Idempotent: an existing file is never overwritten, so a team restore
+        cannot clobber edits made to a seeded file since team creation.
+        """
+        assert self._workspace is not None
+        for resource in self.resources:
+            if self._workspace.exists(resource.file_name):
+                continue
+            self._workspace.write(resource.file_name, resource.to_bytes())
 
     @property
     def workspace(self) -> Filesystem:

--- a/src/akgentic/tool/workspace/tool.py
+++ b/src/akgentic/tool/workspace/tool.py
@@ -12,17 +12,20 @@ The default ``read_only=False`` also includes write-side callables (``workspace_
 
 from __future__ import annotations
 
+import base64
 import difflib
 import io
 import re as _re
 import shutil
 import subprocess
+from enum import StrEnum
 from pathlib import Path, PurePosixPath
 from typing import Any, Callable
 
 from pydantic import PrivateAttr
 from pydantic_ai.messages import BinaryContent
 
+from akgentic.core.utils import SerializableBaseModel
 from akgentic.tool.core import COMMAND, TOOL_CALL, BaseToolParam, Channels, ToolCard, _resolve
 from akgentic.tool.errors import RetriableError
 from akgentic.tool.event import ActorToolObserver
@@ -356,6 +359,48 @@ class WorkspaceMkdir(BaseToolParam):
     """Create a directory (and parents) in the team workspace."""
 
     expose: set[Channels] = {TOOL_CALL}
+
+
+class ResourceType(StrEnum):
+    """Encoding of a seeded resource's ``content`` field.
+
+    Acts as the explicit encoding discriminator for a :class:`Resource`: it
+    decides how ``content`` is decoded into bytes (see :meth:`Resource.to_bytes`).
+    Encoding is always explicit — never inferred from the filename extension.
+    """
+
+    TEXT = "text"  # content is UTF-8 text, written verbatim
+    IMAGE = "image"  # content is base64-encoded binary, decoded before write
+
+
+class Resource(SerializableBaseModel):
+    """A file seeded into the team workspace at team-creation time.
+
+    Fully Pydantic-serializable: primitive fields plus a :class:`ResourceType`
+    ``StrEnum`` only, so it round-trips cleanly through ``model_dump`` /
+    ``model_validate``. The file extension lives in ``file_name`` (e.g.
+    ``logo.png``); ``file_type`` carries the encoding discriminator, not a MIME
+    type.
+    """
+
+    file_name: str
+    file_type: ResourceType = ResourceType.TEXT
+    content: str
+
+    def to_bytes(self) -> bytes:
+        """Decode ``content`` into the bytes to write to the workspace.
+
+        Returns:
+            ``base64.b64decode(content)`` when ``file_type`` is
+            :attr:`ResourceType.IMAGE`, else ``content.encode("utf-8")``.
+
+        Raises:
+            binascii.Error: If ``file_type`` is :attr:`ResourceType.IMAGE` and
+                ``content`` is not valid base64.
+        """
+        if self.file_type is ResourceType.IMAGE:
+            return base64.b64decode(self.content)
+        return self.content.encode("utf-8")
 
 
 class WorkspaceTool(ToolCard):

--- a/src/akgentic/tool/workspace/workspace.py
+++ b/src/akgentic/tool/workspace/workspace.py
@@ -41,6 +41,8 @@ class Workspace(Protocol):
 
     def mkdir(self, path: str) -> None: ...
 
+    def exists(self, path: str) -> bool: ...
+
 
 class Filesystem:
     """Local filesystem backend for a single team workspace.
@@ -142,6 +144,16 @@ class Filesystem:
         """
         resolved = self._validate_path(path)
         resolved.mkdir(parents=True, exist_ok=True)
+
+    def exists(self, path: str) -> bool:
+        """Return ``True`` if *path* exists inside the workspace.
+
+        Directories count as existing — :meth:`Path.exists` is not file-only.
+
+        Raises:
+            PermissionError: if *path* escapes the workspace root.
+        """
+        return self._validate_path(path).exists()
 
 
 def get_workspace(workspace_name: str) -> Filesystem:

--- a/tests/workspace/test_workspace_tool.py
+++ b/tests/workspace/test_workspace_tool.py
@@ -1104,3 +1104,134 @@ def test_resource_and_resourcetype_importable_from_public_api() -> None:
 
     assert PublicResource is Resource
     assert PublicResourceType is ResourceType
+
+
+# ---------------------------------------------------------------------------
+# Story 19.3: seed declared resources at WorkspaceTool startup (AC #1-#9)
+# ---------------------------------------------------------------------------
+
+
+def _seed_tool(
+    tmp_path: Path,
+    resources: list[Resource],
+) -> tuple[WorkspaceTool, Filesystem]:
+    """Wire a WorkspaceTool carrying *resources* to a real tmp Filesystem."""
+    observer, fs = make_observer(tmp_path)
+    with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
+        tool = WorkspaceTool(resources=resources)
+        tool.observer(observer)
+    return tool, fs
+
+
+class TestWorkspaceToolResourcesField:
+    """The `resources` field: default, typing, serialization (AC #1, #5)."""
+
+    def test_resources_defaults_to_empty_list(self) -> None:
+        """resources defaults to [] when not configured (AC #1, #5)."""
+        tool = WorkspaceTool()
+        assert tool.resources == []
+
+    def test_resources_round_trips_through_model_dump(self) -> None:
+        """A WorkspaceTool with resources round-trips identically (AC #1)."""
+        resources = [
+            Resource(file_name="notes.md", file_type=ResourceType.TEXT, content="hello"),
+            Resource(file_name="logo.png", file_type=ResourceType.IMAGE, content="QUJD"),
+        ]
+        tool = WorkspaceTool(resources=resources)
+        restored = WorkspaceTool.model_validate(tool.model_dump())
+        assert restored.resources == resources
+
+    def test_resources_serialize_as_plain_dicts(self) -> None:
+        """`resources` serializes to plain dicts — list[Resource] is serializable (AC #1)."""
+        resources = [
+            Resource(file_name="notes.md", file_type=ResourceType.TEXT, content="hello"),
+        ]
+        dumped = WorkspaceTool(resources=resources).model_dump()["resources"]
+        assert isinstance(dumped, list) and len(dumped) == 1
+        entry = dumped[0]
+        assert isinstance(entry, dict)
+        assert entry["file_name"] == "notes.md"
+        assert entry["file_type"] == "text"
+        assert entry["content"] == "hello"
+
+
+class TestWorkspaceToolSeedResources:
+    """observer() seeds declared resources into the workspace (AC #2-#8)."""
+
+    def test_observer_seeds_text_and_image_resources(self, tmp_path: Path) -> None:
+        """A TEXT resource lands as UTF-8, an IMAGE resource as decoded bytes (AC #2)."""
+        raw = b"\x89PNG\r\n\x1a\n"
+        encoded = base64.b64encode(raw).decode("ascii")
+        resources = [
+            Resource(file_name="notes.md", file_type=ResourceType.TEXT, content="héllo"),
+            Resource(file_name="logo.png", file_type=ResourceType.IMAGE, content=encoded),
+        ]
+        tool, fs = _seed_tool(tmp_path, resources)
+        assert fs.read("notes.md") == "héllo".encode("utf-8")
+        assert fs.read("logo.png") == raw
+
+    def test_observer_does_not_overwrite_existing_file(self, tmp_path: Path) -> None:
+        """A resource whose file_name already exists is preserved (AC #3)."""
+        observer, fs = make_observer(tmp_path)
+        fs.write("notes.md", b"original content")
+        resources = [Resource(file_name="notes.md", content="seeded content")]
+        with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
+            tool = WorkspaceTool(resources=resources)
+            tool.observer(observer)
+        assert fs.read("notes.md") == b"original content"
+
+    def test_observer_seeds_nested_path_creating_parents(self, tmp_path: Path) -> None:
+        """A nested file_name seeds with parent directories created (AC #4)."""
+        resources = [Resource(file_name="docs/spec.md", content="spec body")]
+        tool, fs = _seed_tool(tmp_path, resources)
+        assert fs.read("docs/spec.md") == b"spec body"
+
+    def test_observer_empty_resources_seeds_nothing(self, tmp_path: Path) -> None:
+        """Default empty resources → observer() seeds nothing (AC #5)."""
+        tool, fs = _seed_tool(tmp_path, [])
+        assert fs.list() == []
+
+    def test_observer_root_escaping_resource_raises_permission_error(
+        self, tmp_path: Path
+    ) -> None:
+        """A root-escaping file_name raises PermissionError out of observer() (AC #6)."""
+        observer, fs = make_observer(tmp_path)
+        resources = [Resource(file_name="../escape.txt", content="evil")]
+        with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
+            tool = WorkspaceTool(resources=resources)
+            with pytest.raises(PermissionError):
+                tool.observer(observer)
+
+    def test_observer_malformed_base64_image_raises_binascii_error(
+        self, tmp_path: Path
+    ) -> None:
+        """An IMAGE resource with malformed base64 raises binascii.Error (AC #7)."""
+        observer, fs = make_observer(tmp_path)
+        resources = [
+            Resource(file_name="logo.png", file_type=ResourceType.IMAGE, content="not!base64!")
+        ]
+        with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
+            tool = WorkspaceTool(resources=resources)
+            with pytest.raises(binascii.Error):
+                tool.observer(observer)
+
+    def test_observer_run_twice_preserves_existing_and_seeds_missing(
+        self, tmp_path: Path
+    ) -> None:
+        """A second observer() run preserves existing files, seeds still-missing ones (AC #8)."""
+        observer, fs = make_observer(tmp_path)
+        resources = [
+            Resource(file_name="kept.md", content="seeded once"),
+            Resource(file_name="later.md", content="later body"),
+        ]
+        with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
+            tool = WorkspaceTool(resources=resources)
+            tool.observer(observer)
+        # An agent/human edits the seeded file between team restores.
+        fs.write("kept.md", b"edited by agent")
+        # A team restore builds a fresh WorkspaceTool and re-runs observer().
+        with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
+            restored_tool = WorkspaceTool(resources=resources)
+            restored_tool.observer(observer)
+        assert fs.read("kept.md") == b"edited by agent"
+        assert fs.read("later.md") == b"later body"

--- a/tests/workspace/test_workspace_tool.py
+++ b/tests/workspace/test_workspace_tool.py
@@ -2,15 +2,24 @@
 
 from __future__ import annotations
 
+import base64
+import binascii
 import uuid
+from enum import StrEnum
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from akgentic.core.utils import SerializableBaseModel
 
 from akgentic.tool.errors import RetriableError
 from akgentic.tool.workspace.edit import EditItem
-from akgentic.tool.workspace.tool import WorkspaceTool, _normalize_glob_pattern
+from akgentic.tool.workspace.tool import (
+    Resource,
+    ResourceType,
+    WorkspaceTool,
+    _normalize_glob_pattern,
+)
 from akgentic.tool.workspace.workspace import Filesystem
 
 # ---------------------------------------------------------------------------
@@ -979,3 +988,84 @@ class TestFilesystemRootAbsolute:
         relative_base = str(tmp_path / "rel")
         fs = Filesystem(relative_base, "workspace")
         assert fs._root.is_absolute()
+
+
+# ---------------------------------------------------------------------------
+# Resource model and ResourceType encoding (Story 19.1, AC #1-#6)
+# ---------------------------------------------------------------------------
+
+
+class TestResourceType:
+    """ResourceType is a StrEnum with TEXT and IMAGE string members (AC #1)."""
+
+    def test_resourcetype_is_strenum(self) -> None:
+        """ResourceType members are str instances (StrEnum contract)."""
+        assert issubclass(ResourceType, StrEnum)
+        assert isinstance(ResourceType.TEXT, str)
+        assert isinstance(ResourceType.IMAGE, str)
+
+    def test_resourcetype_member_values(self) -> None:
+        """TEXT == 'text' and IMAGE == 'image'."""
+        assert ResourceType.TEXT.value == "text"
+        assert ResourceType.IMAGE.value == "image"
+
+
+class TestResourceModel:
+    """Resource construction, defaults, to_bytes, and serialization (AC #2-#5)."""
+
+    def test_construct_with_all_fields(self) -> None:
+        """Resource constructs with file_name, file_type, and content (AC #2)."""
+        res = Resource(file_name="logo.png", file_type=ResourceType.IMAGE, content="QUJD")
+        assert res.file_name == "logo.png"
+        assert res.file_type is ResourceType.IMAGE
+        assert res.content == "QUJD"
+
+    def test_file_type_defaults_to_text(self) -> None:
+        """file_type defaults to ResourceType.TEXT when omitted (AC #2)."""
+        res = Resource(file_name="notes.md", content="hello")
+        assert res.file_type is ResourceType.TEXT
+
+    def test_resource_is_serializable_base_model(self) -> None:
+        """Resource subclasses SerializableBaseModel (AC #2)."""
+        assert issubclass(Resource, SerializableBaseModel)
+
+    def test_to_bytes_text_returns_utf8(self) -> None:
+        """to_bytes() on a TEXT resource returns UTF-8 bytes of content (AC #3)."""
+        res = Resource(file_name="notes.md", file_type=ResourceType.TEXT, content="héllo")
+        assert res.to_bytes() == "héllo".encode("utf-8")
+
+    def test_to_bytes_image_returns_decoded_bytes(self) -> None:
+        """to_bytes() on an IMAGE resource returns base64-decoded bytes (AC #4)."""
+        raw = b"\x89PNG\r\n\x1a\n"
+        encoded = base64.b64encode(raw).decode("ascii")
+        res = Resource(file_name="logo.png", file_type=ResourceType.IMAGE, content=encoded)
+        assert res.to_bytes() == raw
+
+    def test_to_bytes_image_malformed_base64_raises(self) -> None:
+        """Malformed base64 content for an IMAGE resource raises binascii.Error (AC #4)."""
+        res = Resource(file_name="logo.png", file_type=ResourceType.IMAGE, content="not!base64!")
+        with pytest.raises(binascii.Error):
+            res.to_bytes()
+
+    def test_round_trip_text(self) -> None:
+        """A TEXT Resource round-trips through model_dump / model_validate (AC #5)."""
+        res = Resource(file_name="notes.md", file_type=ResourceType.TEXT, content="hello")
+        restored = Resource.model_validate(res.model_dump())
+        assert restored == res
+        assert restored.file_type is ResourceType.TEXT
+
+    def test_round_trip_image(self) -> None:
+        """An IMAGE Resource round-trips through model_dump / model_validate (AC #5)."""
+        res = Resource(file_name="logo.png", file_type=ResourceType.IMAGE, content="QUJD")
+        restored = Resource.model_validate(res.model_dump())
+        assert restored == res
+        assert restored.file_type is ResourceType.IMAGE
+
+
+def test_resource_and_resourcetype_importable_from_public_api() -> None:
+    """Resource and ResourceType import cleanly from akgentic.tool.workspace (AC #6)."""
+    from akgentic.tool.workspace import Resource as PublicResource
+    from akgentic.tool.workspace import ResourceType as PublicResourceType
+
+    assert PublicResource is Resource
+    assert PublicResourceType is ResourceType

--- a/tests/workspace/test_workspace_tool.py
+++ b/tests/workspace/test_workspace_tool.py
@@ -20,7 +20,7 @@ from akgentic.tool.workspace.tool import (
     WorkspaceTool,
     _normalize_glob_pattern,
 )
-from akgentic.tool.workspace.workspace import Filesystem
+from akgentic.tool.workspace.workspace import Filesystem, Workspace
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -598,6 +598,41 @@ class TestFilesystemMkdir:
         tool, fs = make_wired_tool(tmp_path)
         with pytest.raises(PermissionError):
             fs.mkdir("../../escape")
+
+
+# ---------------------------------------------------------------------------
+# Story 19.2: Filesystem.exists()
+# ---------------------------------------------------------------------------
+
+
+class TestFilesystemExists:
+    def test_exists_true_for_existing_file(self, tmp_path: Path) -> None:
+        """exists() returns True for a file that was written (AC #2)."""
+        tool, fs = make_wired_tool(tmp_path)
+        fs.write("notes/todo.txt", b"hello")
+        assert fs.exists("notes/todo.txt") is True
+
+    def test_exists_false_for_absent_path(self, tmp_path: Path) -> None:
+        """exists() returns False for a path that was never created (AC #3)."""
+        tool, fs = make_wired_tool(tmp_path)
+        assert fs.exists("missing.txt") is False
+
+    def test_exists_true_for_existing_directory(self, tmp_path: Path) -> None:
+        """exists() returns True for an existing directory (AC #4)."""
+        tool, fs = make_wired_tool(tmp_path)
+        fs.mkdir("src/utils")
+        assert fs.exists("src/utils") is True
+
+    def test_exists_traversal_raises(self, tmp_path: Path) -> None:
+        """exists() raises PermissionError for a root-escaping path (AC #5)."""
+        tool, fs = make_wired_tool(tmp_path)
+        with pytest.raises(PermissionError):
+            fs.exists("../escape")
+
+    def test_filesystem_satisfies_workspace_protocol(self, tmp_path: Path) -> None:
+        """Filesystem satisfies the runtime-checkable Workspace Protocol (AC #1)."""
+        tool, fs = make_wired_tool(tmp_path)
+        assert isinstance(fs, Workspace)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Epic 19 — Workspace Resource Seeding

Lets a `WorkspaceTool` carry a declarative list of `Resource` files (text and
base64-encoded images) seeded into the team workspace at team-creation time —
idempotently — with no change to `Filesystem` construction and no cross-package
dependency.

This is the umbrella PR for the epic. Stories land on this shared branch in order.

### Story checklist

- [x] `19-1-resource-model-and-resourcetype-encoding` (Relates to #169)
- [x] `19-2-filesystem-exists-workspace-primitive` (Relates to #171)
- [x] `19-3-seed-declared-resources-at-workspacetool-startup` (Relates to #172)

## Review status

**19-1-resource-model-and-resourcetype-encoding — DONE.**

Adversarial code review of commit `7739e52`:
- All 6 acceptance criteria implemented and verified.
- `ResourceType(StrEnum)` with `TEXT="text"` / `IMAGE="image"`.
- `Resource(SerializableBaseModel)` — primitives + `StrEnum` only, no
  `ConfigDict(arbitrary_types_allowed=True)`; `model_dump`/`model_validate`
  round-trip verified for both encodings.
- `to_bytes()` covers both branches (UTF-8 / base64) plus the malformed-base64
  `binascii.Error` path.
- `Resource` and `ResourceType` exported via `workspace/__init__.py` and `__all__`.
- No fix-worthy issues found — no review fixup commit required.

Local gate (CI policy: full local suite is the gate):
- `pytest packages/akgentic-tool/tests/` — 1358 passed.
- `mypy packages/akgentic-tool/src/` — no issues in 39 source files.
- `ruff check packages/akgentic-tool/src/` — all checks passed.

**19-2-filesystem-exists-workspace-primitive — DONE.**

Adversarial code review of commit `b5f2ba0`:
- All 7 acceptance criteria implemented and verified.
- `exists(self, path: str) -> bool` added to the `Workspace` Protocol.
- `Filesystem.exists()` is the one-line delegation `_validate_path(path).exists()`
  prescribed by ADR-026 — root-escaping paths raise `PermissionError` at the same
  boundary as every other operation.
- `Filesystem.__init__` and `_validate_path` unchanged (AC #6) — diff is purely
  additive.
- `TestFilesystemExists` covers existing file → `True`, absent path → `False`,
  existing directory → `True`, root-escaping path → `PermissionError`, and
  `isinstance(fs, Workspace)` against the runtime-checkable Protocol.
- No ADR-string assertions in tests. No fix-worthy issues — no review fixup commit.

Local gate:
- `pytest packages/akgentic-tool/tests/` — 1363 passed (1358 baseline + 5 new).
- `mypy packages/akgentic-tool/src/` — no issues in 39 source files.
- `ruff check packages/akgentic-tool/src/` — all checks passed.

**19-3-seed-declared-resources-at-workspacetool-startup — DONE.**

Adversarial code review of commit `71c36fd`:
- All 9 acceptance criteria implemented and verified.
- `resources: list[Resource] = []` added to `WorkspaceTool` — defaults to `[]`,
  fully serializable (`list` of `SerializableBaseModel`), no
  `ConfigDict(arbitrary_types_allowed=True)` introduced; runtime `_workspace`
  stays a `PrivateAttr`.
- `_seed_resources()` is the prescribed ADR-026 idempotent helper — writes a
  resource only when `exists()` is `False`, so a team restore never clobbers
  edited files. No directory-creation code (`Filesystem.write` creates parents),
  no exception wrapping (`PermissionError` / `binascii.Error` propagate).
- `observer()` change is the single `_seed_resources()` line after
  `get_workspace()` and before `return self` — no other line touched.
- `TestWorkspaceToolResourcesField` + `TestWorkspaceToolSeedResources` cover
  default `[]`, `model_dump()` round-trip, TEXT + IMAGE seeding, the
  no-overwrite/idempotent skip branch, nested-path parent creation, empty-list
  no-op, root-escape `PermissionError`, malformed-base64 `binascii.Error`, and
  the run-twice restore-safety case — both branches of the `exists()` skip
  exercised. Tests reuse the existing `make_observer` fixture per the story spec.
- No ADR-string assertions in tests. No fix-worthy issues — no review fixup commit.
- INFO (out of scope, no action): `WorkspaceTool` inherits
  `arbitrary_types_allowed=True` from its base `ToolCard`. This is pre-existing,
  not introduced by `71c36fd`. AC #1's serialization guarantee is verified
  behaviorally via the `model_dump()` round-trip test. Tightening the base-class
  config is a separate concern (one commit, one responsibility).

Local gate:
- `pytest packages/akgentic-tool/tests/` — 1373 passed (1363 baseline + 10 new).
- `mypy packages/akgentic-tool/src/` — no issues in 39 source files.
- `ruff check packages/akgentic-tool/src/` — all checks passed.

## Epic 19 slice complete

All 3 stories of Epic 19 have landed on this branch and passed adversarial review:

- **19-1** — `ResourceType` encoding enum and the `Resource` model with
  `to_bytes()` (UTF-8 for text, base64-decode for images).
- **19-2** — the `Filesystem.exists()` / `Workspace.exists()` Protocol primitive
  used to make seeding idempotent.
- **19-3** — the user-visible feature: a `WorkspaceTool` now carries a
  declarative `resources` list, seeded into the team workspace at `observer()`
  time before the agent's first turn, with no LLM tokens spent.

What the epic delivers: a team author can declare starter files (text and
images) on a `WorkspaceTool`; they materialise in the workspace at team creation
and are never clobbered on team restore. Backward compatible — `resources`
defaults to `[]`, so every existing `WorkspaceTool` caller is unaffected.
Contained entirely within `akgentic-tool`; `Filesystem` construction is
unchanged and there is no cross-package dependency.

## Scope guard

All changes in this PR stay inside `packages/akgentic-tool/`:
- `src/akgentic/tool/workspace/tool.py`
- `src/akgentic/tool/workspace/workspace.py`
- `src/akgentic/tool/workspace/__init__.py`
- `tests/workspace/test_workspace_tool.py`

No cross-submodule edits. `Filesystem.__init__` and `_validate_path` are untouched.
