### PR TITLE
docs: clarify TeamTool roster and role-profile prompt wording

### DIFF
--- a/src/akgentic/tool/team/team.py
+++ b/src/akgentic/tool/team/team.py
@@ -478,7 +478,9 @@ class TeamTool(ToolCard):
                 if not team_members_names:
                     return ""
 
-                return "**Team members:**\n" + "\n".join(team_members_names)
+                return "**Here is the team member list by name (and role):**\n" + "\n".join(
+                    team_members_names
+                )
             except Exception:
                 logger.error("Failed to get team roster", exc_info=True)
                 return "Cannot get team roster..."
@@ -518,7 +520,9 @@ class TeamTool(ToolCard):
                 if not profiles:
                     return ""
 
-                return "**Available team roles:**\n" + "\n".join(profiles)
+                return "**Here is the available team role list (for hiring):**\n" + "\n".join(
+                    profiles
+                )
             except Exception:
                 logger.error("Failed to get role profiles", exc_info=True)
                 return "Cannot get role profiles..."

--- a/tests/test_team_tool.py
+++ b/tests/test_team_tool.py
@@ -304,7 +304,7 @@ def test_team_roster_prompt():
 
     result = roster_prompt()
 
-    assert "Team members:" in result
+    assert "Here is the team member list by name (and role):" in result
     assert "@Manager (role: Manager)" in result
     assert "[you]" in result  # Current agent marked
     assert "@Developer (role: Developer)" in result
@@ -355,7 +355,7 @@ def test_role_profiles_prompt():
 
     result = profiles_prompt()
 
-    assert "Available team roles:" in result
+    assert "Here is the available team role list (for hiring):" in result
     assert "Developer: Writes code (Skills: python, testing)" in result
     assert "Tester: Tests code (Skills: selenium, pytest)" in result
 


### PR DESCRIPTION
Closes #175.

## What

Updates the two dynamic system prompts emitted by `TeamTool` so each list self-documents its purpose to the LLM:

| Prompt | Before | After |
|--------|--------|-------|
| Roster | `**Team members:**` | `**Here is the team member list by name (and role):**` |
| Profiles | `**Available team roles:**` | `**Here is the available team role list (for hiring):**` |

The role-profiles header now states the hiring affordance explicitly, since that list is what the agent draws from when calling `hire_members`.

## Scope

- `src/akgentic/tool/team/team.py` — both prompt factory functions.
- `tests/test_team_tool.py` — `test_team_roster_prompt` and `test_role_profiles_prompt` assertions updated to the new wording.

Member/role formatting, the `[you]` self-marker, and tool-actor exclusion are unchanged — this is prompt text only.

## Verification

`pytest packages/akgentic-tool/tests/test_team_tool.py` — 32 passed. `ruff check` and `ruff format --check` clean.