### PR TITLE
feat(akgentic-tool): 21-4 keyword (key=value) arguments in command dispatch

### DIFF
--- a/src/akgentic/tool/core.py
+++ b/src/akgentic/tool/core.py
@@ -427,61 +427,117 @@ class CommandRegistry:
         """Parse a ``/``-prefixed command, invoke it, and return a result string.
 
         Strips the leading ``/``, ``shlex.split``s the remainder, resolves the
-        first token to a command, coerces the remaining tokens as positional args,
-        invokes the command, and string-renders the result.
+        first token to a command, classifies the remaining tokens as positional or
+        ``name=value`` keyword arguments, coerces and merges them, invokes the
+        command, and string-renders the result.
+
+        A token is a **keyword** only when the text before its first ``=`` matches a
+        real parameter name on the command; otherwise it is positional (so values
+        containing ``=`` are never silently swallowed). Positionals must precede
+        keywords. ``key=value`` is opt-in — purely-positional dispatch is unchanged.
 
         Raises:
             CommandNotRecognized: If the first token does not name a known command
                 (so the caller may fall back to normal LLM processing). No command
                 is invoked in this case.
 
-        Post-identification failures (missing/extra args, coercion errors, or the
-        command body raising) are caught **inside** this method and returned as a
-        plain result string — ``CommandNotRecognized`` is never raised once a
-        command has been identified.
+        Post-identification failures (missing/extra args, coercion errors, unknown
+        keyword, duplicate binding, positional-after-keyword, or the command body
+        raising) are caught **inside** this method and returned as a plain result
+        string — ``CommandNotRecognized`` is never raised once a command has been
+        identified.
         """
         tokens = shlex.split(text[1:] if text.startswith("/") else text)
         if not tokens:
             raise CommandNotRecognized(text)
-        name, positional = tokens[0], tokens[1:]
+        name, args = tokens[0], tokens[1:]
         if name not in self._entries:
             raise CommandNotRecognized(name)
-        return self._invoke(name, positional)
+        return self._invoke(name, args)
 
-    def _invoke(self, name: str, positional: list[str]) -> str:
-        """Coerce *positional* tokens for command *name* and invoke it.
+    def _invoke(self, name: str, args: list[str]) -> str:
+        """Classify, merge, coerce *args* for command *name* and invoke it.
 
-        Any failure (too many args, missing required arg, coercion error, or the
-        command body raising) is caught and returned as a result string.
+        Any failure (positional-after-keyword, too many/missing args, unknown
+        keyword, duplicate binding, coercion error, or the command body raising) is
+        caught and returned as a result string.
         """
         entry = self._entries[name]
         try:
-            coerced = self._coerce(entry, positional)
-            return str(entry.fn(*coerced))
+            positional, keyword = self._classify_tokens(entry, args)
+            bound = self._bind(entry, positional, keyword)
+            return str(entry.fn(**bound))
         except Exception as exc:  # noqa: BLE001 — failures become result strings (ADR-028 §4)
             return f"Command '{name}' failed: {exc}"
 
     @staticmethod
-    def _coerce(entry: _CommandEntry, positional: list[str]) -> list[Any]:
-        """Coerce *positional* tokens against *entry*'s ordered arg adapters.
+    def _classify_tokens(
+        entry: _CommandEntry, args: list[str]
+    ) -> tuple[list[str], dict[str, str]]:
+        """Partition *args* into ``(positional, keyword)`` for *entry*.
 
-        Validates arity (at least ``required_count``, at most ``len(args)``) then
-        coerces each supplied token through its per-arg :class:`TypeAdapter`.
-        Unsupplied trailing optional args are omitted so the callable applies its
-        own defaults.
+        A token is a keyword iff it contains ``=`` AND the substring before the
+        **first** ``=`` is a known parameter name on *entry*; the value is the
+        remainder after that first ``=``. All other tokens are positional. A
+        positional token appearing after any keyword token is rejected.
+
+        Raises:
+            ValueError: If a positional token follows a keyword token (names the
+                offending positional value).
+        """
+        names = {spec.name for spec in entry.args}
+        positional: list[str] = []
+        keyword: dict[str, str] = {}
+        for token in args:
+            key, sep, value = token.partition("=")
+            if sep and key in names:
+                keyword[key] = value
+            elif keyword:
+                raise ValueError(
+                    f"positional argument '{token}' cannot follow a keyword argument"
+                )
+            else:
+                positional.append(token)
+        return positional, keyword
+
+    @staticmethod
+    def _bind(
+        entry: _CommandEntry, positional: list[str], keyword: dict[str, str]
+    ) -> dict[str, Any]:
+        """Merge *positional* + *keyword* onto *entry*'s params and coerce each.
+
+        Maps positionals onto the leading parameters in signature order, then binds
+        keywords by name, detecting unknown names and duplicate bindings. Validates
+        arity (at least ``required_count``, at most ``len(args)``) over the merged
+        set, then coerces every bound value through its per-arg :class:`TypeAdapter`.
+        Unbound trailing optionals are omitted so the callable applies its defaults.
+
+        Raises:
+            ValueError: Too many positionals, unknown keyword, duplicate binding, a
+                required parameter left unbound, or a coercion failure.
         """
         if len(positional) > len(entry.args):
             raise ValueError(
                 f"accepts at most {len(entry.args)} argument(s), got {len(positional)}"
             )
-        if len(positional) < entry.required_count:
-            raise ValueError(
-                f"requires at least {entry.required_count} argument(s), got {len(positional)}"
-            )
-        return [
-            spec.adapter.validate_python(token)
+        raw: dict[str, str] = {
+            spec.name: token
             for spec, token in zip(entry.args, positional, strict=False)
-        ]
+        }
+        specs_by_name = {spec.name: spec for spec in entry.args}
+        for key, value in keyword.items():
+            if key not in specs_by_name:
+                raise ValueError(f"unknown keyword argument '{key}'")
+            if key in raw:
+                raise ValueError(f"got multiple values for argument '{key}'")
+            raw[key] = value
+        missing = [spec.name for spec in entry.args if spec.required and spec.name not in raw]
+        if missing:
+            raise ValueError(f"missing required argument(s): {', '.join(missing)}")
+        return {
+            name: specs_by_name[name].adapter.validate_python(token)
+            for name, token in raw.items()
+        }
 
 
 class ToolFactory:

--- a/src/akgentic/tool/planning/planning.py
+++ b/src/akgentic/tool/planning/planning.py
@@ -292,23 +292,23 @@ class PlanningTool(ToolCard):
         planning_proxy = self._planning_proxy
 
         def search_planning(
+            query: str | None = None,
+            mode: Literal["hybrid", "vector", "keyword"] = "hybrid",
             status: TaskStatus | None = None,
             owner: str | None = None,
             creator: str | None = None,
-            query: str | None = None,
-            mode: Literal["hybrid", "vector", "keyword"] = "hybrid",
             top_k: int | None = None,
             score_threshold: float | None = None,
         ) -> list[str]:
             """Search tasks. All filters are AND-combined; omit all for full list.
 
             Args:
-                status: Filter by status.
-                owner: Filter by owner.
-                creator: Filter by creator.
                 query: Search text for keyword and/or semantic matching.
                 mode: "hybrid" (default) = keyword + semantic,
                     "keyword" = substring only, "vector" = semantic only.
+                status: Filter by status.
+                owner: Filter by owner.
+                creator: Filter by creator.
                 top_k: Max semantic hits (default 10).
                 score_threshold: Min cosine similarity (default 0.5).
 

--- a/tests/test_command_registry.py
+++ b/tests/test_command_registry.py
@@ -10,7 +10,7 @@ assertion checks for an ADR-reference string (Golden Rule #8 / NFR3).
 from __future__ import annotations
 
 import warnings
-from typing import Callable
+from typing import Callable, Literal
 
 import pytest
 
@@ -444,3 +444,227 @@ def test_retry_exception_wrapping_preserves_name_and_translates() -> None:
     # catches and returns as a string (identified-command failure semantics).
     result = registry.dispatch("/needy x")
     assert "needy" in result
+
+
+# ===========================================================================
+# Story 21.4 — keyword (key=value) arguments in command dispatch
+# ===========================================================================
+
+_Status = Literal["pending", "started", "completed", "abort"]
+
+
+class _SearchCard(ToolCard):
+    """``search_planning``-shaped all-optional, multi-parameter command.
+
+    Mirrors the motivating signature (status, owner, creator, query, mode) whose
+    all-optional shape positional-only dispatch cannot serve for later params.
+    """
+
+    name: str = "search-card"
+    description: str = "search card"
+
+    def get_tools(self) -> list[Callable]:
+        return []
+
+    def get_commands(self) -> dict[type[BaseToolParam], Callable]:
+        def search_planning(
+            status: _Status | None = None,
+            owner: str | None = None,
+            creator: str | None = None,
+            query: str | None = None,
+            mode: str = "hybrid",
+        ) -> dict[str, object]:
+            """Search planning tasks by optional filters."""
+            return {
+                "status": status,
+                "owner": owner,
+                "creator": creator,
+                "query": query,
+                "mode": mode,
+            }
+
+        return {_HireParam: search_planning}
+
+
+class _RequiredPairCard(ToolCard):
+    """``f(a: str, b: str)`` with both required, for merged-arity tests."""
+
+    name: str = "pair-card"
+    description: str = "pair card"
+
+    def get_tools(self) -> list[Callable]:
+        return []
+
+    def get_commands(self) -> dict[type[BaseToolParam], Callable]:
+        def f(a: str, b: str) -> str:
+            """Concatenate a and b."""
+            return f"{a}|{b}"
+
+        return {_HireParam: f}
+
+
+# --- AC1: positional dispatch unchanged (backward compatibility) ------------
+
+
+def test_kw_positional_dispatch_unchanged() -> None:
+    registry = _registry(_HireCard())
+    result = registry.dispatch('/hire_member Developer "Alice Smith"')
+    assert "Developer" in result
+    assert "Alice Smith" in result
+
+
+# --- AC2: a name=value token binds by parameter name ------------------------
+
+
+def test_kw_binds_by_name_with_coercion() -> None:
+    registry = _registry(_SearchCard())
+    result = registry.dispatch("/search_planning status=pending")
+    assert "'status': 'pending'" in result
+    # Every other parameter falls back to its own default.
+    assert "'owner': None" in result
+    assert "'mode': 'hybrid'" in result
+
+
+# --- AC3: keyword reaches a later optional without filling earlier ones ------
+
+
+def test_kw_reaches_later_optional_only() -> None:
+    registry = _registry(_SearchCard())
+    result = registry.dispatch('/search_planning query="deploy the service"')
+    assert "'query': 'deploy the service'" in result
+    assert "'status': None" in result
+    assert "'owner': None" in result
+    assert "'creator': None" in result
+
+
+# --- AC4: mixed positional + keyword; positional-after-keyword errors --------
+
+
+def test_kw_mixed_positional_and_keyword() -> None:
+    registry = _registry(_SearchCard())
+    result = registry.dispatch("/search_planning pending owner=@Manager")
+    assert "'status': 'pending'" in result
+    assert "'owner': '@Manager'" in result
+
+
+def test_kw_positional_after_keyword_is_result_string() -> None:
+    registry = _registry(_SearchCard())
+    result = registry.dispatch("/search_planning status=pending @Manager")
+    assert isinstance(result, str)
+    # Post-identification failure: names the offending positional, not CommandNotRecognized.
+    assert "search_planning" in result
+    assert "@Manager" in result
+
+
+def test_kw_positional_after_keyword_does_not_raise() -> None:
+    registry = _registry(_SearchCard())
+    # Must NOT raise CommandNotRecognized — command was identified.
+    result = registry.dispatch("/search_planning status=pending @Manager")
+    assert isinstance(result, str)
+
+
+# --- AC5: keyword only when LHS is a real parameter name; first-= split ------
+
+
+def test_kw_value_containing_equals_via_keyword() -> None:
+    registry = _registry(_SearchCard())
+    result = registry.dispatch('/search_planning query="a=b"')
+    # Split on the FIRST '=' only -> query value is "a=b".
+    assert "'query': 'a=b'" in result
+
+
+def test_kw_unknown_lhs_is_positional_value() -> None:
+    registry = _registry(_HireCard())
+    # 'x' is NOT a parameter name -> token 'x=y' is a POSITIONAL value bound to role.
+    result = registry.dispatch("/hire_member x=y")
+    # role coerces the literal string "x=y" (first-= split is irrelevant: positional).
+    assert "x=y" in result
+
+
+# --- AC6: unknown keyword name -> result string, not CommandNotRecognized ----
+
+
+def test_kw_unknown_keyword_is_result_string() -> None:
+    registry = _registry(_SearchCard())
+    result = registry.dispatch("/search_planning foo=bar")
+    assert isinstance(result, str)
+    assert "search_planning" in result
+    assert "foo" in result
+
+
+def test_kw_unknown_keyword_does_not_raise_command_not_recognized() -> None:
+    registry = _registry(_SearchCard())
+    result = registry.dispatch("/search_planning foo=bar")
+    assert isinstance(result, str)  # caught inside dispatch
+
+
+# --- AC7: duplicate binding -> result string --------------------------------
+
+
+def test_kw_duplicate_positional_and_keyword_is_result_string() -> None:
+    registry = _registry(_SearchCard())
+    result = registry.dispatch("/search_planning pending status=started")
+    assert isinstance(result, str)
+    assert "status" in result
+
+
+def test_kw_duplicate_same_keyword_twice_is_result_string() -> None:
+    registry = _registry(_SearchCard())
+    # shlex keeps both tokens; first-= classification yields a repeated keyword.
+    result = registry.dispatch("/search_planning status=pending status=started")
+    assert isinstance(result, str)
+    assert "status" in result
+
+
+# --- AC8: arity / required checks over the merged binding -------------------
+
+
+def test_kw_missing_required_over_merged_set() -> None:
+    registry = _registry(_RequiredPairCard())
+    result = registry.dispatch("/f a=x")  # b left unbound
+    assert isinstance(result, str)
+    assert "f" in result
+    assert "b" in result
+
+
+def test_kw_over_supply_positionals_is_result_string() -> None:
+    registry = _registry(_RequiredPairCard())
+    result = registry.dispatch("/f x y z")  # max 2
+    assert isinstance(result, str)
+    assert "f" in result
+
+
+# --- AC9: coercion identical for keyword and positional values --------------
+
+
+def test_kw_int_coercion() -> None:
+    registry = _registry(_IntCard())
+    # f(task_id) returns task_id * 2 -> 10 proves "5" coerced to int via keyword.
+    assert registry.dispatch("/f task_id=5") == "10"
+
+
+def test_kw_bad_int_coercion_is_result_string() -> None:
+    registry = _registry(_IntCard())
+    result = registry.dispatch("/f task_id=notanint")
+    assert isinstance(result, str)
+    assert "f" in result
+
+
+# --- AC10: descriptors unchanged; unknown first token still raises -----------
+
+
+def test_kw_descriptors_unchanged_with_keyword_support() -> None:
+    registry = _registry(_HireCard(), _FireCard())
+    descriptors = registry.descriptors()
+    by_name = {d.name: d for d in descriptors}
+    assert set(by_name) == {"hire_member", "fire_member"}
+    hire = by_name["hire_member"]
+    assert [a.name for a in hire.args] == ["role", "name"]
+    assert hire.args[0].required is True
+    assert hire.args[1].required is False
+
+
+def test_kw_unknown_first_token_still_raises() -> None:
+    registry = _registry(_SearchCard())
+    with pytest.raises(CommandNotRecognized):
+        registry.dispatch("/frobnicate status=pending")


### PR DESCRIPTION
## Story 21.4 — Keyword (`key=value`) arguments in command dispatch

### Problem (the positional-only limitation this removes)

`CommandRegistry.dispatch` (Story 21.2, `core.py`) was **positional-only**: after `shlex.split`, token *N* bound to parameter *N* in signature order. There was no way to skip an earlier optional parameter, so for an all-optional command like `search_planning(status, owner, creator, query, mode)`:

- `/search_planning pending` worked (binds `status=pending`), but
- `/search_planning status pending` failed — `"status"` was coerced against `status: Literal[...]` and raised a literal-validation error, and
- searching by `query` alone was **not expressible at all**, because `status/owner/creator` come first.

### Fix (opt-in `key=value`)

Adds an opt-in `name=value` keyword form to `dispatch` so any parameter is addressable by name. Purely-positional dispatch is unchanged.

`dispatch` → `_invoke(name, args)` now delegates to two new static helpers:

- **`_classify_tokens(entry, args) -> (positional, keyword)`** — a token is a keyword **iff** it contains `=` AND the text before the **first** `=` (`str.partition("=")`) matches a real parameter name on the command; otherwise it is positional. A positional appearing after a keyword raises `ValueError`.
- **`_bind(entry, positional, keyword) -> dict`** — maps positionals onto the leading params in signature order, binds keywords by name, detects unknown-keyword and duplicate-binding, checks arity over the **merged** set, then coerces every bound value through the **same** per-arg `TypeAdapter` used for positionals. `fn(**bound)`; unbound trailing optionals are omitted so the callable applies its own defaults.

### Load-bearing parse rules

- **First-`=` split + name-guard** — values containing `=` (e.g. `query="a=b"`, or a positional `a=b` where `a` is not a parameter) are never silently swallowed as keywords.
- **Positional-before-keyword** — mirrors Python call grammar; a positional after a keyword is a user error returned as a result string.
- **Failure semantics inherited verbatim from 21.2** — only an unknown **first token** raises `CommandNotRecognized` (caller falls back to the LLM); every arg-level problem (unknown keyword, duplicate, bad coercion, arity, positional-after-keyword) is caught inside `dispatch` and returned as a plain result string.
- **`descriptors()` output is byte-for-byte unchanged** — keyword support is a dispatch-parse concern, not a schema change.

### Acceptance criteria

All 11 ACs verified. AC1 (positional unchanged), AC2/AC9 (keyword bind via same TypeAdapter), AC3 (later-optional reachable), AC4 (mixed + positional-after-keyword error), AC5 (first-`=` split + name-guard), AC6 (unknown keyword → result string), AC7 (duplicate → result string), AC8 (arity over merged set), AC10 (`descriptors()` unchanged + unknown first token still raises), AC11 (quality gates).

### Review

Senior Developer Review (Rex): **APPROVED**. One LOW cosmetic finding (a `_bind` docstring mentions `required_count` while the implementation uses the merged-set `missing` list — behavior is more correct than the doc); no HIGH/MEDIUM issues, so no fixup commit. Each helper ≤ ~50 lines.

### Local test result

- `pytest packages/akgentic-tool/tests/` → **1440 passed**
- `ruff check packages/akgentic-tool/src/` → clean
- `mypy packages/akgentic-tool/src/` → 65 pre-existing baseline errors, **zero introduced** by this change (none in the changed `_invoke`/`_classify_tokens`/`_bind` region)

### Note

The ADR-028 §Decision 2 amendment (superseding the `no key=value` clause; nested structures stay out of scope) and the `architecture/02-core.md#Dispatch grammar` update ride as **root-repo docs** (`_bmad-output/**`), intentionally kept out of this submodule commit per Golden Rule #4.

Relates to #182
Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)
