### PR TITLE
feat(akgentic-tool): epic 22 — Weak-reference the tool observer (22-1 → 22-3)

### DIFF
--- a/src/akgentic/tool/__init__.py
+++ b/src/akgentic/tool/__init__.py
@@ -19,7 +19,7 @@ from .core import (  # noqa: F401
     ToolCard,
     ToolFactory,
 )
-from .errors import CommandNotRecognized, RetriableError  # noqa: F401
+from .errors import CommandNotRecognized, RetriableError, ToolObserverGone  # noqa: F401
 from .event import (  # noqa: F401
     ActorToolObserver,
     CommandArg,
@@ -56,6 +56,7 @@ __all__ = [
     # Errors
     "RetriableError",
     "CommandNotRecognized",
+    "ToolObserverGone",
     # Events and observers
     "ToolObserver",
     "ActorToolObserver",

--- a/src/akgentic/tool/core.py
+++ b/src/akgentic/tool/core.py
@@ -10,16 +10,17 @@ import functools
 import inspect
 import shlex
 import warnings
+import weakref
 from abc import ABC, abstractmethod
 from collections import deque
 from dataclasses import dataclass
 from enum import StrEnum
 from typing import Any, Callable, TypeVar, get_type_hints
 
-from pydantic import TypeAdapter
+from pydantic import PrivateAttr, TypeAdapter
 
 from akgentic.core.utils import SerializableBaseModel
-from akgentic.tool.errors import CommandNotRecognized, RetriableError
+from akgentic.tool.errors import CommandNotRecognized, RetriableError, ToolObserverGone
 from akgentic.tool.event import CommandArg, CommandDescriptor, ToolObserver
 
 T = TypeVar("T", bound="BaseToolParam")
@@ -116,6 +117,9 @@ class ToolCard(SerializableBaseModel, ABC):
     on the card payload.
     """
 
+    # Runtime-only, WEAK: a tool/closure/registry must never pin its agent.
+    _observer_ref: "weakref.ref[ToolObserver] | None" = PrivateAttr(default=None)
+
     @property
     def depends_on(self) -> list[str]:
         """Class-name list of ToolCards that MUST be wired before this one.
@@ -130,11 +134,14 @@ class ToolCard(SerializableBaseModel, ABC):
         return []
 
     def observer(self, observer: ToolObserver) -> "ToolCard":
-        """Attach an observer and perform runtime setup.
+        """Attach an observer (held weakly) and perform runtime setup.
 
         Follows the same pattern as ``BaseState.observer()``.
         Override for setup that requires the observer (e.g., actor proxies).
         All methods can then access the observer via ``self._observer``.
+
+        The observer is stored through a ``weakref`` so a tool, its closures, and
+        its command registry can never pin a stopped owning agent in memory.
 
         Args:
             observer: Optional observer for tool call events.
@@ -144,6 +151,23 @@ class ToolCard(SerializableBaseModel, ABC):
         """
         self._observer = observer
         return self
+
+    @property
+    def _observer(self) -> "ToolObserver":
+        """Live observer for synchronous, in-life use. Raises if the agent has stopped."""
+        obs = self._observer_or_none()
+        if obs is None:
+            raise ToolObserverGone("tool used after its owning agent was stopped")
+        return obs
+
+    @_observer.setter
+    def _observer(self, observer: ToolObserver) -> None:
+        """Store the observer weakly (backward-compatible ``self._observer = observer``)."""
+        self._observer_ref = weakref.ref(observer)
+
+    def _observer_or_none(self) -> "ToolObserver | None":
+        """Return the live observer, or ``None`` if unset or already collected."""
+        return self._observer_ref() if self._observer_ref is not None else None
 
     @abstractmethod
     def get_tools(self) -> list[Callable]:

--- a/src/akgentic/tool/errors.py
+++ b/src/akgentic/tool/errors.py
@@ -16,6 +16,12 @@ class RetriableError(Exception):
     pass
 
 
+class ToolObserverGone(RuntimeError):  # noqa: N818 — name mirrors CommandNotRecognized precedent
+    """A tool callable ran after its owning agent was stopped."""
+
+    pass
+
+
 class CommandNotRecognized(Exception):  # noqa: N818 — story-mandated name; identification signal
     """Raised when the first dispatch token is not a known command (ADR-028 §Decision 4).
 

--- a/src/akgentic/tool/knowledge_graph/kg_tool.py
+++ b/src/akgentic/tool/knowledge_graph/kg_tool.py
@@ -167,7 +167,7 @@ class KnowledgeGraphTool(ToolCard):
         from akgentic.tool.knowledge_graph import _check_kg_dependencies
 
         _check_kg_dependencies()
-        self._observer = observer
+        super().observer(observer)  # store the observer weakly via the base setter
 
         if observer.orchestrator is None:
             raise ValueError("KnowledgeGraphTool requires access to the orchestrator.")

--- a/src/akgentic/tool/planning/planning.py
+++ b/src/akgentic/tool/planning/planning.py
@@ -15,6 +15,7 @@ from akgentic.tool.core import (
     ToolCard,
     _resolve,
 )
+from akgentic.tool.errors import RetriableError
 from akgentic.tool.event import ActorToolObserver
 from akgentic.tool.planning.planning_actor import (
     PlanActor,
@@ -125,7 +126,7 @@ class PlanningTool(ToolCard):
 
         Requires an ActorToolObserver for actor system access.
         """
-        self._observer = observer
+        super().observer(observer)  # store the observer weakly via the base setter
         if observer.orchestrator is None:
             raise ValueError("PlanningTool requires access to the orchestrator.")
 
@@ -273,7 +274,7 @@ class PlanningTool(ToolCard):
 
     def _update_planning_factory(self, params: UpdatePlanning) -> Callable:
         planning_proxy = self._planning_proxy
-        observer = self._observer
+        observer_or_none = self._observer_or_none  # bound method -> weak edge to agent
 
         def update_planning(update: UpdatePlan) -> str:
             """Update team tasks (create, update, delete).
@@ -282,6 +283,9 @@ class PlanningTool(ToolCard):
             - description: max 300 characters — keep it concise.
             - output: max 150 characters — will be truncated automatically if exceeded.
             """
+            observer = observer_or_none()
+            if observer is None:
+                raise RetriableError("Plan is unavailable; the agent is shutting down.")
             ## observer.myAddress is used to set the creator of any new tasks in the plan.
             return planning_proxy.update_planning(update, observer.myAddress)
 

--- a/src/akgentic/tool/sandbox/tool.py
+++ b/src/akgentic/tool/sandbox/tool.py
@@ -135,7 +135,7 @@ class ExecTool(ToolCard):
             ValueError: If observer.orchestrator is None.
             KeyError: If ``self.mode`` names an unregistered backend.
         """
-        self._observer = observer
+        super().observer(observer)  # store the observer weakly via the base setter
         if observer.orchestrator is None:
             raise ValueError("ExecTool requires access to the orchestrator.")
 

--- a/src/akgentic/tool/team/team.py
+++ b/src/akgentic/tool/team/team.py
@@ -192,7 +192,7 @@ class TeamTool(ToolCard):
         Raises:
             ValueError: If observer.orchestrator is None
         """
-        self._observer = observer
+        super().observer(observer)  # store the observer weakly via the base setter
         if observer.orchestrator is None:
             raise ValueError("TeamTool requires access to the orchestrator.")
 
@@ -271,7 +271,7 @@ class TeamTool(ToolCard):
             Callable that hires team members
         """
         orchestrator_proxy = self._orchestrator_proxy
-        observer = self._observer
+        observer_or_none = self._observer_or_none  # bound method -> weak edge to agent
 
         def hire_members(roles: list[str]) -> str:
             """Hire multiple new team members with the given roles.
@@ -289,6 +289,9 @@ class TeamTool(ToolCard):
                 Confirmation message with hired member names
                 (e.g., 'Members hired: [@Developer123, @Tester456]')
             """
+            observer = observer_or_none()
+            if observer is None:
+                raise RetriableError("Team is shutting down; cannot hire.")
             if not roles:
                 raise RetriableError("No roles provided. Specify at least one role to hire.")
 
@@ -338,7 +341,7 @@ class TeamTool(ToolCard):
             Callable that hires a single team member
         """
         orchestrator_proxy = self._orchestrator_proxy
-        observer = self._observer
+        observer_or_none = self._observer_or_none  # bound method -> weak edge to agent
 
         def hire_member(role: str, name: str | None = None):
             """Hire a single new team member with the given role.
@@ -353,6 +356,9 @@ class TeamTool(ToolCard):
             Returns:
                 Tuple of (member_name, member_address)
             """
+            observer = observer_or_none()
+            if observer is None:
+                raise RetriableError("Team is shutting down; cannot hire.")
             existing_names = {member.name for member in orchestrator_proxy.get_team()}
             return _hire_single_member(orchestrator_proxy, observer, role, name, existing_names)
 
@@ -368,7 +374,7 @@ class TeamTool(ToolCard):
             Callable that fires team members
         """
         orchestrator_proxy = self._orchestrator_proxy
-        observer = self._observer
+        observer_or_none = self._observer_or_none  # bound method -> weak edge to agent
 
         def fire_members(names: list[str]) -> str:
             """Fire multiple team members with the given names.
@@ -385,6 +391,9 @@ class TeamTool(ToolCard):
             Returns:
                 Combined confirmation messages (e.g., "Members fired: @Developer123, @Tester456")
             """
+            observer = observer_or_none()
+            if observer is None:
+                raise RetriableError("Team is shutting down; cannot fire.")
             if not names:
                 raise RetriableError("No names provided. Specify at least one member name to fire.")
 
@@ -424,7 +433,7 @@ class TeamTool(ToolCard):
             Callable that fires a single team member
         """
         orchestrator_proxy = self._orchestrator_proxy
-        observer = self._observer
+        observer_or_none = self._observer_or_none  # bound method -> weak edge to agent
 
         def fire_member(name: str) -> str:
             """Fire a team member with the given name.
@@ -437,6 +446,9 @@ class TeamTool(ToolCard):
             Returns:
                 Confirmation message (e.g., "Member @Developer123 has been fired.")
             """
+            observer = observer_or_none()
+            if observer is None:
+                raise RetriableError("Team is shutting down; cannot fire.")
             _fire_single_member(orchestrator_proxy, observer, name)
             return f"Member {name} has been fired."
 
@@ -452,7 +464,7 @@ class TeamTool(ToolCard):
             Callable that generates team roster prompt
         """
         orchestrator_proxy = self._orchestrator_proxy
-        observer = self._observer
+        observer_or_none = self._observer_or_none  # bound method -> weak edge to agent
 
         def team_members() -> str:
             """Get current team composition as context.
@@ -464,6 +476,9 @@ class TeamTool(ToolCard):
                 Formatted team roster or empty string if no members
             """
             try:
+                observer = observer_or_none()
+                if observer is None:
+                    return ""  # agent gone -> no roster context
                 team_members = orchestrator_proxy.get_team()
                 if not team_members:
                     return ""

--- a/src/akgentic/tool/vector_store/tool.py
+++ b/src/akgentic/tool/vector_store/tool.py
@@ -85,7 +85,7 @@ class VectorStoreTool(ToolCard):
         Raises:
             ValueError: When ``observer.orchestrator`` is ``None``.
         """
-        self._observer = observer
+        super().observer(observer)  # store the observer weakly via the base setter
 
         if observer.orchestrator is None:
             raise ValueError("VectorStoreTool requires access to the orchestrator.")

--- a/src/akgentic/tool/workspace/tool.py
+++ b/src/akgentic/tool/workspace/tool.py
@@ -465,7 +465,7 @@ class WorkspaceTool(ToolCard):
         """
         if observer.orchestrator is None:
             raise ValueError("WorkspaceTool requires access to the orchestrator.")
-        self._observer = observer
+        super().observer(observer)  # store the observer weakly via the base setter
         ws_name = self.workspace_id or str(observer.team_id)
         self._workspace = get_workspace(ws_name)
         self._seed_resources()

--- a/tests/test_command_registry_weak_observer.py
+++ b/tests/test_command_registry_weak_observer.py
@@ -1,0 +1,131 @@
+"""Cross-tool gc-reclamation regression tests (Epic 22 / ADR-030, Story 22.3).
+
+A tool's command registry — built via the public ``ToolFactory`` API — must never
+pin a weak-referenced owning agent. After the only strong reference to the observer
+is dropped and ``gc.collect()`` runs, the agent is reclaimed even while the registry
+and its ``_CommandEntry`` closures are still held. This proves FR6: no tool, its
+closures, or the agent's command registry keeps a stopped ``BaseAgent`` alive.
+
+Also covers ``PlanningTool._update_planning_factory`` deref-at-call behaviour:
+the alive path performs the existing ``planning_proxy.update_planning(...)`` call;
+the gone path raises ``RetriableError`` (not ``AttributeError`` / ``ToolObserverGone``).
+"""
+
+from __future__ import annotations
+
+import gc
+import uuid
+import weakref
+from unittest.mock import Mock
+
+import pytest
+from akgentic.core import ActorAddressProxy
+from akgentic.core.orchestrator import Orchestrator
+from akgentic.tool.core import ToolFactory
+from akgentic.tool.errors import RetriableError
+from akgentic.tool.event import TeamManagementToolObserver
+from akgentic.tool.planning.planning import PlanningTool, UpdatePlanning
+from akgentic.tool.team import TeamTool
+
+
+def _address(name: str, role: str = "Agent") -> ActorAddressProxy:
+    """Create a mock ActorAddress for testing."""
+    return ActorAddressProxy(
+        {
+            "__actor_address__": True,
+            "__actor_type__": "test.Agent",
+            "agent_id": str(uuid.uuid4()),
+            "name": name,
+            "role": role,
+            "team_id": str(uuid.uuid4()),
+            "squad_id": str(uuid.uuid4()),
+            "user_message": True,
+        }
+    )
+
+
+def _make_observer() -> Mock:
+    """Weak-referenceable observer with a DETACHED orchestrator proxy.
+
+    ``Mock`` (unlike a bare ``object()``) is weak-referenceable. The orchestrator
+    proxy is a free-standing ``Mock`` (NOT a child of ``observer``): a child mock's
+    parent chain would back-edge to the observer and, pinned by a tool's strong
+    ``_orchestrator_proxy`` / ``_planning_proxy``, defeat gc reclamation.
+    ``proxy_ask`` returns that detached orchestrator for every call, so both
+    ``PlanningTool`` and ``TeamTool`` wire against it without pinning the observer.
+    """
+    observer = Mock(spec=TeamManagementToolObserver)
+    observer.orchestrator = _address("@Orchestrator", "Orchestrator")
+    observer.myAddress = _address("@Manager", "Manager")
+
+    orchestrator = Mock(spec=Orchestrator)
+    orchestrator.get_team.return_value = [_address("@Manager", "Manager")]
+    observer.proxy_ask = Mock(return_value=orchestrator)
+    return observer
+
+
+def _build_registry(observer: Mock) -> object:
+    """Wire TeamTool + PlanningTool through the public ToolFactory and build the registry.
+
+    ``PlanningTool(vector_store=False)`` runs in degraded mode so it declares no
+    ``VectorStoreTool`` dependency — the command wiring under test (and the weak
+    observer edge) is independent of the VectorStoreActor lookup.
+    """
+    factory = ToolFactory([TeamTool(), PlanningTool(vector_store=False)], observer=observer)
+    return factory.get_command_registry()
+
+
+# ── Cross-tool command-registry gc reclamation (AC6) ─────────────────────────
+
+
+def test_command_registry_does_not_pin_stopped_agent() -> None:
+    # AC6: a command registry built from TeamTool + PlanningTool must NOT keep the
+    # weak-referenced agent alive once the only strong ref is dropped + gc runs.
+    observer = _make_observer()
+    registry = _build_registry(observer)
+
+    agent_weakref = weakref.ref(observer)
+    del observer
+    gc.collect()
+
+    assert agent_weakref() is None  # registry + closures do not pin the agent
+    assert registry is not None  # registry is still held, yet the agent was reclaimed
+
+
+# ── PlanningTool._update_planning_factory deref-at-call (AC3, AC7) ────────────
+
+
+def test_update_planning_in_life_calls_proxy() -> None:
+    # AC7 alive path: while the agent is alive, update_planning performs the same
+    # planning_proxy.update_planning(update, observer.myAddress) call as before.
+    observer = _make_observer()
+    tool = PlanningTool(vector_store=False)
+    tool.observer(observer)
+
+    # Replace the wired PlanActor proxy with a dedicated mock to assert the call.
+    planning_proxy = Mock()
+    planning_proxy.update_planning.return_value = "updated"
+    tool._planning_proxy = planning_proxy
+    update_planning = tool._update_planning_factory(UpdatePlanning())
+
+    update = Mock()
+    result = update_planning(update)
+
+    assert result == "updated"
+    planning_proxy.update_planning.assert_called_once_with(update, observer.myAddress)
+
+
+def test_update_planning_raises_after_stop() -> None:
+    # AC3 gone path: once the agent is collected, update_planning raises
+    # RetriableError (not AttributeError / ToolObserverGone).
+    observer = _make_observer()
+    tool = PlanningTool(vector_store=False)
+    tool.observer(observer)
+    update_planning = tool._update_planning_factory(UpdatePlanning())
+
+    del observer
+    gc.collect()
+
+    assert tool._observer_or_none() is None
+    with pytest.raises(RetriableError, match="shutting down"):
+        update_planning(Mock())

--- a/tests/test_core_factory.py
+++ b/tests/test_core_factory.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar
 
 import pytest
-
 from akgentic.tool.core import (
     COMMAND,
     TOOL_CALL,
@@ -375,6 +374,8 @@ class StubPlanningTool(ToolCard):
 
 def test_tool_factory_topological_sort_happy_path() -> None:
     """VectorStore is wired before KG and Planning regardless of input order."""
+    from unittest.mock import MagicMock  # noqa: PLC0415
+
     calls: list[str] = []
 
     class _RecordingVS(StubVectorStoreTool):
@@ -400,7 +401,9 @@ def test_tool_factory_topological_sort_happy_path() -> None:
     plan = _RecordingPlan()
     vs = _RecordingVS()
 
-    factory = ToolFactory(tool_cards=[kg, plan, vs], observer=object())
+    # Observer is held weakly by ToolCard, so it must be weak-referenceable
+    # (a bare object() is not). The value is irrelevant to the ordering assertion.
+    factory = ToolFactory(tool_cards=[kg, plan, vs], observer=MagicMock())
     # VS must be first; KG and Planning preserve their relative input order (kg before plan).
     assert calls == ["_RecordingVS", "_RecordingKG", "_RecordingPlan"]
     assert [type(c).__name__ for c in factory.tool_cards] == [

--- a/tests/test_team_tool_weak_observer.py
+++ b/tests/test_team_tool_weak_observer.py
@@ -1,0 +1,182 @@
+"""Weak-observer regression tests for ``TeamTool`` (Epic 22 / ADR-030).
+
+Story 22.2: every observer-capturing closure factory captures the tool's weak
+accessor (``self._observer_or_none``) and derefs at call time, so a ``TeamTool``,
+its tool/command/prompt closures, and the agent's command registry can never pin
+a stopped owning agent. Once the agent is collected, hire/fire callables raise
+``RetriableError`` and the roster prompt returns the benign fallback.
+"""
+
+from __future__ import annotations
+
+import gc
+import uuid
+import weakref
+from unittest.mock import Mock
+
+import pytest
+from akgentic.core import ActorAddressProxy
+from akgentic.core.orchestrator import Orchestrator
+
+from akgentic.tool.errors import RetriableError
+from akgentic.tool.event import TeamManagementToolObserver
+from akgentic.tool.team import (
+    FireTeamMember,
+    GetTeamRoster,
+    HireTeamMember,
+    TeamTool,
+)
+
+
+def _address(name: str, role: str = "Agent") -> ActorAddressProxy:
+    """Create a mock ActorAddress for testing."""
+    return ActorAddressProxy(
+        {
+            "__actor_address__": True,
+            "__actor_type__": "test.Agent",
+            "agent_id": str(uuid.uuid4()),
+            "name": name,
+            "role": role,
+            "team_id": str(uuid.uuid4()),
+            "squad_id": str(uuid.uuid4()),
+            "user_message": True,
+        }
+    )
+
+
+def _make_observer() -> Mock:
+    """Weak-referenceable observer stand-in with a live orchestrator proxy.
+
+    ``Mock`` (unlike a bare ``object()``) is weak-referenceable, matching the
+    idiom the existing ``TeamTool`` tests rely on.
+    """
+    observer = Mock(spec=TeamManagementToolObserver)
+    observer.orchestrator = _address("@Orchestrator", "Orchestrator")
+    observer.myAddress = _address("@Manager", "Manager")
+
+    # Detached orchestrator mock: NOT a child of ``observer`` (a child mock's
+    # parent chain would strongly pin the observer through
+    # ``tool._orchestrator_proxy`` and defeat the gc reclamation assertions).
+    orchestrator = Mock(spec=Orchestrator)
+    orchestrator.get_team.return_value = [_address("@Manager", "Manager")]
+    observer.proxy_ask = Mock(return_value=orchestrator)
+    return observer
+
+
+# ── In-life parity (AC4) ─────────────────────────────────────────────────────
+
+
+def test_in_life_roster_unchanged() -> None:
+    # While the agent is alive, the roster prompt produces its usual output.
+    observer = _make_observer()
+    tool = TeamTool()
+    tool.observer(observer)
+
+    roster_prompt = tool.get_system_prompts()[0]
+    result = roster_prompt()
+    assert "Here is the team member list by name (and role):" in result
+    assert "@Manager (role: Manager)" in result
+    assert "[you]" in result
+
+
+def test_in_life_hire_unchanged() -> None:
+    # While the agent is alive, hire still calls createActor + on_hire.
+    observer = _make_observer()
+    orchestrator = observer.proxy_ask.return_value
+
+    agent_card = Mock()
+    agent_card.role = "Developer"
+    agent_card.get_agent_class.return_value = Mock
+    agent_card.get_config_copy.return_value = Mock()
+    orchestrator.get_team.return_value = []
+    orchestrator.get_agent_catalog.return_value = [agent_card]
+    observer.createActor.return_value = _address("@Developer123", "Developer")
+
+    tool = TeamTool()
+    tool.observer(observer)
+    hire_members = tool.get_tools()[0]
+
+    result = hire_members(["Developer"])
+    assert "Members hired:" in result
+    observer.createActor.assert_called_once()
+    observer.on_hire.assert_called_once()
+
+
+# ── Post-stop reclamation + clean failure (AC5) ──────────────────────────────
+
+
+def test_closures_do_not_pin_stopped_agent() -> None:
+    # AC5 (a)+(b): after dropping the only strong ref and gc, the observer is
+    # collected even though the built closures are still held.
+    observer = _make_observer()
+    tool = TeamTool()
+    tool.observer(observer)
+
+    ref = weakref.ref(observer)
+    # Build (and hold) tool/command/prompt closures — they must NOT pin the agent.
+    held = [
+        *tool.get_tools(),
+        *tool.get_system_prompts(),
+        *tool.get_commands().values(),
+    ]
+
+    del observer
+    gc.collect()
+
+    assert tool._observer_or_none() is None  # tool does not keep the observer alive
+    assert ref() is None  # closures do not pin the agent
+    assert held  # closures are still referenced here, yet the agent was reclaimed
+
+
+def test_hire_callables_raise_after_stop() -> None:
+    # AC5 (c): hire tool + command raise RetriableError (not AttributeError /
+    # ToolObserverGone) once the agent is gone.
+    observer = _make_observer()
+    tool = TeamTool()
+    tool.observer(observer)
+
+    hire_members = tool.get_tools()[0]
+    hire_member = tool.get_commands()[HireTeamMember]
+
+    del observer
+    gc.collect()
+
+    with pytest.raises(RetriableError, match="cannot hire"):
+        hire_members(["Developer"])
+    with pytest.raises(RetriableError, match="cannot hire"):
+        hire_member("Developer")
+
+
+def test_fire_callables_raise_after_stop() -> None:
+    # AC5 (c): fire tool + command raise RetriableError once the agent is gone.
+    observer = _make_observer()
+    tool = TeamTool()
+    tool.observer(observer)
+
+    fire_members = tool.get_tools()[1]
+    fire_member = tool.get_commands()[FireTeamMember]
+
+    del observer
+    gc.collect()
+
+    with pytest.raises(RetriableError, match="cannot fire"):
+        fire_members(["@Developer123"])
+    with pytest.raises(RetriableError, match="cannot fire"):
+        fire_member("@Developer123")
+
+
+def test_roster_prompt_returns_fallback_after_stop() -> None:
+    # AC5 (d): roster prompt returns the benign fallback (a string, no raise)
+    # once the agent is gone — observer.myAddress.name must never run on None.
+    observer = _make_observer()
+    tool = TeamTool()
+    tool.observer(observer)
+
+    roster_prompt = tool.get_commands()[GetTeamRoster]
+
+    del observer
+    gc.collect()
+
+    result = roster_prompt()
+    assert isinstance(result, str)
+    assert result == ""

--- a/tests/test_toolcard_weak_observer.py
+++ b/tests/test_toolcard_weak_observer.py
@@ -1,0 +1,89 @@
+"""Behavioral tests for the base ``ToolCard`` weak-observer storage (Epic 22 / ADR-030).
+
+The observer (owning agent) is held through a ``weakref`` so a tool, its closures,
+and its command registry can never pin a stopped agent in memory. Access goes
+through the ``_observer`` property, which derefs the weakref and raises
+``ToolObserverGone`` once the referent is collected.
+"""
+
+import gc
+import weakref
+from typing import Callable
+
+import pytest
+from akgentic.tool.core import ToolCard
+from akgentic.tool.errors import ToolObserverGone
+
+
+class _DummyToolCard(ToolCard):
+    """Minimal concrete ``ToolCard`` for exercising base observer storage."""
+
+    def get_tools(self) -> list[Callable]:
+        return []
+
+
+class _Observer:
+    """Trivial weak-referenceable observer stand-in (satisfies the shape used here)."""
+
+
+def test_observer_stores_a_weakref_and_does_not_pin() -> None:
+    # AC6(a): observer() stores a weakref — the card does not keep the observer alive.
+    card = _DummyToolCard()
+    obs = _Observer()
+    assert card.observer(obs) is card  # method chaining preserved
+
+    ref = weakref.ref(obs)
+    del obs
+    gc.collect()
+    assert ref() is None  # card did not pin it
+
+
+def test_observer_property_returns_live_observer() -> None:
+    # AC6(b): _observer returns the live observer while it is referenced.
+    card = _DummyToolCard()
+    obs = _Observer()
+    card.observer(obs)
+    assert card._observer is obs
+
+
+def test_observer_gone_after_collection() -> None:
+    # AC6(c): after drop + gc, _observer_or_none() is None and _observer raises.
+    card = _DummyToolCard()
+    obs = _Observer()
+    card.observer(obs)
+    del obs
+    gc.collect()
+    assert card._observer_or_none() is None
+    with pytest.raises(ToolObserverGone):
+        _ = card._observer
+
+
+def test_observer_or_none_when_unset() -> None:
+    # Covers the `_observer_ref is None` branch of _observer_or_none().
+    card = _DummyToolCard()
+    assert card._observer_or_none() is None
+    with pytest.raises(ToolObserverGone):
+        _ = card._observer
+
+
+def test_observer_setter_stores_weakly() -> None:
+    # LEAD DECISION (backward compatibility): `self._observer = obs` keeps working
+    # and stores the observer weakly, so direct assignment never pins the agent.
+    card = _DummyToolCard()
+    obs = _Observer()
+    card._observer = obs
+    assert card._observer is obs
+
+    ref = weakref.ref(obs)
+    del obs
+    gc.collect()
+    assert ref() is None
+    assert card._observer_or_none() is None
+
+
+def test_observer_ref_excluded_from_model_dump() -> None:
+    # AC6(d): _observer_ref is a PrivateAttr — excluded from serialization.
+    card = _DummyToolCard()
+    card.observer(_Observer())
+    assert "_observer_ref" not in card.model_dump()
+    assert "_observer_ref" not in card.model_dump(mode="json")


### PR DESCRIPTION
## Epic 22 — Weak-reference the tool observer (ADR-030)

Hold the `ToolCard` observer (the owning agent) through a `weakref` so a tool, its
closures, and its command registry can never pin a stopped `BaseAgent` in memory,
making stopped agents reclaimable by `gc.collect()`.

This is the umbrella PR for the epic. Stories land coherently on this single shared
branch so the `akgentic-tool` suite stays green at each step.

## Stories (submodule code)

- [x] **22-1** Base `ToolCard` weak-observer storage, `_observer` property, and `ToolObserverGone` (Relates to #184)
- [x] **22-2** `TeamTool` factories — weak-accessor pattern (Relates to #186)
- [x] **22-3** Audit other tools + GC regression test (Relates to #187)

## Review status

- **22-1 — done.** All ACs satisfied. AC3 was amended by a documented LEAD DECISION:
  `_observer` is a property with a deref-or-raise getter (raises `ToolObserverGone`
  once the agent is collected) PLUS a weak-storing setter, so existing subclasses
  that assign `self._observer = observer` keep working. This is backward compatible
  by design with no strong fallback — a read-only property would red the suite until
  22-2/22-3 land. Full local suite green (1446 passed), mypy strict clean (submodule
  config, 39 files), `ruff check src/` clean, coverage 92.32% (gate 80%). No fixup
  commit was required — the implementation was correct as committed (`9de1fce`).
- **22-2 — PASS (done).** All six ACs satisfied as committed (`5850092`); no fixup
  required. `TeamTool.observer()` delegates storage to `super().observer()` (weak
  setter), keeping the orchestrator guard, the strong `_orchestrator_proxy` capture,
  and `return self` (AC1). All five observer-capturing factories now capture the weak
  accessor `observer_or_none = self._observer_or_none` and deref at call time:
  hire/fire raise `RetriableError` on a stopped agent (before touching
  `_hire_single_member`/`_fire_single_member`), the roster prompt returns the benign
  `""` fallback before `observer.myAddress.name` can run on `None` (AC2/AC3).
  `_role_profiles_prompt_factory` correctly unchanged — orchestrator-only capture.
  In-life parity preserved (AC4) and a new gc regression test
  (`test_team_tool_weak_observer.py`) proves the closures do not pin the agent and
  post-stop calls fail cleanly (AC5 a–d). Full local suite green (1452 passed), mypy
  strict + `ruff check` clean on the touched files (AC6). No `ADR-NNN` assertions, no
  edits outside `packages/akgentic-tool/`.
- **22-3 — PASS (done).** All eight ACs satisfied as committed (`184a9d6`); no fixup
  required. The five remaining `observer()` overrides (`PlanningTool`,
  `WorkspaceTool`, `KnowledgeGraphTool`, `ExecTool`, `VectorStoreTool`) now delegate
  storage to `super().observer()` with every guard, actor-wiring line, return value,
  and annotation preserved byte-for-byte (AC1/AC2/AC5). The one in-scope closure
  capture — `PlanningTool._update_planning_factory` — now captures the weak accessor
  `observer_or_none = self._observer_or_none` and derefs at call time, raising
  `RetriableError("Plan is unavailable; the agent is shutting down.")` once the agent
  has stopped (AC3). `_planning_prompt_factory`'s synchronous bind-time
  `agent_name = self._observer.myAddress.name` read (string-only closure) and
  `SearchTool` are correctly left unchanged (AC4/AC5). The new
  `test_command_registry_weak_observer.py` proves — non-vacuously, holding the
  registry across `del observer` + `gc.collect()` — that a `ToolFactory(...)`
  command registry built over `TeamTool` + `PlanningTool` does not pin the weak
  observer, plus alive-path (`assert_called_once_with(update, observer.myAddress)`)
  and gone-path (`RetriableError`) behavioral tests exercising both branches of the
  new guard (AC6/AC7/AC8). Full local suite green (1455 passed), mypy strict clean
  (39 files), `ruff check` clean on `src/` + the new test. No `ADR-NNN` assertions,
  no `arbitrary_types_allowed`, no Pydantic field changes, no edits outside
  `packages/akgentic-tool/`.

## Epic 22 slice complete

The three code stories of Epic 22 have landed on this branch:

- **22-1** — base `ToolCard` weak-observer storage (`_observer_ref` weak `PrivateAttr`,
  deref-or-raise property, `ToolObserverGone`).
- **22-2** — `TeamTool`'s `observer()` delegation + its five factories converted to the
  weak-accessor / deref-at-call pattern.
- **22-3** — the remaining tools' `observer()` overrides delegated, the last in-scope
  closure capture (`PlanningTool._update_planning_factory`) converted, and a cross-tool
  command-registry gc-reclamation regression test added.

With FR6 complete, no tool — through its closures, prompts, or the agent's command
registry — pins a stopped `BaseAgent`, so the agent ↔ state cycle is reclaimed by
`gc.collect()`. Stopped agents are now genuinely reclaimable. Story 22-4 (architecture
docs) is a separate root-repo, doc-only change and is **not** part of this submodule PR.

## Scope guard

All changes in this PR stay inside `packages/akgentic-tool/` (verified against
commit `9de1fce`: `src/akgentic/tool/core.py`, `errors.py`, `__init__.py`, and the
two test files; `5850092`: `src/akgentic/tool/team/team.py` plus
`tests/test_team_tool_weak_observer.py`; and `184a9d6`:
`src/akgentic/tool/{planning/planning.py, workspace/tool.py, knowledge_graph/kg_tool.py, sandbox/tool.py, vector_store/tool.py}`
plus `tests/test_command_registry_weak_observer.py`). No cross-submodule edits
(CLAUDE.md Golden Rule #4).

---

> Footnote: Story 22-4 (architecture docs) is a root-repo doc change tracked
> separately, not in this PR.
