### PR TITLE
feat(akgentic-tool): epic 21 — Command channel registry, dispatch & discovery models (21-3, 21-2)

### DIFF
--- a/src/akgentic/tool/__init__.py
+++ b/src/akgentic/tool/__init__.py
@@ -15,6 +15,7 @@ from .core import (  # noqa: F401
     TOOL_CALL,
     BaseToolParam,
     Channels,
+    CommandRegistry,
     ToolCard,
     ToolFactory,
 )
@@ -46,6 +47,7 @@ __all__ = [
     "BaseToolParam",
     "ToolCard",
     "ToolFactory",
+    "CommandRegistry",
     # Expose channel constants
     "COMMAND",
     "SYSTEM_PROMPT",

--- a/src/akgentic/tool/__init__.py
+++ b/src/akgentic/tool/__init__.py
@@ -18,9 +18,12 @@ from .core import (  # noqa: F401
     ToolCard,
     ToolFactory,
 )
-from .errors import RetriableError  # noqa: F401
+from .errors import CommandNotRecognized, RetriableError  # noqa: F401
 from .event import (  # noqa: F401
     ActorToolObserver,
+    CommandArg,
+    CommandDescriptor,
+    CommandsAnnouncedEvent,
     TeamManagementToolObserver,
     ToolObserver,
     ToolStateEvent,
@@ -50,6 +53,7 @@ __all__ = [
     "Channels",
     # Errors
     "RetriableError",
+    "CommandNotRecognized",
     # Events and observers
     "ToolObserver",
     "ActorToolObserver",
@@ -57,6 +61,10 @@ __all__ = [
     "ToolStateEvent",
     "ToolStatePayload",
     "KnowledgeGraphStateEvent",
+    # Command discovery models
+    "CommandArg",
+    "CommandDescriptor",
+    "CommandsAnnouncedEvent",
     # Submodules
     "mcp",
     "planning",

--- a/src/akgentic/tool/core.py
+++ b/src/akgentic/tool/core.py
@@ -7,14 +7,20 @@ Defines the core contracts:
 """
 
 import functools
+import inspect
+import shlex
+import warnings
 from abc import ABC, abstractmethod
 from collections import deque
+from dataclasses import dataclass
 from enum import StrEnum
-from typing import Any, Callable, TypeVar
+from typing import Any, Callable, TypeVar, get_type_hints
+
+from pydantic import TypeAdapter
 
 from akgentic.core.utils import SerializableBaseModel
-from akgentic.tool.errors import RetriableError
-from akgentic.tool.event import ToolObserver
+from akgentic.tool.errors import CommandNotRecognized, RetriableError
+from akgentic.tool.event import CommandArg, CommandDescriptor, ToolObserver
 
 T = TypeVar("T", bound="BaseToolParam")
 
@@ -257,6 +263,227 @@ def _topological_sort(cards: list[ToolCard]) -> list[ToolCard]:
     return ordered
 
 
+@dataclass(frozen=True)
+class _CommandArgSpec:
+    """Ordered metadata + per-arg coercion adapter for one command parameter.
+
+    Runtime-only (not serialized). Captured from the callable signature at
+    registry-construction time. Drives both positional coercion (dispatch) and
+    :class:`CommandDescriptor` building.
+    """
+
+    name: str
+    annotation: Any
+    required: bool
+    adapter: TypeAdapter
+
+
+@dataclass(frozen=True)
+class _CommandEntry:
+    """Runtime record for a single registered command (not a serialized model).
+
+    Holds the callable plus the ordered, per-argument coercion metadata derived
+    from its signature. Per Golden Rule #1b, runtime callables live here in a
+    plain dataclass — never inside a serialized Pydantic field.
+    """
+
+    name: str
+    fn: Callable
+    args: tuple[_CommandArgSpec, ...]
+    tool_card: str
+
+    @property
+    def required_count(self) -> int:
+        """Number of leading required (no-default) parameters."""
+        return sum(1 for spec in self.args if spec.required)
+
+
+def _json_type_name(annotation: Any) -> str:
+    """Return the JSON-schema type name for a parameter annotation.
+
+    Falls back to ``"string"`` when the schema has no top-level ``type`` (e.g.
+    a union like ``str | None`` produces ``anyOf``), matching how the human help
+    surface renders un-typed-or-optional args.
+    """
+    try:
+        schema = TypeAdapter(annotation).json_schema()
+    except Exception:
+        return "string"
+    return schema.get("type", "string")
+
+
+def _build_command_entry(fn: Callable, tool_card: str) -> _CommandEntry:
+    """Derive a per-command arg model + ordered metadata from a callable signature.
+
+    Mirrors how pydantic-ai derives a tool schema from a function signature:
+    inspect the parameters, reject anything un-derivable (``*args``, ``**kwargs``,
+    or an un-annotated parameter), and build a :class:`TypeAdapter` over the
+    ordered positional parameter types for later coercion.
+
+    Raises:
+        ValueError: If the signature has a ``VAR_POSITIONAL`` (``*args``),
+            ``VAR_KEYWORD`` (``**kwargs``), or un-annotated parameter. The message
+            names the command and the offending parameter.
+    """
+    sig = inspect.signature(fn)
+    try:
+        hints = get_type_hints(fn)
+    except Exception:
+        hints = {}
+
+    specs: list[_CommandArgSpec] = []
+    for pname, param in sig.parameters.items():
+        if param.kind is inspect.Parameter.VAR_POSITIONAL:
+            raise ValueError(
+                f"Command '{fn.__name__}' cannot be registered: parameter '*{pname}' "
+                "(*args) has no derivable argument schema."
+            )
+        if param.kind is inspect.Parameter.VAR_KEYWORD:
+            raise ValueError(
+                f"Command '{fn.__name__}' cannot be registered: parameter '**{pname}' "
+                "(**kwargs) has no derivable argument schema."
+            )
+        annotation = hints.get(pname, param.annotation)
+        if annotation is inspect.Parameter.empty:
+            raise ValueError(
+                f"Command '{fn.__name__}' cannot be registered: parameter '{pname}' "
+                "has no type annotation."
+            )
+        required = param.default is inspect.Parameter.empty
+        specs.append(
+            _CommandArgSpec(
+                name=pname,
+                annotation=annotation,
+                required=required,
+                adapter=TypeAdapter(annotation),
+            )
+        )
+
+    return _CommandEntry(name=fn.__name__, fn=fn, args=tuple(specs), tool_card=tool_card)
+
+
+class CommandRegistry:
+    """Name-keyed registry of command callables with signature-derived dispatch.
+
+    Built by :meth:`ToolFactory.get_command_registry` from the ``get_commands()``
+    output of every wired :class:`ToolCard`. Each command is keyed by its
+    callable's ``__name__`` (e.g. ``hire_member``). The registry exposes a typed
+    programmatic surface (:meth:`callable`), a membership test (:meth:`has`),
+    discovery metadata (:meth:`descriptors`), and a human text surface
+    (:meth:`dispatch`) that parses ``/``-prefixed commands.
+
+    This is a runtime object holding callables — deliberately a plain class, not a
+    ``BaseModel`` (Golden Rule #1b): runtime callables must never live in a
+    serialized field.
+    """
+
+    def __init__(self, entries: dict[str, _CommandEntry]) -> None:
+        """Store the name → command-entry mapping. Use the factory to build one."""
+        self._entries = entries
+
+    def has(self, name: str) -> bool:
+        """Return ``True`` if a command named *name* is registered."""
+        return name in self._entries
+
+    def callable(self, name: str) -> Callable:
+        """Return the bound, typed command callable for programmatic invocation.
+
+        The returned callable preserves its **native** (non-stringified) return
+        value, so callers (e.g. ``StructuredOutput`` hire-by-role) can invoke it
+        with native arguments and use the result directly.
+
+        Raises:
+            CommandNotRecognized: If *name* is not a registered command.
+        """
+        try:
+            return self._entries[name].fn
+        except KeyError:
+            raise CommandNotRecognized(name) from None
+
+    def descriptors(self) -> list[CommandDescriptor]:
+        """Return serializable discovery metadata, one entry per command."""
+        result: list[CommandDescriptor] = []
+        for entry in self._entries.values():
+            args = [
+                CommandArg(
+                    name=spec.name,
+                    type=_json_type_name(spec.annotation),
+                    required=spec.required,
+                )
+                for spec in entry.args
+            ]
+            description = inspect.getdoc(entry.fn) or ""
+            result.append(
+                CommandDescriptor(
+                    name=entry.name,
+                    description=description,
+                    args=args,
+                    tool_card=entry.tool_card,
+                )
+            )
+        return result
+
+    def dispatch(self, text: str) -> str:
+        """Parse a ``/``-prefixed command, invoke it, and return a result string.
+
+        Strips the leading ``/``, ``shlex.split``s the remainder, resolves the
+        first token to a command, coerces the remaining tokens as positional args,
+        invokes the command, and string-renders the result.
+
+        Raises:
+            CommandNotRecognized: If the first token does not name a known command
+                (so the caller may fall back to normal LLM processing). No command
+                is invoked in this case.
+
+        Post-identification failures (missing/extra args, coercion errors, or the
+        command body raising) are caught **inside** this method and returned as a
+        plain result string — ``CommandNotRecognized`` is never raised once a
+        command has been identified.
+        """
+        tokens = shlex.split(text[1:] if text.startswith("/") else text)
+        if not tokens:
+            raise CommandNotRecognized(text)
+        name, positional = tokens[0], tokens[1:]
+        if name not in self._entries:
+            raise CommandNotRecognized(name)
+        return self._invoke(name, positional)
+
+    def _invoke(self, name: str, positional: list[str]) -> str:
+        """Coerce *positional* tokens for command *name* and invoke it.
+
+        Any failure (too many args, missing required arg, coercion error, or the
+        command body raising) is caught and returned as a result string.
+        """
+        entry = self._entries[name]
+        try:
+            coerced = self._coerce(entry, positional)
+            return str(entry.fn(*coerced))
+        except Exception as exc:  # noqa: BLE001 — failures become result strings (ADR-028 §4)
+            return f"Command '{name}' failed: {exc}"
+
+    @staticmethod
+    def _coerce(entry: _CommandEntry, positional: list[str]) -> list[Any]:
+        """Coerce *positional* tokens against *entry*'s ordered arg adapters.
+
+        Validates arity (at least ``required_count``, at most ``len(args)``) then
+        coerces each supplied token through its per-arg :class:`TypeAdapter`.
+        Unsupplied trailing optional args are omitted so the callable applies its
+        own defaults.
+        """
+        if len(positional) > len(entry.args):
+            raise ValueError(
+                f"accepts at most {len(entry.args)} argument(s), got {len(positional)}"
+            )
+        if len(positional) < entry.required_count:
+            raise ValueError(
+                f"requires at least {entry.required_count} argument(s), got {len(positional)}"
+            )
+        return [
+            spec.adapter.validate_python(token)
+            for spec, token in zip(entry.args, positional, strict=False)
+        ]
+
+
 class ToolFactory:
     """Resolves ``ToolCard`` instances into callable tools, prompts, and toolsets."""
 
@@ -328,9 +555,19 @@ class ToolFactory:
     def get_commands(self) -> dict[type[BaseToolParam], Callable]:
         """Return command callables aggregated from all tool cards.
 
+        Deprecated:
+            Use :meth:`get_command_registry` instead. This param-class-keyed dict
+            is retained for one migration cycle. The registry keys by canonical
+            command name and adds signature-derived dispatch + discovery metadata.
+
         Returns:
             Dict mapping param class to callable, merged from all tool cards.
         """
+        warnings.warn(
+            "ToolFactory.get_commands() is deprecated; use get_command_registry() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         commands: dict[type[BaseToolParam], Callable] = {}
         for card in self.tool_cards:
             commands.update(card.get_commands())
@@ -338,6 +575,37 @@ class ToolFactory:
         if self._retry_exception is not None:
             commands = {k: self._wrap_with_retry(v) for k, v in commands.items()}
         return commands
+
+    def get_command_registry(self) -> CommandRegistry:
+        """Build a name-keyed :class:`CommandRegistry` from every wired tool card.
+
+        Iterates ``self.tool_cards`` in dependency order, calls each card's
+        ``get_commands()``, and registers every callable under its ``__name__``.
+        Each command's arg schema is derived from its signature at this point, so
+        an un-derivable signature (``*args``/``**kwargs``/un-annotated param) fails
+        loudly here. When ``retry_exception`` is configured, each command is
+        wrapped via :meth:`_wrap_with_retry` (``functools.wraps`` preserves
+        ``__name__``/``__doc__``), matching :meth:`get_commands` behavior.
+
+        Raises:
+            ValueError: If two tool cards expose commands with the same canonical
+                name (collision is a wiring-time error, never a silent overwrite),
+                or if a command has an un-derivable signature. The message names
+                the offending command.
+        """
+        entries: dict[str, _CommandEntry] = {}
+        for card in self.tool_cards:
+            tool_card_name = type(card).__name__
+            for fn in card.get_commands().values():
+                wrapped = self._wrap_with_retry(fn) if self._retry_exception is not None else fn
+                name = wrapped.__name__
+                if name in entries:
+                    raise ValueError(
+                        f"Command name collision: '{name}' is exposed by both "
+                        f"'{entries[name].tool_card}' and '{tool_card_name}'."
+                    )
+                entries[name] = _build_command_entry(wrapped, tool_card_name)
+        return CommandRegistry(entries)
 
     def get_toolsets(self) -> list[Any]:
         """Return toolset instances aggregated from all tool cards."""

--- a/src/akgentic/tool/errors.py
+++ b/src/akgentic/tool/errors.py
@@ -14,3 +14,17 @@ class RetriableError(Exception):
     """
 
     pass
+
+
+class CommandNotRecognized(Exception):  # noqa: N818 — story-mandated name; identification signal
+    """Raised when the first dispatch token is not a known command (ADR-028 §Decision 4).
+
+    This is an *identification-failure* signal, not a tool execution error: it
+    tells the agent message handler "this was never a command — treat it as plain
+    text and fall back to normal LLM processing." It is deliberately NOT a
+    :class:`RetriableError` subclass; a retriable error means "retry with corrected
+    input," which is a semantically distinct outcome. The two hierarchies are
+    kept disjoint on purpose.
+    """
+
+    pass

--- a/src/akgentic/tool/event.py
+++ b/src/akgentic/tool/event.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Protocol, TypeAlias, runtime_checkable
 from akgentic.core.actor_address import ActorAddress
 from akgentic.core.agent import AkgentType
 from akgentic.core.messages import Message
+from akgentic.core.utils.serializer import SerializableBaseModel
 
 if TYPE_CHECKING:
     from akgentic.tool.knowledge_graph.models import KnowledgeGraphStateEvent
@@ -34,6 +35,62 @@ class ToolStateEvent(Message):
     tool_id: str
     seq: int
     payload: ToolStatePayload
+
+
+class CommandArg(SerializableBaseModel):
+    """A single positional/keyword argument of a discoverable command (ADR-028 §Decision 3).
+
+    Derived from a command callable's signature so consumers (the dispatch parser
+    in Story 21.2 and the frontend help renderer) share one typed contract.
+
+    Attributes:
+        name: Argument name as it appears in the callable signature.
+        type: JSON-schema type name (e.g. ``"string"``, ``"integer"``, ``"boolean"``).
+        required: Whether the argument must be supplied (no default).
+        description: Optional human-readable description; ``None`` when absent.
+    """
+
+    name: str
+    type: str
+    required: bool
+    description: str | None = None
+
+
+class CommandDescriptor(SerializableBaseModel):
+    """A discoverable command exposed by a tool (ADR-028 §Decision 3).
+
+    Describes one canonical command, its provenance, and its ordered argument
+    list. The ``args`` order is load-bearing: it drives positional dispatch
+    parsing (Story 21.2) and frontend help rendering.
+
+    Attributes:
+        name: Canonical command name (e.g. ``"hire_member"``).
+        description: Command description, sourced from the callable docstring.
+        args: Ordered list of :class:`CommandArg` entries (may be empty).
+        tool_card: Provenance of the command (e.g. ``"TeamTool"``).
+    """
+
+    name: str
+    description: str
+    args: list[CommandArg]
+    tool_card: str
+
+
+class CommandsAnnouncedEvent(SerializableBaseModel):
+    """Announcement of the command set an agent executes (ADR-028 §Decision 3).
+
+    Emitted so downstream agents/frontends can render the available commands.
+    Fully serializable: the ``__model__`` marker (from ``SerializableBaseModel``)
+    lets consumers discriminate this inner event during deserialization.
+
+    Attributes:
+        agent: Address of the agent that executes these commands (core
+            ``ActorAddress``; the tool layer MAY import core, NFR1).
+        commands: The :class:`CommandDescriptor` set announced for ``agent``.
+    """
+
+    agent: ActorAddress
+    commands: list[CommandDescriptor]
 
 
 @runtime_checkable

--- a/tests/test_command_models.py
+++ b/tests/test_command_models.py
@@ -1,0 +1,273 @@
+"""Tests for the command-discovery models and ``CommandNotRecognized`` (Story 21.3).
+
+Covers ADR-028 §Decision 3 (discovery models) and §Decision 4 (failure handling):
+field shape, defaults, required-vs-optional validation, Pydantic round-trip with the
+``__model__`` marker that drives consumer dispatch, exception type/raisability, and
+public-API importability. Mirrors the round-trip style of ``test_tool_state_event.py``.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from akgentic.core.actor_address import ActorAddress
+from akgentic.core.actor_address_impl import ActorAddressProxy
+from pydantic import ValidationError
+
+from akgentic.tool import (
+    CommandArg,
+    CommandDescriptor,
+    CommandNotRecognized,
+    CommandsAnnouncedEvent,
+)
+from akgentic.tool.errors import RetriableError
+
+
+class SerializableActorAddress(ActorAddress):
+    """A concrete ``ActorAddress`` whose ``serialize()`` carries the dispatch marker.
+
+    Unlike the bare ``MockActorAddress`` in conftest, this produces a full
+    ``ActorAddressDict`` (with ``__actor_address__``) so a round-trip reconstructs
+    it as an ``ActorAddressProxy`` — letting us assert "equivalent ActorAddress".
+    """
+
+    def __init__(self, name: str = "hiring-agent", role: str = "manager") -> None:
+        self._name = name
+        self._role = role
+        self._agent_id = uuid.uuid4()
+        self._team_id = uuid.uuid4()
+
+    @property
+    def agent_id(self) -> uuid.UUID:
+        return self._agent_id
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def role(self) -> str:
+        return self._role
+
+    @property
+    def team_id(self) -> uuid.UUID:
+        return self._team_id
+
+    @property
+    def squad_id(self) -> uuid.UUID | None:
+        return None
+
+    def send(self, recipient: object, message: object) -> None:
+        pass
+
+    def is_alive(self) -> bool:
+        return True
+
+    def handle_user_message(self) -> bool:
+        return False
+
+    def serialize(self) -> dict:  # type: ignore[type-arg]
+        return {
+            "__actor_address__": True,
+            "__actor_type__": "tests.test_command_models.SerializableActorAddress",
+            "agent_id": str(self._agent_id),
+            "name": self._name,
+            "role": self._role,
+            "team_id": str(self._team_id),
+            "squad_id": "",
+            "user_message": False,
+        }
+
+    def __repr__(self) -> str:
+        return f"SerializableActorAddress(name={self._name})"
+
+
+# ---------------------------------------------------------------------------
+# CommandArg (AC #1, #2, #7)
+# ---------------------------------------------------------------------------
+
+
+class TestCommandArg:
+    def test_construct_all_fields(self) -> None:
+        arg = CommandArg(name="role", type="string", required=True, description="Role to hire")
+        assert arg.name == "role"
+        assert arg.type == "string"
+        assert arg.required is True
+        assert arg.description == "Role to hire"
+
+    def test_description_defaults_to_none(self) -> None:
+        arg = CommandArg(name="name", type="string", required=False)
+        assert arg.description is None
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"type": "string", "required": True},  # missing name
+            {"name": "x", "required": True},  # missing type
+            {"name": "x", "type": "string"},  # missing required
+        ],
+    )
+    def test_missing_required_raises(self, kwargs: dict[str, object]) -> None:
+        with pytest.raises(ValidationError):
+            CommandArg(**kwargs)  # type: ignore[arg-type]
+
+    def test_roundtrip_preserves_values(self) -> None:
+        arg = CommandArg(name="count", type="integer", required=True, description="How many")
+        dumped = arg.model_dump()
+        assert "__model__" in dumped
+        restored = CommandArg.model_validate(dumped)
+        assert isinstance(restored, CommandArg)
+        assert restored.name == "count"
+        assert restored.type == "integer"
+        assert restored.required is True
+        assert restored.description == "How many"
+
+
+# ---------------------------------------------------------------------------
+# CommandDescriptor (AC #3, #4, #7)
+# ---------------------------------------------------------------------------
+
+
+def _two_args() -> list[CommandArg]:
+    return [
+        CommandArg(name="role", type="string", required=True, description="Role"),
+        CommandArg(name="name", type="string", required=False),
+    ]
+
+
+class TestCommandDescriptor:
+    def test_construct_with_ordered_args(self) -> None:
+        desc = CommandDescriptor(
+            name="hire_member",
+            description="Hire a new team member",
+            args=_two_args(),
+            tool_card="TeamTool",
+        )
+        assert desc.name == "hire_member"
+        assert desc.description == "Hire a new team member"
+        assert desc.tool_card == "TeamTool"
+        assert len(desc.args) == 2
+        assert all(isinstance(a, CommandArg) for a in desc.args)
+        assert [a.name for a in desc.args] == ["role", "name"]
+
+    def test_empty_args_is_valid(self) -> None:
+        desc = CommandDescriptor(name="x", description="d", args=[], tool_card="T")
+        assert desc.args == []
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"description": "d", "args": [], "tool_card": "T"},  # missing name
+            {"name": "x", "args": [], "tool_card": "T"},  # missing description
+            {"name": "x", "description": "d", "tool_card": "T"},  # missing args
+            {"name": "x", "description": "d", "args": []},  # missing tool_card
+        ],
+    )
+    def test_missing_required_raises(self, kwargs: dict[str, object]) -> None:
+        with pytest.raises(ValidationError):
+            CommandDescriptor(**kwargs)  # type: ignore[arg-type]
+
+    def test_roundtrip_preserves_arg_order_and_types(self) -> None:
+        desc = CommandDescriptor(
+            name="hire_member",
+            description="Hire a member",
+            args=_two_args(),
+            tool_card="TeamTool",
+        )
+        restored = CommandDescriptor.model_validate(desc.model_dump())
+        assert isinstance(restored, CommandDescriptor)
+        assert [a.name for a in restored.args] == ["role", "name"]
+        assert all(isinstance(a, CommandArg) for a in restored.args)
+        assert restored.args[0].required is True
+        assert restored.args[0].description == "Role"
+        assert restored.args[1].required is False
+        assert restored.args[1].description is None
+
+
+# ---------------------------------------------------------------------------
+# CommandsAnnouncedEvent (AC #5, #6, #7)
+# ---------------------------------------------------------------------------
+
+
+def _descriptor() -> CommandDescriptor:
+    return CommandDescriptor(
+        name="hire_member",
+        description="Hire a member",
+        args=_two_args(),
+        tool_card="TeamTool",
+    )
+
+
+class TestCommandsAnnouncedEvent:
+    def test_construct(self) -> None:
+        agent = SerializableActorAddress()
+        desc = _descriptor()
+        event = CommandsAnnouncedEvent(agent=agent, commands=[desc])
+        assert event.agent is agent
+        assert event.commands == [desc]
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"commands": []},  # missing agent
+            {"agent": SerializableActorAddress()},  # missing commands
+        ],
+    )
+    def test_missing_required_raises(self, kwargs: dict[str, object]) -> None:
+        with pytest.raises(ValidationError):
+            CommandsAnnouncedEvent(**kwargs)  # type: ignore[arg-type]
+
+    def test_roundtrip(self) -> None:
+        agent = SerializableActorAddress(name="hiring-agent", role="manager")
+        event = CommandsAnnouncedEvent(agent=agent, commands=[_descriptor()])
+        dumped = event.model_dump()
+        assert "__model__" in dumped
+
+        restored = CommandsAnnouncedEvent.model_validate(dumped)
+        # agent deserializes back to an equivalent ActorAddress
+        assert isinstance(restored.agent, ActorAddress)
+        assert isinstance(restored.agent, ActorAddressProxy)
+        assert restored.agent.agent_id == agent.agent_id
+        assert restored.agent.name == "hiring-agent"
+        assert restored.agent.role == "manager"
+        # nested descriptor/arg models are restored as real models, not dicts
+        assert isinstance(restored.commands[0], CommandDescriptor)
+        assert isinstance(restored.commands[0].args[0], CommandArg)
+        assert restored.commands[0].name == "hire_member"
+        assert restored.commands[0].args[0].name == "role"
+
+
+# ---------------------------------------------------------------------------
+# CommandNotRecognized (AC #8)
+# ---------------------------------------------------------------------------
+
+
+class TestCommandNotRecognized:
+    def test_raisable_and_catchable(self) -> None:
+        with pytest.raises(CommandNotRecognized):
+            raise CommandNotRecognized("frobnicate")
+
+    def test_is_exception_subclass(self) -> None:
+        assert issubclass(CommandNotRecognized, Exception)
+
+    def test_is_not_retriable_error_subclass(self) -> None:
+        assert not issubclass(CommandNotRecognized, RetriableError)
+
+
+# ---------------------------------------------------------------------------
+# Public-API export (AC #9)
+# ---------------------------------------------------------------------------
+
+
+def test_public_api_exports() -> None:
+    import akgentic.tool as tool_pkg
+
+    for name in (
+        "CommandArg",
+        "CommandDescriptor",
+        "CommandsAnnouncedEvent",
+        "CommandNotRecognized",
+    ):
+        assert name in tool_pkg.__all__
+        assert hasattr(tool_pkg, name)

--- a/tests/test_command_registry.py
+++ b/tests/test_command_registry.py
@@ -1,0 +1,446 @@
+"""Tests for ``CommandRegistry`` and ``ToolFactory.get_command_registry()`` (Story 21.2).
+
+Covers ADR-028 §Decision 1 (registry construction, collision), §Decision 2
+(signature-derived arg schema, shlex dispatch grammar, positional coercion),
+§Decision 4 (failure semantics: ``CommandNotRecognized`` vs caught result string),
+and §Decision 6 (programmatic typed access). Behavioral assertions only — no
+assertion checks for an ADR-reference string (Golden Rule #8 / NFR3).
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import Callable
+
+import pytest
+
+from akgentic.tool.core import (
+    COMMAND,
+    BaseToolParam,
+    CommandRegistry,
+    ToolCard,
+    ToolFactory,
+)
+from akgentic.tool.errors import CommandNotRecognized, RetriableError
+from akgentic.tool.event import CommandDescriptor
+
+# ---------------------------------------------------------------------------
+# Fixtures: ToolCards exposing command callables (TeamTool-shaped signatures)
+# ---------------------------------------------------------------------------
+
+
+class _HireParam(BaseToolParam):
+    expose: set[str] = {COMMAND}
+
+
+class _FireParam(BaseToolParam):
+    expose: set[str] = {COMMAND}
+
+
+class _HireCard(ToolCard):
+    """Card exposing a ``hire_member(role, name=None)`` command."""
+
+    name: str = "hire-card"
+    description: str = "hire card"
+
+    def get_tools(self) -> list[Callable]:
+        return []
+
+    def get_commands(self) -> dict[type[BaseToolParam], Callable]:
+        def hire_member(role: str, name: str | None = None) -> tuple[str, str | None]:
+            """Hire a single new team member with the given role.
+
+            Args:
+                role: Role to hire.
+                name: Optional specific name.
+            """
+            return (role, name)
+
+        return {_HireParam: hire_member}
+
+
+class _FireCard(ToolCard):
+    """Card exposing a ``fire_member(name)`` command."""
+
+    name: str = "fire-card"
+    description: str = "fire card"
+
+    def get_tools(self) -> list[Callable]:
+        return []
+
+    def get_commands(self) -> dict[type[BaseToolParam], Callable]:
+        def fire_member(name: str) -> str:
+            """Fire a team member with the given name."""
+            return f"Member {name} has been fired."
+
+        return {_FireParam: fire_member}
+
+
+class _IntCard(ToolCard):
+    """Card exposing ``f(task_id: int)`` for coercion tests."""
+
+    name: str = "int-card"
+    description: str = "int card"
+
+    def get_tools(self) -> list[Callable]:
+        return []
+
+    def get_commands(self) -> dict[type[BaseToolParam], Callable]:
+        def f(task_id: int) -> int:
+            """Return double the task id."""
+            return task_id * 2
+
+        return {_HireParam: f}
+
+
+class _RaisingCard(ToolCard):
+    """Card whose command body raises when invoked."""
+
+    name: str = "raising-card"
+    description: str = "raising card"
+
+    def get_tools(self) -> list[Callable]:
+        return []
+
+    def get_commands(self) -> dict[type[BaseToolParam], Callable]:
+        def boom(arg: str) -> str:
+            """Always raises."""
+            raise RuntimeError("kaboom")
+
+        return {_HireParam: boom}
+
+
+def _registry(*cards: ToolCard) -> CommandRegistry:
+    factory = ToolFactory(tool_cards=list(cards))
+    return factory.get_command_registry()
+
+
+# ---------------------------------------------------------------------------
+# AC 1 — Registry construction keyed by canonical name
+# ---------------------------------------------------------------------------
+
+
+def test_registry_keyed_by_callable_name() -> None:
+    registry = _registry(_HireCard(), _FireCard())
+    assert registry.has("hire_member") is True
+    assert registry.has("fire_member") is True
+    assert registry.has("not_a_command") is False
+
+
+# ---------------------------------------------------------------------------
+# AC 2 — Cross-card name-collision detection
+# ---------------------------------------------------------------------------
+
+
+def test_cross_card_name_collision_raises() -> None:
+    class _DupCard(ToolCard):
+        name: str = "dup-card"
+        description: str = "dup card"
+
+        def get_tools(self) -> list[Callable]:
+            return []
+
+        def get_commands(self) -> dict[type[BaseToolParam], Callable]:
+            def hire_member(role: str) -> str:
+                """Duplicate hire_member."""
+                return role
+
+            return {_FireParam: hire_member}
+
+    factory = ToolFactory(tool_cards=[_HireCard(), _DupCard()])
+    with pytest.raises(ValueError) as exc:
+        factory.get_command_registry()
+    assert "hire_member" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# AC 3 — Signature-derived argument schema (required/optional + order)
+# ---------------------------------------------------------------------------
+
+
+def test_signature_derived_schema_required_optional_and_order() -> None:
+    registry = _registry(_HireCard())
+    descriptors = registry.descriptors()
+    assert len(descriptors) == 1
+    desc = descriptors[0]
+    assert [a.name for a in desc.args] == ["role", "name"]
+    assert desc.args[0].required is True
+    assert desc.args[1].required is False
+
+
+# ---------------------------------------------------------------------------
+# AC 4 — Loud rejection of un-derivable signatures
+# ---------------------------------------------------------------------------
+
+
+def test_var_positional_rejected_at_construction() -> None:
+    class _VarArgsCard(ToolCard):
+        name: str = "varargs"
+        description: str = "varargs"
+
+        def get_tools(self) -> list[Callable]:
+            return []
+
+        def get_commands(self) -> dict[type[BaseToolParam], Callable]:
+            def variadic(*args: str) -> str:
+                """Bad: *args."""
+                return "x"
+
+            return {_HireParam: variadic}
+
+    factory = ToolFactory(tool_cards=[_VarArgsCard()])
+    with pytest.raises(ValueError) as exc:
+        factory.get_command_registry()
+    assert "variadic" in str(exc.value)
+
+
+def test_var_keyword_rejected_at_construction() -> None:
+    class _KwargsCard(ToolCard):
+        name: str = "kwargs"
+        description: str = "kwargs"
+
+        def get_tools(self) -> list[Callable]:
+            return []
+
+        def get_commands(self) -> dict[type[BaseToolParam], Callable]:
+            def variadic_kw(**kwargs: str) -> str:
+                """Bad: **kwargs."""
+                return "x"
+
+            return {_HireParam: variadic_kw}
+
+    factory = ToolFactory(tool_cards=[_KwargsCard()])
+    with pytest.raises(ValueError) as exc:
+        factory.get_command_registry()
+    assert "variadic_kw" in str(exc.value)
+
+
+def test_untyped_param_rejected_at_construction() -> None:
+    class _UntypedCard(ToolCard):
+        name: str = "untyped"
+        description: str = "untyped"
+
+        def get_tools(self) -> list[Callable]:
+            return []
+
+        def get_commands(self) -> dict[type[BaseToolParam], Callable]:
+            def untyped(role) -> str:  # type: ignore[no-untyped-def]
+                """Bad: no annotation."""
+                return "x"
+
+            return {_HireParam: untyped}
+
+    factory = ToolFactory(tool_cards=[_UntypedCard()])
+    with pytest.raises(ValueError) as exc:
+        factory.get_command_registry()
+    assert "untyped" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# AC 5 — Dispatch parses, coerces, invokes, returns a string
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_quoted_args_happy_path() -> None:
+    registry = _registry(_HireCard())
+    result = registry.dispatch('/hire_member Developer "Alice Smith"')
+    assert isinstance(result, str)
+    assert "Developer" in result
+    assert "Alice Smith" in result
+
+
+def test_dispatch_optional_arg_omitted() -> None:
+    registry = _registry(_HireCard())
+    result = registry.dispatch("/hire_member Developer")
+    # name omitted -> callable default None applies; native return was ('Developer', None)
+    assert "Developer" in result
+    assert "None" in result
+
+
+# ---------------------------------------------------------------------------
+# AC 6 — Type coercion of positional args
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_coerces_int_arg() -> None:
+    registry = _registry(_IntCard())
+    # f(task_id) returns task_id * 2 -> 10 proves "5" coerced to int, not "55"
+    assert registry.dispatch("/f 5") == "10"
+
+
+# ---------------------------------------------------------------------------
+# AC 7 — Unknown first token raises CommandNotRecognized
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("text", ["/frobnicate", "/etc/passwd", "/", "/ "])
+def test_unknown_first_token_raises_command_not_recognized(text: str) -> None:
+    registry = _registry(_HireCard())
+    with pytest.raises(CommandNotRecognized):
+        registry.dispatch(text)
+
+
+def test_command_not_recognized_does_not_invoke_command() -> None:
+    invoked: list[str] = []
+
+    class _SpyCard(ToolCard):
+        name: str = "spy"
+        description: str = "spy"
+
+        def get_tools(self) -> list[Callable]:
+            return []
+
+        def get_commands(self) -> dict[type[BaseToolParam], Callable]:
+            def known(arg: str) -> str:
+                """Spy command."""
+                invoked.append(arg)
+                return arg
+
+            return {_HireParam: known}
+
+    registry = _registry(_SpyCard())
+    with pytest.raises(CommandNotRecognized):
+        registry.dispatch("/unknown x")
+    assert invoked == []
+
+
+# ---------------------------------------------------------------------------
+# AC 8 — Post-identification failures returned as result strings
+# ---------------------------------------------------------------------------
+
+
+def test_missing_required_arg_returns_string() -> None:
+    registry = _registry(_HireCard())
+    result = registry.dispatch("/hire_member")  # role is required
+    assert isinstance(result, str)
+    assert "hire_member" in result
+
+
+def test_extra_args_returns_string() -> None:
+    registry = _registry(_HireCard())
+    result = registry.dispatch("/hire_member a b c")  # max 2 args
+    assert isinstance(result, str)
+    assert "hire_member" in result
+
+
+def test_coercion_error_returns_string() -> None:
+    registry = _registry(_IntCard())
+    result = registry.dispatch("/f notanint")
+    assert isinstance(result, str)
+    assert "f" in result
+
+
+def test_command_body_raises_returns_string() -> None:
+    registry = _registry(_RaisingCard())
+    result = registry.dispatch("/boom hello")
+    assert isinstance(result, str)
+    assert "boom" in result
+
+
+@pytest.mark.parametrize(
+    "text",
+    ["/hire_member", "/hire_member a b c"],
+)
+def test_post_identification_failure_does_not_raise_command_not_recognized(text: str) -> None:
+    registry = _registry(_HireCard())
+    # Must NOT raise — identified command failures become result strings.
+    result = registry.dispatch(text)
+    assert isinstance(result, str)
+
+
+# ---------------------------------------------------------------------------
+# AC 9 — Programmatic typed access
+# ---------------------------------------------------------------------------
+
+
+def test_callable_returns_native_value() -> None:
+    registry = _registry(_HireCard())
+    fn = registry.callable("hire_member")
+    result = fn("Developer")
+    # Native (non-stringified) return value preserved.
+    assert result == ("Developer", None)
+
+
+def test_callable_unknown_raises_command_not_recognized() -> None:
+    registry = _registry(_HireCard())
+    with pytest.raises(CommandNotRecognized):
+        registry.callable("not_a_command")
+
+
+# ---------------------------------------------------------------------------
+# AC 10 — descriptors() returns serializable metadata
+# ---------------------------------------------------------------------------
+
+
+def test_descriptors_shape() -> None:
+    registry = _registry(_HireCard(), _FireCard())
+    descriptors = registry.descriptors()
+    assert all(isinstance(d, CommandDescriptor) for d in descriptors)
+    by_name = {d.name: d for d in descriptors}
+    assert set(by_name) == {"hire_member", "fire_member"}
+
+    hire = by_name["hire_member"]
+    assert hire.tool_card == "_HireCard"
+    assert "Hire a single new team member" in hire.description
+    assert [a.name for a in hire.args] == ["role", "name"]
+    assert hire.args[0].type == "string"
+    assert hire.args[0].required is True
+    assert hire.args[1].required is False
+
+    fire = by_name["fire_member"]
+    assert fire.tool_card == "_FireCard"
+    assert [a.name for a in fire.args] == ["name"]
+
+
+def test_descriptor_int_arg_type() -> None:
+    registry = _registry(_IntCard())
+    desc = registry.descriptors()[0]
+    assert desc.args[0].name == "task_id"
+    assert desc.args[0].type == "integer"
+
+
+# ---------------------------------------------------------------------------
+# AC 11 — Deprecated get_commands() alias retained
+# ---------------------------------------------------------------------------
+
+
+def test_get_commands_still_returns_legacy_dict_and_warns() -> None:
+    factory = ToolFactory(tool_cards=[_HireCard()])
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        commands = factory.get_commands()
+    assert _HireParam in commands  # legacy param-class keying preserved
+    assert any(issubclass(w.category, DeprecationWarning) for w in caught)
+
+
+# ---------------------------------------------------------------------------
+# retry_exception wrapping preserves name and translates RetriableError
+# ---------------------------------------------------------------------------
+
+
+def test_retry_exception_wrapping_preserves_name_and_translates() -> None:
+    class _MyRetryError(Exception):
+        pass
+
+    class _RetriableCmdCard(ToolCard):
+        name: str = "retriable-cmd"
+        description: str = "retriable cmd"
+
+        def get_tools(self) -> list[Callable]:
+            return []
+
+        def get_commands(self) -> dict[type[BaseToolParam], Callable]:
+            def needy(arg: str) -> str:
+                """Raises retriable when called."""
+                raise RetriableError("retry me")
+
+            return {_HireParam: needy}
+
+    factory = ToolFactory(tool_cards=[_RetriableCmdCard()], retry_exception=_MyRetryError)
+    registry = factory.get_command_registry()
+    # Name survives functools.wraps so name-keying still works.
+    assert registry.has("needy")
+    # The wrapped command translates RetriableError -> _MyRetry, which dispatch
+    # catches and returns as a string (identified-command failure semantics).
+    result = registry.dispatch("/needy x")
+    assert "needy" in result


### PR DESCRIPTION
## Epic 21 — Command channel: registry, dispatch & discovery models (ADR-028)

Umbrella PR for the **akgentic-tool** code stories of Epic 21. Stacked on a single shared epic branch; stories land in dependency order (21-3 first, since 21-2's `CommandRegistry` returns `list[CommandDescriptor]` and raises `CommandNotRecognized`).

### Code stories

- [x] **21-3** — Discovery models (`CommandArg`, `CommandDescriptor`, `CommandsAnnouncedEvent`) + `CommandNotRecognized` exception, exported from the public API (Relates to #179)
- [x] 21-2 — CommandRegistry + dispatch (Relates to #181)

> **Note:** Story **21-1** (architecture doc — command channel, registry & discovery) is a documentation-only change in the **root repo** under `_bmad-output/`. It has **no `akgentic-tool` submodule artifact** and therefore is **not** part of this PR.

### Story 21-3 — what landed

Three `SerializableBaseModel` discovery models plus an identification-failure exception:

- `CommandArg` — `name`, `type` (JSON-schema type name), `required`, `description: str | None = None`.
- `CommandDescriptor` — `name`, `description`, ordered `args: list[CommandArg]`, `tool_card` provenance.
- `CommandsAnnouncedEvent` — `agent: ActorAddress` (core type; tool MAY import core, NFR1), `commands: list[CommandDescriptor]`.
- `CommandNotRecognized(Exception)` — direct `Exception` subclass, deliberately disjoint from `RetriableError`.

All four exported from `akgentic.tool` and listed in `__all__`. No `dict[str, Any]`; no per-model `ConfigDict(arbitrary_types_allowed=True)` (Golden Rules #1 / #1b). Full Pydantic round-trip via the inherited `__model__` marker so frontend consumers can discriminate the inner event.

### Story 21-2 — what landed

`CommandRegistry` + `ToolFactory.get_command_registry()` — the runtime dispatch layer over the 21-3 models:

- `CommandRegistry` — plain class (not a `BaseModel`); runtime callables held in a frozen `_CommandEntry` dataclass, never in a serialized field (Golden Rule #1b).
- Name-keyed by `callable.__name__`; `has(name)` membership test.
- `_build_command_entry()` derives a per-argument `pydantic.TypeAdapter` from the callable signature (mirrors pydantic-ai tool-schema derivation). Rejects `*args` / `**kwargs` / un-annotated params loudly at wiring time, naming the offending command + parameter.
- `dispatch(text)` — strips leading `/`, `shlex.split`, resolves first token; unknown first token (incl. `/etc/passwd`, bare `/`) raises `CommandNotRecognized` so the caller falls back to the LLM. Post-identification failures (missing/extra args, coercion error, command body raising) are caught **inside** dispatch and returned as result strings — never re-raised.
- `callable(name)` returns the bound typed callable preserving the **native** return value for programmatic callers.
- `descriptors()` builds `list[CommandDescriptor]` from the 21-3 models (docstring-derived description, ordered args, `tool_card` provenance).
- `get_command_registry()` raises a wiring-time `ValueError` on cross-card name collision (names both originating cards); applies `_wrap_with_retry` for parity with `get_commands()` (`functools.wraps` preserves `__name__`/`__doc__`).
- `ToolFactory.get_commands()` deprecated (emits `DeprecationWarning` + `Deprecated:` docstring) in favor of `get_command_registry()`, retained one migration cycle.

## Review status

**Story 21-3:** APPROVED by Rex (commit `b2fd58e`). All 10 ACs implemented and tested; 21 new tests in `test_command_models.py`. No HIGH/MEDIUM findings — no fixup commit required.

- Full suite: **1396 passed**
- mypy strict: **clean** (39 source files)
- ruff (E/F/I/N/UP/ANN/ASYNC/C901/PLR0912/PLR0915): **clean**
- No `ADR-NNN` test assertions (Golden Rule #8) — ADR refs confined to docstrings (allowed)

**Story 21-2:** APPROVED by Rex (commit `0306440`). All 12 ACs implemented and verified against the code; every `[x]` task genuinely done. No HIGH/MEDIUM findings — no fixup commit required.

- 21-2 review: PASS — all 12 ACs verified; 26 new tests in `test_command_registry.py`; full suite **1422 passed**; ruff clean on changed files; `core.py` mypy-clean; no `ADR-NNN` test assertions; all changes confined to `packages/akgentic-tool/`.

## Epic 21 slice complete

Both `akgentic-tool` code stories of Epic 21 have landed on this branch:

- **21-3** — the three discovery models (`CommandArg`, `CommandDescriptor`, `CommandsAnnouncedEvent`) + `CommandNotRecognized`.
- **21-2** — the `CommandRegistry` runtime (signature-derived arg parsing, shlex slash dispatch, collision detection, programmatic typed access, `descriptors()`) wired through `ToolFactory.get_command_registry()`, with `get_commands()` deprecated.

This completes the command-channel foundation in `akgentic-tool`. The remaining wiring — `BaseAgent` slash interception, `CommandsAnnouncedEvent` emission in `on_start`, operator-action LLM-context injection, and removal of the legacy `cmd_*` methods — is out of scope here and lands in **akgentic-agent (Epic 8)**, which now has a stable registry + discovery contract to build on. Frontend `/` mention (akgentic-frontend Epic 15) and infra WS passthrough (akgentic-infra Epic 32) are documentation-only downstream consumers.

## Scope guard

All changes in this PR stay inside `packages/akgentic-tool/`:

- `src/akgentic/tool/event.py` — three discovery models (21-3)
- `src/akgentic/tool/errors.py` — `CommandNotRecognized` (21-3)
- `src/akgentic/tool/core.py` — `CommandRegistry`, signature helper, `get_command_registry()`; `get_commands()` deprecated (21-2)
- `src/akgentic/tool/__init__.py` — exports + `__all__` (21-3 + 21-2)
- `tests/test_command_models.py` — 21 tests (21-3, new)
- `tests/test_command_registry.py` — 26 tests (21-2, new)

Zero cross-submodule changes. `BaseAgent` wiring, slash interception, and WS envelope are out of scope (akgentic-agent / akgentic-infra epics per ADR-028).

Relates to #179
Relates to #181
