### PR TITLE
feat: backport resource-lifecycle / weak-observer fixes + pydantic-ai pin to version-1.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "akgentic-core",
     "pydantic>=2.0.0",
     "tavily-python>=0.7.12",
-    "pydantic-ai>=0.1.0",
+    "pydantic-ai>=1.107.0,<2",
     "httpx>=0.27.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akgentic-tool"
-version = "1.2.0"
+version = "1.2.1"
 description = "Tool interface and factory for Akgentic agent systems"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/akgentic/tool/__init__.py
+++ b/src/akgentic/tool/__init__.py
@@ -19,7 +19,7 @@ from .core import (  # noqa: F401
     ToolCard,
     ToolFactory,
 )
-from .errors import CommandNotRecognized, RetriableError  # noqa: F401
+from .errors import CommandNotRecognized, RetriableError, ToolObserverGone  # noqa: F401
 from .event import (  # noqa: F401
     ActorToolObserver,
     CommandArg,
@@ -56,6 +56,7 @@ __all__ = [
     # Errors
     "RetriableError",
     "CommandNotRecognized",
+    "ToolObserverGone",
     # Events and observers
     "ToolObserver",
     "ActorToolObserver",

--- a/src/akgentic/tool/__init__.py
+++ b/src/akgentic/tool/__init__.py
@@ -15,12 +15,16 @@ from .core import (  # noqa: F401
     TOOL_CALL,
     BaseToolParam,
     Channels,
+    CommandRegistry,
     ToolCard,
     ToolFactory,
 )
-from .errors import RetriableError  # noqa: F401
+from .errors import CommandNotRecognized, RetriableError  # noqa: F401
 from .event import (  # noqa: F401
     ActorToolObserver,
+    CommandArg,
+    CommandDescriptor,
+    CommandsAnnouncedEvent,
     TeamManagementToolObserver,
     ToolObserver,
     ToolStateEvent,
@@ -43,6 +47,7 @@ __all__ = [
     "BaseToolParam",
     "ToolCard",
     "ToolFactory",
+    "CommandRegistry",
     # Expose channel constants
     "COMMAND",
     "SYSTEM_PROMPT",
@@ -50,6 +55,7 @@ __all__ = [
     "Channels",
     # Errors
     "RetriableError",
+    "CommandNotRecognized",
     # Events and observers
     "ToolObserver",
     "ActorToolObserver",
@@ -57,6 +63,10 @@ __all__ = [
     "ToolStateEvent",
     "ToolStatePayload",
     "KnowledgeGraphStateEvent",
+    # Command discovery models
+    "CommandArg",
+    "CommandDescriptor",
+    "CommandsAnnouncedEvent",
     # Submodules
     "mcp",
     "planning",

--- a/src/akgentic/tool/core.py
+++ b/src/akgentic/tool/core.py
@@ -10,16 +10,17 @@ import functools
 import inspect
 import shlex
 import warnings
+import weakref
 from abc import ABC, abstractmethod
 from collections import deque
 from dataclasses import dataclass
 from enum import StrEnum
 from typing import Any, Callable, TypeVar, get_type_hints
 
-from pydantic import TypeAdapter
+from pydantic import PrivateAttr, TypeAdapter
 
 from akgentic.core.utils import SerializableBaseModel
-from akgentic.tool.errors import CommandNotRecognized, RetriableError
+from akgentic.tool.errors import CommandNotRecognized, RetriableError, ToolObserverGone
 from akgentic.tool.event import CommandArg, CommandDescriptor, ToolObserver
 
 T = TypeVar("T", bound="BaseToolParam")
@@ -120,6 +121,8 @@ class ToolCard(SerializableBaseModel, ABC):
 
     name: str
     description: str
+    # Runtime-only, WEAK: a tool/closure/registry must never pin its agent.
+    _observer_ref: "weakref.ref[ToolObserver] | None" = PrivateAttr(default=None)
 
     @property
     def depends_on(self) -> list[str]:
@@ -135,11 +138,14 @@ class ToolCard(SerializableBaseModel, ABC):
         return []
 
     def observer(self, observer: ToolObserver) -> "ToolCard":
-        """Attach an observer and perform runtime setup.
+        """Attach an observer (held weakly) and perform runtime setup.
 
         Follows the same pattern as ``BaseState.observer()``.
         Override for setup that requires the observer (e.g., actor proxies).
         All methods can then access the observer via ``self._observer``.
+
+        The observer is stored through a ``weakref`` so a tool, its closures, and
+        its command registry can never pin a stopped owning agent in memory.
 
         Args:
             observer: Optional observer for tool call events.
@@ -149,6 +155,23 @@ class ToolCard(SerializableBaseModel, ABC):
         """
         self._observer = observer
         return self
+
+    @property
+    def _observer(self) -> "ToolObserver":
+        """Live observer for synchronous, in-life use. Raises if the agent has stopped."""
+        obs = self._observer_or_none()
+        if obs is None:
+            raise ToolObserverGone("tool used after its owning agent was stopped")
+        return obs
+
+    @_observer.setter
+    def _observer(self, observer: ToolObserver) -> None:
+        """Store the observer weakly (backward-compatible ``self._observer = observer``)."""
+        self._observer_ref = weakref.ref(observer)
+
+    def _observer_or_none(self) -> "ToolObserver | None":
+        """Return the live observer, or ``None`` if unset or already collected."""
+        return self._observer_ref() if self._observer_ref is not None else None
 
     @abstractmethod
     def get_tools(self) -> list[Callable]:

--- a/src/akgentic/tool/core.py
+++ b/src/akgentic/tool/core.py
@@ -435,61 +435,117 @@ class CommandRegistry:
         """Parse a ``/``-prefixed command, invoke it, and return a result string.
 
         Strips the leading ``/``, ``shlex.split``s the remainder, resolves the
-        first token to a command, coerces the remaining tokens as positional args,
-        invokes the command, and string-renders the result.
+        first token to a command, classifies the remaining tokens as positional or
+        ``name=value`` keyword arguments, coerces and merges them, invokes the
+        command, and string-renders the result.
+
+        A token is a **keyword** only when the text before its first ``=`` matches a
+        real parameter name on the command; otherwise it is positional (so values
+        containing ``=`` are never silently swallowed). Positionals must precede
+        keywords. ``key=value`` is opt-in — purely-positional dispatch is unchanged.
 
         Raises:
             CommandNotRecognized: If the first token does not name a known command
                 (so the caller may fall back to normal LLM processing). No command
                 is invoked in this case.
 
-        Post-identification failures (missing/extra args, coercion errors, or the
-        command body raising) are caught **inside** this method and returned as a
-        plain result string — ``CommandNotRecognized`` is never raised once a
-        command has been identified.
+        Post-identification failures (missing/extra args, coercion errors, unknown
+        keyword, duplicate binding, positional-after-keyword, or the command body
+        raising) are caught **inside** this method and returned as a plain result
+        string — ``CommandNotRecognized`` is never raised once a command has been
+        identified.
         """
         tokens = shlex.split(text[1:] if text.startswith("/") else text)
         if not tokens:
             raise CommandNotRecognized(text)
-        name, positional = tokens[0], tokens[1:]
+        name, args = tokens[0], tokens[1:]
         if name not in self._entries:
             raise CommandNotRecognized(name)
-        return self._invoke(name, positional)
+        return self._invoke(name, args)
 
-    def _invoke(self, name: str, positional: list[str]) -> str:
-        """Coerce *positional* tokens for command *name* and invoke it.
+    def _invoke(self, name: str, args: list[str]) -> str:
+        """Classify, merge, coerce *args* for command *name* and invoke it.
 
-        Any failure (too many args, missing required arg, coercion error, or the
-        command body raising) is caught and returned as a result string.
+        Any failure (positional-after-keyword, too many/missing args, unknown
+        keyword, duplicate binding, coercion error, or the command body raising) is
+        caught and returned as a result string.
         """
         entry = self._entries[name]
         try:
-            coerced = self._coerce(entry, positional)
-            return str(entry.fn(*coerced))
+            positional, keyword = self._classify_tokens(entry, args)
+            bound = self._bind(entry, positional, keyword)
+            return str(entry.fn(**bound))
         except Exception as exc:  # noqa: BLE001 — failures become result strings (ADR-028 §4)
             return f"Command '{name}' failed: {exc}"
 
     @staticmethod
-    def _coerce(entry: _CommandEntry, positional: list[str]) -> list[Any]:
-        """Coerce *positional* tokens against *entry*'s ordered arg adapters.
+    def _classify_tokens(
+        entry: _CommandEntry, args: list[str]
+    ) -> tuple[list[str], dict[str, str]]:
+        """Partition *args* into ``(positional, keyword)`` for *entry*.
 
-        Validates arity (at least ``required_count``, at most ``len(args)``) then
-        coerces each supplied token through its per-arg :class:`TypeAdapter`.
-        Unsupplied trailing optional args are omitted so the callable applies its
-        own defaults.
+        A token is a keyword iff it contains ``=`` AND the substring before the
+        **first** ``=`` is a known parameter name on *entry*; the value is the
+        remainder after that first ``=``. All other tokens are positional. A
+        positional token appearing after any keyword token is rejected.
+
+        Raises:
+            ValueError: If a positional token follows a keyword token (names the
+                offending positional value).
+        """
+        names = {spec.name for spec in entry.args}
+        positional: list[str] = []
+        keyword: dict[str, str] = {}
+        for token in args:
+            key, sep, value = token.partition("=")
+            if sep and key in names:
+                keyword[key] = value
+            elif keyword:
+                raise ValueError(
+                    f"positional argument '{token}' cannot follow a keyword argument"
+                )
+            else:
+                positional.append(token)
+        return positional, keyword
+
+    @staticmethod
+    def _bind(
+        entry: _CommandEntry, positional: list[str], keyword: dict[str, str]
+    ) -> dict[str, Any]:
+        """Merge *positional* + *keyword* onto *entry*'s params and coerce each.
+
+        Maps positionals onto the leading parameters in signature order, then binds
+        keywords by name, detecting unknown names and duplicate bindings. Validates
+        arity (at least ``required_count``, at most ``len(args)``) over the merged
+        set, then coerces every bound value through its per-arg :class:`TypeAdapter`.
+        Unbound trailing optionals are omitted so the callable applies its defaults.
+
+        Raises:
+            ValueError: Too many positionals, unknown keyword, duplicate binding, a
+                required parameter left unbound, or a coercion failure.
         """
         if len(positional) > len(entry.args):
             raise ValueError(
                 f"accepts at most {len(entry.args)} argument(s), got {len(positional)}"
             )
-        if len(positional) < entry.required_count:
-            raise ValueError(
-                f"requires at least {entry.required_count} argument(s), got {len(positional)}"
-            )
-        return [
-            spec.adapter.validate_python(token)
+        raw: dict[str, str] = {
+            spec.name: token
             for spec, token in zip(entry.args, positional, strict=False)
-        ]
+        }
+        specs_by_name = {spec.name: spec for spec in entry.args}
+        for key, value in keyword.items():
+            if key not in specs_by_name:
+                raise ValueError(f"unknown keyword argument '{key}'")
+            if key in raw:
+                raise ValueError(f"got multiple values for argument '{key}'")
+            raw[key] = value
+        missing = [spec.name for spec in entry.args if spec.required and spec.name not in raw]
+        if missing:
+            raise ValueError(f"missing required argument(s): {', '.join(missing)}")
+        return {
+            name: specs_by_name[name].adapter.validate_python(token)
+            for name, token in raw.items()
+        }
 
 
 class ToolFactory:

--- a/src/akgentic/tool/core.py
+++ b/src/akgentic/tool/core.py
@@ -7,14 +7,20 @@ Defines the core contracts:
 """
 
 import functools
+import inspect
+import shlex
+import warnings
 from abc import ABC, abstractmethod
 from collections import deque
+from dataclasses import dataclass
 from enum import StrEnum
-from typing import Any, Callable, TypeVar
+from typing import Any, Callable, TypeVar, get_type_hints
+
+from pydantic import TypeAdapter
 
 from akgentic.core.utils import SerializableBaseModel
-from akgentic.tool.errors import RetriableError
-from akgentic.tool.event import ToolObserver
+from akgentic.tool.errors import CommandNotRecognized, RetriableError
+from akgentic.tool.event import CommandArg, CommandDescriptor, ToolObserver
 
 T = TypeVar("T", bound="BaseToolParam")
 
@@ -265,6 +271,227 @@ def _topological_sort(cards: list[ToolCard]) -> list[ToolCard]:
     return ordered
 
 
+@dataclass(frozen=True)
+class _CommandArgSpec:
+    """Ordered metadata + per-arg coercion adapter for one command parameter.
+
+    Runtime-only (not serialized). Captured from the callable signature at
+    registry-construction time. Drives both positional coercion (dispatch) and
+    :class:`CommandDescriptor` building.
+    """
+
+    name: str
+    annotation: Any
+    required: bool
+    adapter: TypeAdapter
+
+
+@dataclass(frozen=True)
+class _CommandEntry:
+    """Runtime record for a single registered command (not a serialized model).
+
+    Holds the callable plus the ordered, per-argument coercion metadata derived
+    from its signature. Per Golden Rule #1b, runtime callables live here in a
+    plain dataclass — never inside a serialized Pydantic field.
+    """
+
+    name: str
+    fn: Callable
+    args: tuple[_CommandArgSpec, ...]
+    tool_card: str
+
+    @property
+    def required_count(self) -> int:
+        """Number of leading required (no-default) parameters."""
+        return sum(1 for spec in self.args if spec.required)
+
+
+def _json_type_name(annotation: Any) -> str:
+    """Return the JSON-schema type name for a parameter annotation.
+
+    Falls back to ``"string"`` when the schema has no top-level ``type`` (e.g.
+    a union like ``str | None`` produces ``anyOf``), matching how the human help
+    surface renders un-typed-or-optional args.
+    """
+    try:
+        schema = TypeAdapter(annotation).json_schema()
+    except Exception:
+        return "string"
+    return schema.get("type", "string")
+
+
+def _build_command_entry(fn: Callable, tool_card: str) -> _CommandEntry:
+    """Derive a per-command arg model + ordered metadata from a callable signature.
+
+    Mirrors how pydantic-ai derives a tool schema from a function signature:
+    inspect the parameters, reject anything un-derivable (``*args``, ``**kwargs``,
+    or an un-annotated parameter), and build a :class:`TypeAdapter` over the
+    ordered positional parameter types for later coercion.
+
+    Raises:
+        ValueError: If the signature has a ``VAR_POSITIONAL`` (``*args``),
+            ``VAR_KEYWORD`` (``**kwargs``), or un-annotated parameter. The message
+            names the command and the offending parameter.
+    """
+    sig = inspect.signature(fn)
+    try:
+        hints = get_type_hints(fn)
+    except Exception:
+        hints = {}
+
+    specs: list[_CommandArgSpec] = []
+    for pname, param in sig.parameters.items():
+        if param.kind is inspect.Parameter.VAR_POSITIONAL:
+            raise ValueError(
+                f"Command '{fn.__name__}' cannot be registered: parameter '*{pname}' "
+                "(*args) has no derivable argument schema."
+            )
+        if param.kind is inspect.Parameter.VAR_KEYWORD:
+            raise ValueError(
+                f"Command '{fn.__name__}' cannot be registered: parameter '**{pname}' "
+                "(**kwargs) has no derivable argument schema."
+            )
+        annotation = hints.get(pname, param.annotation)
+        if annotation is inspect.Parameter.empty:
+            raise ValueError(
+                f"Command '{fn.__name__}' cannot be registered: parameter '{pname}' "
+                "has no type annotation."
+            )
+        required = param.default is inspect.Parameter.empty
+        specs.append(
+            _CommandArgSpec(
+                name=pname,
+                annotation=annotation,
+                required=required,
+                adapter=TypeAdapter(annotation),
+            )
+        )
+
+    return _CommandEntry(name=fn.__name__, fn=fn, args=tuple(specs), tool_card=tool_card)
+
+
+class CommandRegistry:
+    """Name-keyed registry of command callables with signature-derived dispatch.
+
+    Built by :meth:`ToolFactory.get_command_registry` from the ``get_commands()``
+    output of every wired :class:`ToolCard`. Each command is keyed by its
+    callable's ``__name__`` (e.g. ``hire_member``). The registry exposes a typed
+    programmatic surface (:meth:`callable`), a membership test (:meth:`has`),
+    discovery metadata (:meth:`descriptors`), and a human text surface
+    (:meth:`dispatch`) that parses ``/``-prefixed commands.
+
+    This is a runtime object holding callables — deliberately a plain class, not a
+    ``BaseModel`` (Golden Rule #1b): runtime callables must never live in a
+    serialized field.
+    """
+
+    def __init__(self, entries: dict[str, _CommandEntry]) -> None:
+        """Store the name → command-entry mapping. Use the factory to build one."""
+        self._entries = entries
+
+    def has(self, name: str) -> bool:
+        """Return ``True`` if a command named *name* is registered."""
+        return name in self._entries
+
+    def callable(self, name: str) -> Callable:
+        """Return the bound, typed command callable for programmatic invocation.
+
+        The returned callable preserves its **native** (non-stringified) return
+        value, so callers (e.g. ``StructuredOutput`` hire-by-role) can invoke it
+        with native arguments and use the result directly.
+
+        Raises:
+            CommandNotRecognized: If *name* is not a registered command.
+        """
+        try:
+            return self._entries[name].fn
+        except KeyError:
+            raise CommandNotRecognized(name) from None
+
+    def descriptors(self) -> list[CommandDescriptor]:
+        """Return serializable discovery metadata, one entry per command."""
+        result: list[CommandDescriptor] = []
+        for entry in self._entries.values():
+            args = [
+                CommandArg(
+                    name=spec.name,
+                    type=_json_type_name(spec.annotation),
+                    required=spec.required,
+                )
+                for spec in entry.args
+            ]
+            description = inspect.getdoc(entry.fn) or ""
+            result.append(
+                CommandDescriptor(
+                    name=entry.name,
+                    description=description,
+                    args=args,
+                    tool_card=entry.tool_card,
+                )
+            )
+        return result
+
+    def dispatch(self, text: str) -> str:
+        """Parse a ``/``-prefixed command, invoke it, and return a result string.
+
+        Strips the leading ``/``, ``shlex.split``s the remainder, resolves the
+        first token to a command, coerces the remaining tokens as positional args,
+        invokes the command, and string-renders the result.
+
+        Raises:
+            CommandNotRecognized: If the first token does not name a known command
+                (so the caller may fall back to normal LLM processing). No command
+                is invoked in this case.
+
+        Post-identification failures (missing/extra args, coercion errors, or the
+        command body raising) are caught **inside** this method and returned as a
+        plain result string — ``CommandNotRecognized`` is never raised once a
+        command has been identified.
+        """
+        tokens = shlex.split(text[1:] if text.startswith("/") else text)
+        if not tokens:
+            raise CommandNotRecognized(text)
+        name, positional = tokens[0], tokens[1:]
+        if name not in self._entries:
+            raise CommandNotRecognized(name)
+        return self._invoke(name, positional)
+
+    def _invoke(self, name: str, positional: list[str]) -> str:
+        """Coerce *positional* tokens for command *name* and invoke it.
+
+        Any failure (too many args, missing required arg, coercion error, or the
+        command body raising) is caught and returned as a result string.
+        """
+        entry = self._entries[name]
+        try:
+            coerced = self._coerce(entry, positional)
+            return str(entry.fn(*coerced))
+        except Exception as exc:  # noqa: BLE001 — failures become result strings (ADR-028 §4)
+            return f"Command '{name}' failed: {exc}"
+
+    @staticmethod
+    def _coerce(entry: _CommandEntry, positional: list[str]) -> list[Any]:
+        """Coerce *positional* tokens against *entry*'s ordered arg adapters.
+
+        Validates arity (at least ``required_count``, at most ``len(args)``) then
+        coerces each supplied token through its per-arg :class:`TypeAdapter`.
+        Unsupplied trailing optional args are omitted so the callable applies its
+        own defaults.
+        """
+        if len(positional) > len(entry.args):
+            raise ValueError(
+                f"accepts at most {len(entry.args)} argument(s), got {len(positional)}"
+            )
+        if len(positional) < entry.required_count:
+            raise ValueError(
+                f"requires at least {entry.required_count} argument(s), got {len(positional)}"
+            )
+        return [
+            spec.adapter.validate_python(token)
+            for spec, token in zip(entry.args, positional, strict=False)
+        ]
+
+
 class ToolFactory:
     """Resolves ``ToolCard`` instances into callable tools, prompts, and toolsets."""
 
@@ -336,9 +563,19 @@ class ToolFactory:
     def get_commands(self) -> dict[type[BaseToolParam], Callable]:
         """Return command callables aggregated from all tool cards.
 
+        Deprecated:
+            Use :meth:`get_command_registry` instead. This param-class-keyed dict
+            is retained for one migration cycle. The registry keys by canonical
+            command name and adds signature-derived dispatch + discovery metadata.
+
         Returns:
             Dict mapping param class to callable, merged from all tool cards.
         """
+        warnings.warn(
+            "ToolFactory.get_commands() is deprecated; use get_command_registry() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         commands: dict[type[BaseToolParam], Callable] = {}
         for card in self.tool_cards:
             commands.update(card.get_commands())
@@ -346,6 +583,37 @@ class ToolFactory:
         if self._retry_exception is not None:
             commands = {k: self._wrap_with_retry(v) for k, v in commands.items()}
         return commands
+
+    def get_command_registry(self) -> CommandRegistry:
+        """Build a name-keyed :class:`CommandRegistry` from every wired tool card.
+
+        Iterates ``self.tool_cards`` in dependency order, calls each card's
+        ``get_commands()``, and registers every callable under its ``__name__``.
+        Each command's arg schema is derived from its signature at this point, so
+        an un-derivable signature (``*args``/``**kwargs``/un-annotated param) fails
+        loudly here. When ``retry_exception`` is configured, each command is
+        wrapped via :meth:`_wrap_with_retry` (``functools.wraps`` preserves
+        ``__name__``/``__doc__``), matching :meth:`get_commands` behavior.
+
+        Raises:
+            ValueError: If two tool cards expose commands with the same canonical
+                name (collision is a wiring-time error, never a silent overwrite),
+                or if a command has an un-derivable signature. The message names
+                the offending command.
+        """
+        entries: dict[str, _CommandEntry] = {}
+        for card in self.tool_cards:
+            tool_card_name = type(card).__name__
+            for fn in card.get_commands().values():
+                wrapped = self._wrap_with_retry(fn) if self._retry_exception is not None else fn
+                name = wrapped.__name__
+                if name in entries:
+                    raise ValueError(
+                        f"Command name collision: '{name}' is exposed by both "
+                        f"'{entries[name].tool_card}' and '{tool_card_name}'."
+                    )
+                entries[name] = _build_command_entry(wrapped, tool_card_name)
+        return CommandRegistry(entries)
 
     def get_toolsets(self) -> list[Any]:
         """Return toolset instances aggregated from all tool cards."""

--- a/src/akgentic/tool/errors.py
+++ b/src/akgentic/tool/errors.py
@@ -14,3 +14,17 @@ class RetriableError(Exception):
     """
 
     pass
+
+
+class CommandNotRecognized(Exception):  # noqa: N818 — story-mandated name; identification signal
+    """Raised when the first dispatch token is not a known command (ADR-028 §Decision 4).
+
+    This is an *identification-failure* signal, not a tool execution error: it
+    tells the agent message handler "this was never a command — treat it as plain
+    text and fall back to normal LLM processing." It is deliberately NOT a
+    :class:`RetriableError` subclass; a retriable error means "retry with corrected
+    input," which is a semantically distinct outcome. The two hierarchies are
+    kept disjoint on purpose.
+    """
+
+    pass

--- a/src/akgentic/tool/errors.py
+++ b/src/akgentic/tool/errors.py
@@ -16,6 +16,12 @@ class RetriableError(Exception):
     pass
 
 
+class ToolObserverGone(RuntimeError):  # noqa: N818 — name mirrors CommandNotRecognized precedent
+    """A tool callable ran after its owning agent was stopped."""
+
+    pass
+
+
 class CommandNotRecognized(Exception):  # noqa: N818 — story-mandated name; identification signal
     """Raised when the first dispatch token is not a known command (ADR-028 §Decision 4).
 

--- a/src/akgentic/tool/event.py
+++ b/src/akgentic/tool/event.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Protocol, TypeAlias, runtime_checkable
 from akgentic.core.actor_address import ActorAddress
 from akgentic.core.agent import AkgentType
 from akgentic.core.messages import Message
+from akgentic.core.utils.serializer import SerializableBaseModel
 
 if TYPE_CHECKING:
     from akgentic.tool.knowledge_graph.models import KnowledgeGraphStateEvent
@@ -34,6 +35,62 @@ class ToolStateEvent(Message):
     tool_id: str
     seq: int
     payload: ToolStatePayload
+
+
+class CommandArg(SerializableBaseModel):
+    """A single positional/keyword argument of a discoverable command (ADR-028 §Decision 3).
+
+    Derived from a command callable's signature so consumers (the dispatch parser
+    in Story 21.2 and the frontend help renderer) share one typed contract.
+
+    Attributes:
+        name: Argument name as it appears in the callable signature.
+        type: JSON-schema type name (e.g. ``"string"``, ``"integer"``, ``"boolean"``).
+        required: Whether the argument must be supplied (no default).
+        description: Optional human-readable description; ``None`` when absent.
+    """
+
+    name: str
+    type: str
+    required: bool
+    description: str | None = None
+
+
+class CommandDescriptor(SerializableBaseModel):
+    """A discoverable command exposed by a tool (ADR-028 §Decision 3).
+
+    Describes one canonical command, its provenance, and its ordered argument
+    list. The ``args`` order is load-bearing: it drives positional dispatch
+    parsing (Story 21.2) and frontend help rendering.
+
+    Attributes:
+        name: Canonical command name (e.g. ``"hire_member"``).
+        description: Command description, sourced from the callable docstring.
+        args: Ordered list of :class:`CommandArg` entries (may be empty).
+        tool_card: Provenance of the command (e.g. ``"TeamTool"``).
+    """
+
+    name: str
+    description: str
+    args: list[CommandArg]
+    tool_card: str
+
+
+class CommandsAnnouncedEvent(SerializableBaseModel):
+    """Announcement of the command set an agent executes (ADR-028 §Decision 3).
+
+    Emitted so downstream agents/frontends can render the available commands.
+    Fully serializable: the ``__model__`` marker (from ``SerializableBaseModel``)
+    lets consumers discriminate this inner event during deserialization.
+
+    Attributes:
+        agent: Address of the agent that executes these commands (core
+            ``ActorAddress``; the tool layer MAY import core, NFR1).
+        commands: The :class:`CommandDescriptor` set announced for ``agent``.
+    """
+
+    agent: ActorAddress
+    commands: list[CommandDescriptor]
 
 
 @runtime_checkable

--- a/src/akgentic/tool/knowledge_graph/kg_tool.py
+++ b/src/akgentic/tool/knowledge_graph/kg_tool.py
@@ -170,7 +170,7 @@ class KnowledgeGraphTool(ToolCard):
         from akgentic.tool.knowledge_graph import _check_kg_dependencies
 
         _check_kg_dependencies()
-        self._observer = observer
+        super().observer(observer)  # store the observer weakly via the base setter
 
         if observer.orchestrator is None:
             raise ValueError("KnowledgeGraphTool requires access to the orchestrator.")

--- a/src/akgentic/tool/planning/planning.py
+++ b/src/akgentic/tool/planning/planning.py
@@ -15,6 +15,7 @@ from akgentic.tool.core import (
     ToolCard,
     _resolve,
 )
+from akgentic.tool.errors import RetriableError
 from akgentic.tool.event import ActorToolObserver
 from akgentic.tool.planning.planning_actor import (
     PlanActor,
@@ -128,7 +129,7 @@ class PlanningTool(ToolCard):
 
         Requires an ActorToolObserver for actor system access.
         """
-        self._observer = observer
+        super().observer(observer)  # store the observer weakly via the base setter
         if observer.orchestrator is None:
             raise ValueError("PlanningTool requires access to the orchestrator.")
 
@@ -275,7 +276,7 @@ class PlanningTool(ToolCard):
 
     def _update_planning_factory(self, params: UpdatePlanning) -> Callable:
         planning_proxy = self._planning_proxy
-        observer = self._observer
+        observer_or_none = self._observer_or_none  # bound method -> weak edge to agent
 
         def update_planning(update: UpdatePlan) -> str:
             """Update team tasks (create, update, delete).
@@ -284,6 +285,9 @@ class PlanningTool(ToolCard):
             - description: max 300 characters — keep it concise.
             - output: max 150 characters — will be truncated automatically if exceeded.
             """
+            observer = observer_or_none()
+            if observer is None:
+                raise RetriableError("Plan is unavailable; the agent is shutting down.")
             ## observer.myAddress is used to set the creator of any new tasks in the plan.
             return planning_proxy.update_planning(update, observer.myAddress)
 

--- a/src/akgentic/tool/planning/planning.py
+++ b/src/akgentic/tool/planning/planning.py
@@ -294,23 +294,23 @@ class PlanningTool(ToolCard):
         planning_proxy = self._planning_proxy
 
         def search_planning(
+            query: str | None = None,
+            mode: Literal["hybrid", "vector", "keyword"] = "hybrid",
             status: TaskStatus | None = None,
             owner: str | None = None,
             creator: str | None = None,
-            query: str | None = None,
-            mode: Literal["hybrid", "vector", "keyword"] = "hybrid",
             top_k: int | None = None,
             score_threshold: float | None = None,
         ) -> list[str]:
             """Search tasks. All filters are AND-combined; omit all for full list.
 
             Args:
-                status: Filter by status.
-                owner: Filter by owner.
-                creator: Filter by creator.
                 query: Search text for keyword and/or semantic matching.
                 mode: "hybrid" (default) = keyword + semantic,
                     "keyword" = substring only, "vector" = semantic only.
+                status: Filter by status.
+                owner: Filter by owner.
+                creator: Filter by creator.
                 top_k: Max semantic hits (default 10).
                 score_threshold: Min cosine similarity (default 0.5).
 

--- a/src/akgentic/tool/sandbox/tool.py
+++ b/src/akgentic/tool/sandbox/tool.py
@@ -137,7 +137,7 @@ class ExecTool(ToolCard):
             ValueError: If observer.orchestrator is None.
             KeyError: If ``self.mode`` names an unregistered backend.
         """
-        self._observer = observer
+        super().observer(observer)  # store the observer weakly via the base setter
         if observer.orchestrator is None:
             raise ValueError("ExecTool requires access to the orchestrator.")
 

--- a/src/akgentic/tool/team/team.py
+++ b/src/akgentic/tool/team/team.py
@@ -195,7 +195,7 @@ class TeamTool(ToolCard):
         Raises:
             ValueError: If observer.orchestrator is None
         """
-        self._observer = observer
+        super().observer(observer)  # store the observer weakly via the base setter
         if observer.orchestrator is None:
             raise ValueError("TeamTool requires access to the orchestrator.")
 
@@ -274,7 +274,7 @@ class TeamTool(ToolCard):
             Callable that hires team members
         """
         orchestrator_proxy = self._orchestrator_proxy
-        observer = self._observer
+        observer_or_none = self._observer_or_none  # bound method -> weak edge to agent
 
         def hire_members(roles: list[str]) -> str:
             """Hire multiple new team members with the given roles.
@@ -292,6 +292,9 @@ class TeamTool(ToolCard):
                 Confirmation message with hired member names
                 (e.g., 'Members hired: [@Developer123, @Tester456]')
             """
+            observer = observer_or_none()
+            if observer is None:
+                raise RetriableError("Team is shutting down; cannot hire.")
             if not roles:
                 raise RetriableError("No roles provided. Specify at least one role to hire.")
 
@@ -341,7 +344,7 @@ class TeamTool(ToolCard):
             Callable that hires a single team member
         """
         orchestrator_proxy = self._orchestrator_proxy
-        observer = self._observer
+        observer_or_none = self._observer_or_none  # bound method -> weak edge to agent
 
         def hire_member(role: str, name: str | None = None):
             """Hire a single new team member with the given role.
@@ -356,6 +359,9 @@ class TeamTool(ToolCard):
             Returns:
                 Tuple of (member_name, member_address)
             """
+            observer = observer_or_none()
+            if observer is None:
+                raise RetriableError("Team is shutting down; cannot hire.")
             existing_names = {member.name for member in orchestrator_proxy.get_team()}
             return _hire_single_member(orchestrator_proxy, observer, role, name, existing_names)
 
@@ -371,7 +377,7 @@ class TeamTool(ToolCard):
             Callable that fires team members
         """
         orchestrator_proxy = self._orchestrator_proxy
-        observer = self._observer
+        observer_or_none = self._observer_or_none  # bound method -> weak edge to agent
 
         def fire_members(names: list[str]) -> str:
             """Fire multiple team members with the given names.
@@ -388,6 +394,9 @@ class TeamTool(ToolCard):
             Returns:
                 Combined confirmation messages (e.g., "Members fired: @Developer123, @Tester456")
             """
+            observer = observer_or_none()
+            if observer is None:
+                raise RetriableError("Team is shutting down; cannot fire.")
             if not names:
                 raise RetriableError("No names provided. Specify at least one member name to fire.")
 
@@ -427,7 +436,7 @@ class TeamTool(ToolCard):
             Callable that fires a single team member
         """
         orchestrator_proxy = self._orchestrator_proxy
-        observer = self._observer
+        observer_or_none = self._observer_or_none  # bound method -> weak edge to agent
 
         def fire_member(name: str) -> str:
             """Fire a team member with the given name.
@@ -440,6 +449,9 @@ class TeamTool(ToolCard):
             Returns:
                 Confirmation message (e.g., "Member @Developer123 has been fired.")
             """
+            observer = observer_or_none()
+            if observer is None:
+                raise RetriableError("Team is shutting down; cannot fire.")
             _fire_single_member(orchestrator_proxy, observer, name)
             return f"Member {name} has been fired."
 
@@ -455,7 +467,7 @@ class TeamTool(ToolCard):
             Callable that generates team roster prompt
         """
         orchestrator_proxy = self._orchestrator_proxy
-        observer = self._observer
+        observer_or_none = self._observer_or_none  # bound method -> weak edge to agent
 
         def team_roster_prompt() -> str:
             """Get current team composition as context.
@@ -467,6 +479,9 @@ class TeamTool(ToolCard):
                 Formatted team roster or empty string if no members
             """
             try:
+                observer = observer_or_none()
+                if observer is None:
+                    return ""  # agent gone -> no roster context
                 team_members = orchestrator_proxy.get_team()
                 if not team_members:
                     return ""

--- a/src/akgentic/tool/vector_store/tool.py
+++ b/src/akgentic/tool/vector_store/tool.py
@@ -88,7 +88,7 @@ class VectorStoreTool(ToolCard):
         Raises:
             ValueError: When ``observer.orchestrator`` is ``None``.
         """
-        self._observer = observer
+        super().observer(observer)  # store the observer weakly via the base setter
 
         if observer.orchestrator is None:
             raise ValueError("VectorStoreTool requires access to the orchestrator.")

--- a/src/akgentic/tool/workspace/__init__.py
+++ b/src/akgentic/tool/workspace/__init__.py
@@ -19,6 +19,8 @@ from akgentic.tool.workspace.readers import (
 )
 from akgentic.tool.workspace.tool import (
     ExpandMediaRefs,
+    Resource,
+    ResourceType,
     WorkspaceDelete,
     WorkspaceEdit,
     WorkspaceGlob,
@@ -58,6 +60,8 @@ __all__ = [
     "Workspace",
     "get_workspace",
     "ExpandMediaRefs",
+    "Resource",
+    "ResourceType",
     "WorkspaceView",
     "WorkspaceRead",
     "WorkspaceList",

--- a/src/akgentic/tool/workspace/readers.py
+++ b/src/akgentic/tool/workspace/readers.py
@@ -170,11 +170,14 @@ class DocumentReader(BaseModel):
         # Pass 1: plain MarkItDown (no LLM)
         text = self._convert_via_tempfile(MarkItDown(), content, suffix)
 
-        # Pass 2: LLM vision fallback if Pass 1 yielded insufficient content
-        openai_client = self._get_openai_client()
-        if len("".join(text.split())) < 50 and openai_client is not None:
-            md_vision = MarkItDown(llm_client=openai_client, llm_model=self.llm_model)
-            text = self._convert_via_tempfile(md_vision, content, suffix)
+        # Pass 2: LLM vision fallback if Pass 1 yielded insufficient content.
+        # Only construct the OpenAI client when Pass 1 came up short — otherwise
+        # a successful Pass 1 would needlessly require credentials it never uses.
+        if len("".join(text.split())) < 50:
+            openai_client = self._get_openai_client()
+            if openai_client is not None:
+                md_vision = MarkItDown(llm_client=openai_client, llm_model=self.llm_model)
+                text = self._convert_via_tempfile(md_vision, content, suffix)
 
         if len("".join(text.split())) < 50:
             return "<!-- markitdown: no text extracted -->"

--- a/src/akgentic/tool/workspace/tool.py
+++ b/src/akgentic/tool/workspace/tool.py
@@ -444,6 +444,11 @@ class WorkspaceTool(ToolCard):
     workspace_patch: WorkspacePatch | bool = True
     workspace_mkdir: WorkspaceMkdir | bool = True
 
+    resources: list[Resource] = []
+    """Files seeded into the team workspace at observer() time, before the
+    agent's first turn. Each resource is written only if its path does not
+    already exist — restoring a team never clobbers edited files."""
+
     # Private runtime state — not part of the serialised config.
     # Default None sentinel lets the workspace property detect uninitialized state
     # reliably under both normal execution and coverage instrumentation.
@@ -468,7 +473,20 @@ class WorkspaceTool(ToolCard):
         self._observer = observer
         ws_name = self.workspace_id or str(observer.team_id)
         self._workspace = get_workspace(ws_name)
+        self._seed_resources()
         return self
+
+    def _seed_resources(self) -> None:
+        """Write each configured resource that is not already present.
+
+        Idempotent: an existing file is never overwritten, so a team restore
+        cannot clobber edits made to a seeded file since team creation.
+        """
+        assert self._workspace is not None
+        for resource in self.resources:
+            if self._workspace.exists(resource.file_name):
+                continue
+            self._workspace.write(resource.file_name, resource.to_bytes())
 
     @property
     def workspace(self) -> Filesystem:

--- a/src/akgentic/tool/workspace/tool.py
+++ b/src/akgentic/tool/workspace/tool.py
@@ -745,7 +745,9 @@ class WorkspaceTool(ToolCard):
                 files as ``name (N bytes)``. Returns "Empty directory." if no entries.
 
             Raises:
-                RetriableError: If path escapes the workspace root.
+                RetriableError: If the directory does not exist, the path points at
+                    a file rather than a directory, or the path escapes the
+                    workspace root.
             """
             try:
                 if path:
@@ -770,6 +772,8 @@ class WorkspaceTool(ToolCard):
                     # ASCII tree — depth=0 means unlimited, depth>1 means N levels
                     tree_lines = _build_tree(resolved, max_depth=depth)
                     return ".\n" + "\n".join(tree_lines) if tree_lines else "Empty directory."
+            except (FileNotFoundError, NotADirectoryError):
+                raise RetriableError(f"Directory not found: {path}")
             except PermissionError:
                 raise RetriableError(_PERM_ERR_MSG)
 

--- a/src/akgentic/tool/workspace/tool.py
+++ b/src/akgentic/tool/workspace/tool.py
@@ -470,7 +470,7 @@ class WorkspaceTool(ToolCard):
         """
         if observer.orchestrator is None:
             raise ValueError("WorkspaceTool requires access to the orchestrator.")
-        self._observer = observer
+        super().observer(observer)  # store the observer weakly via the base setter
         ws_name = self.workspace_id or str(observer.team_id)
         self._workspace = get_workspace(ws_name)
         self._seed_resources()

--- a/src/akgentic/tool/workspace/tool.py
+++ b/src/akgentic/tool/workspace/tool.py
@@ -12,17 +12,20 @@ The default ``read_only=False`` also includes write-side callables (``workspace_
 
 from __future__ import annotations
 
+import base64
 import difflib
 import io
 import re as _re
 import shutil
 import subprocess
+from enum import StrEnum
 from pathlib import Path, PurePosixPath
 from typing import Any, Callable
 
 from pydantic import PrivateAttr
 from pydantic_ai.messages import BinaryContent
 
+from akgentic.core.utils import SerializableBaseModel
 from akgentic.tool.core import COMMAND, TOOL_CALL, BaseToolParam, Channels, ToolCard, _resolve
 from akgentic.tool.errors import RetriableError
 from akgentic.tool.event import ActorToolObserver
@@ -356,6 +359,48 @@ class WorkspaceMkdir(BaseToolParam):
     """Create a directory (and parents) in the team workspace."""
 
     expose: set[Channels] = {TOOL_CALL}
+
+
+class ResourceType(StrEnum):
+    """Encoding of a seeded resource's ``content`` field.
+
+    Acts as the explicit encoding discriminator for a :class:`Resource`: it
+    decides how ``content`` is decoded into bytes (see :meth:`Resource.to_bytes`).
+    Encoding is always explicit — never inferred from the filename extension.
+    """
+
+    TEXT = "text"  # content is UTF-8 text, written verbatim
+    IMAGE = "image"  # content is base64-encoded binary, decoded before write
+
+
+class Resource(SerializableBaseModel):
+    """A file seeded into the team workspace at team-creation time.
+
+    Fully Pydantic-serializable: primitive fields plus a :class:`ResourceType`
+    ``StrEnum`` only, so it round-trips cleanly through ``model_dump`` /
+    ``model_validate``. The file extension lives in ``file_name`` (e.g.
+    ``logo.png``); ``file_type`` carries the encoding discriminator, not a MIME
+    type.
+    """
+
+    file_name: str
+    file_type: ResourceType = ResourceType.TEXT
+    content: str
+
+    def to_bytes(self) -> bytes:
+        """Decode ``content`` into the bytes to write to the workspace.
+
+        Returns:
+            ``base64.b64decode(content)`` when ``file_type`` is
+            :attr:`ResourceType.IMAGE`, else ``content.encode("utf-8")``.
+
+        Raises:
+            binascii.Error: If ``file_type`` is :attr:`ResourceType.IMAGE` and
+                ``content`` is not valid base64.
+        """
+        if self.file_type is ResourceType.IMAGE:
+            return base64.b64decode(self.content)
+        return self.content.encode("utf-8")
 
 
 class WorkspaceTool(ToolCard):

--- a/src/akgentic/tool/workspace/workspace.py
+++ b/src/akgentic/tool/workspace/workspace.py
@@ -41,6 +41,8 @@ class Workspace(Protocol):
 
     def mkdir(self, path: str) -> None: ...
 
+    def exists(self, path: str) -> bool: ...
+
 
 class Filesystem:
     """Local filesystem backend for a single team workspace.
@@ -142,6 +144,16 @@ class Filesystem:
         """
         resolved = self._validate_path(path)
         resolved.mkdir(parents=True, exist_ok=True)
+
+    def exists(self, path: str) -> bool:
+        """Return ``True`` if *path* exists inside the workspace.
+
+        Directories count as existing — :meth:`Path.exists` is not file-only.
+
+        Raises:
+            PermissionError: if *path* escapes the workspace root.
+        """
+        return self._validate_path(path).exists()
 
 
 def get_workspace(workspace_name: str) -> Filesystem:

--- a/tests/test_command_models.py
+++ b/tests/test_command_models.py
@@ -1,0 +1,273 @@
+"""Tests for the command-discovery models and ``CommandNotRecognized`` (Story 21.3).
+
+Covers ADR-028 §Decision 3 (discovery models) and §Decision 4 (failure handling):
+field shape, defaults, required-vs-optional validation, Pydantic round-trip with the
+``__model__`` marker that drives consumer dispatch, exception type/raisability, and
+public-API importability. Mirrors the round-trip style of ``test_tool_state_event.py``.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from akgentic.core.actor_address import ActorAddress
+from akgentic.core.actor_address_impl import ActorAddressProxy
+from pydantic import ValidationError
+
+from akgentic.tool import (
+    CommandArg,
+    CommandDescriptor,
+    CommandNotRecognized,
+    CommandsAnnouncedEvent,
+)
+from akgentic.tool.errors import RetriableError
+
+
+class SerializableActorAddress(ActorAddress):
+    """A concrete ``ActorAddress`` whose ``serialize()`` carries the dispatch marker.
+
+    Unlike the bare ``MockActorAddress`` in conftest, this produces a full
+    ``ActorAddressDict`` (with ``__actor_address__``) so a round-trip reconstructs
+    it as an ``ActorAddressProxy`` — letting us assert "equivalent ActorAddress".
+    """
+
+    def __init__(self, name: str = "hiring-agent", role: str = "manager") -> None:
+        self._name = name
+        self._role = role
+        self._agent_id = uuid.uuid4()
+        self._team_id = uuid.uuid4()
+
+    @property
+    def agent_id(self) -> uuid.UUID:
+        return self._agent_id
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def role(self) -> str:
+        return self._role
+
+    @property
+    def team_id(self) -> uuid.UUID:
+        return self._team_id
+
+    @property
+    def squad_id(self) -> uuid.UUID | None:
+        return None
+
+    def send(self, recipient: object, message: object) -> None:
+        pass
+
+    def is_alive(self) -> bool:
+        return True
+
+    def handle_user_message(self) -> bool:
+        return False
+
+    def serialize(self) -> dict:  # type: ignore[type-arg]
+        return {
+            "__actor_address__": True,
+            "__actor_type__": "tests.test_command_models.SerializableActorAddress",
+            "agent_id": str(self._agent_id),
+            "name": self._name,
+            "role": self._role,
+            "team_id": str(self._team_id),
+            "squad_id": "",
+            "user_message": False,
+        }
+
+    def __repr__(self) -> str:
+        return f"SerializableActorAddress(name={self._name})"
+
+
+# ---------------------------------------------------------------------------
+# CommandArg (AC #1, #2, #7)
+# ---------------------------------------------------------------------------
+
+
+class TestCommandArg:
+    def test_construct_all_fields(self) -> None:
+        arg = CommandArg(name="role", type="string", required=True, description="Role to hire")
+        assert arg.name == "role"
+        assert arg.type == "string"
+        assert arg.required is True
+        assert arg.description == "Role to hire"
+
+    def test_description_defaults_to_none(self) -> None:
+        arg = CommandArg(name="name", type="string", required=False)
+        assert arg.description is None
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"type": "string", "required": True},  # missing name
+            {"name": "x", "required": True},  # missing type
+            {"name": "x", "type": "string"},  # missing required
+        ],
+    )
+    def test_missing_required_raises(self, kwargs: dict[str, object]) -> None:
+        with pytest.raises(ValidationError):
+            CommandArg(**kwargs)  # type: ignore[arg-type]
+
+    def test_roundtrip_preserves_values(self) -> None:
+        arg = CommandArg(name="count", type="integer", required=True, description="How many")
+        dumped = arg.model_dump()
+        assert "__model__" in dumped
+        restored = CommandArg.model_validate(dumped)
+        assert isinstance(restored, CommandArg)
+        assert restored.name == "count"
+        assert restored.type == "integer"
+        assert restored.required is True
+        assert restored.description == "How many"
+
+
+# ---------------------------------------------------------------------------
+# CommandDescriptor (AC #3, #4, #7)
+# ---------------------------------------------------------------------------
+
+
+def _two_args() -> list[CommandArg]:
+    return [
+        CommandArg(name="role", type="string", required=True, description="Role"),
+        CommandArg(name="name", type="string", required=False),
+    ]
+
+
+class TestCommandDescriptor:
+    def test_construct_with_ordered_args(self) -> None:
+        desc = CommandDescriptor(
+            name="hire_member",
+            description="Hire a new team member",
+            args=_two_args(),
+            tool_card="TeamTool",
+        )
+        assert desc.name == "hire_member"
+        assert desc.description == "Hire a new team member"
+        assert desc.tool_card == "TeamTool"
+        assert len(desc.args) == 2
+        assert all(isinstance(a, CommandArg) for a in desc.args)
+        assert [a.name for a in desc.args] == ["role", "name"]
+
+    def test_empty_args_is_valid(self) -> None:
+        desc = CommandDescriptor(name="x", description="d", args=[], tool_card="T")
+        assert desc.args == []
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"description": "d", "args": [], "tool_card": "T"},  # missing name
+            {"name": "x", "args": [], "tool_card": "T"},  # missing description
+            {"name": "x", "description": "d", "tool_card": "T"},  # missing args
+            {"name": "x", "description": "d", "args": []},  # missing tool_card
+        ],
+    )
+    def test_missing_required_raises(self, kwargs: dict[str, object]) -> None:
+        with pytest.raises(ValidationError):
+            CommandDescriptor(**kwargs)  # type: ignore[arg-type]
+
+    def test_roundtrip_preserves_arg_order_and_types(self) -> None:
+        desc = CommandDescriptor(
+            name="hire_member",
+            description="Hire a member",
+            args=_two_args(),
+            tool_card="TeamTool",
+        )
+        restored = CommandDescriptor.model_validate(desc.model_dump())
+        assert isinstance(restored, CommandDescriptor)
+        assert [a.name for a in restored.args] == ["role", "name"]
+        assert all(isinstance(a, CommandArg) for a in restored.args)
+        assert restored.args[0].required is True
+        assert restored.args[0].description == "Role"
+        assert restored.args[1].required is False
+        assert restored.args[1].description is None
+
+
+# ---------------------------------------------------------------------------
+# CommandsAnnouncedEvent (AC #5, #6, #7)
+# ---------------------------------------------------------------------------
+
+
+def _descriptor() -> CommandDescriptor:
+    return CommandDescriptor(
+        name="hire_member",
+        description="Hire a member",
+        args=_two_args(),
+        tool_card="TeamTool",
+    )
+
+
+class TestCommandsAnnouncedEvent:
+    def test_construct(self) -> None:
+        agent = SerializableActorAddress()
+        desc = _descriptor()
+        event = CommandsAnnouncedEvent(agent=agent, commands=[desc])
+        assert event.agent is agent
+        assert event.commands == [desc]
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"commands": []},  # missing agent
+            {"agent": SerializableActorAddress()},  # missing commands
+        ],
+    )
+    def test_missing_required_raises(self, kwargs: dict[str, object]) -> None:
+        with pytest.raises(ValidationError):
+            CommandsAnnouncedEvent(**kwargs)  # type: ignore[arg-type]
+
+    def test_roundtrip(self) -> None:
+        agent = SerializableActorAddress(name="hiring-agent", role="manager")
+        event = CommandsAnnouncedEvent(agent=agent, commands=[_descriptor()])
+        dumped = event.model_dump()
+        assert "__model__" in dumped
+
+        restored = CommandsAnnouncedEvent.model_validate(dumped)
+        # agent deserializes back to an equivalent ActorAddress
+        assert isinstance(restored.agent, ActorAddress)
+        assert isinstance(restored.agent, ActorAddressProxy)
+        assert restored.agent.agent_id == agent.agent_id
+        assert restored.agent.name == "hiring-agent"
+        assert restored.agent.role == "manager"
+        # nested descriptor/arg models are restored as real models, not dicts
+        assert isinstance(restored.commands[0], CommandDescriptor)
+        assert isinstance(restored.commands[0].args[0], CommandArg)
+        assert restored.commands[0].name == "hire_member"
+        assert restored.commands[0].args[0].name == "role"
+
+
+# ---------------------------------------------------------------------------
+# CommandNotRecognized (AC #8)
+# ---------------------------------------------------------------------------
+
+
+class TestCommandNotRecognized:
+    def test_raisable_and_catchable(self) -> None:
+        with pytest.raises(CommandNotRecognized):
+            raise CommandNotRecognized("frobnicate")
+
+    def test_is_exception_subclass(self) -> None:
+        assert issubclass(CommandNotRecognized, Exception)
+
+    def test_is_not_retriable_error_subclass(self) -> None:
+        assert not issubclass(CommandNotRecognized, RetriableError)
+
+
+# ---------------------------------------------------------------------------
+# Public-API export (AC #9)
+# ---------------------------------------------------------------------------
+
+
+def test_public_api_exports() -> None:
+    import akgentic.tool as tool_pkg
+
+    for name in (
+        "CommandArg",
+        "CommandDescriptor",
+        "CommandsAnnouncedEvent",
+        "CommandNotRecognized",
+    ):
+        assert name in tool_pkg.__all__
+        assert hasattr(tool_pkg, name)

--- a/tests/test_command_registry.py
+++ b/tests/test_command_registry.py
@@ -1,0 +1,446 @@
+"""Tests for ``CommandRegistry`` and ``ToolFactory.get_command_registry()`` (Story 21.2).
+
+Covers ADR-028 §Decision 1 (registry construction, collision), §Decision 2
+(signature-derived arg schema, shlex dispatch grammar, positional coercion),
+§Decision 4 (failure semantics: ``CommandNotRecognized`` vs caught result string),
+and §Decision 6 (programmatic typed access). Behavioral assertions only — no
+assertion checks for an ADR-reference string (Golden Rule #8 / NFR3).
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import Callable
+
+import pytest
+
+from akgentic.tool.core import (
+    COMMAND,
+    BaseToolParam,
+    CommandRegistry,
+    ToolCard,
+    ToolFactory,
+)
+from akgentic.tool.errors import CommandNotRecognized, RetriableError
+from akgentic.tool.event import CommandDescriptor
+
+# ---------------------------------------------------------------------------
+# Fixtures: ToolCards exposing command callables (TeamTool-shaped signatures)
+# ---------------------------------------------------------------------------
+
+
+class _HireParam(BaseToolParam):
+    expose: set[str] = {COMMAND}
+
+
+class _FireParam(BaseToolParam):
+    expose: set[str] = {COMMAND}
+
+
+class _HireCard(ToolCard):
+    """Card exposing a ``hire_member(role, name=None)`` command."""
+
+    name: str = "hire-card"
+    description: str = "hire card"
+
+    def get_tools(self) -> list[Callable]:
+        return []
+
+    def get_commands(self) -> dict[type[BaseToolParam], Callable]:
+        def hire_member(role: str, name: str | None = None) -> tuple[str, str | None]:
+            """Hire a single new team member with the given role.
+
+            Args:
+                role: Role to hire.
+                name: Optional specific name.
+            """
+            return (role, name)
+
+        return {_HireParam: hire_member}
+
+
+class _FireCard(ToolCard):
+    """Card exposing a ``fire_member(name)`` command."""
+
+    name: str = "fire-card"
+    description: str = "fire card"
+
+    def get_tools(self) -> list[Callable]:
+        return []
+
+    def get_commands(self) -> dict[type[BaseToolParam], Callable]:
+        def fire_member(name: str) -> str:
+            """Fire a team member with the given name."""
+            return f"Member {name} has been fired."
+
+        return {_FireParam: fire_member}
+
+
+class _IntCard(ToolCard):
+    """Card exposing ``f(task_id: int)`` for coercion tests."""
+
+    name: str = "int-card"
+    description: str = "int card"
+
+    def get_tools(self) -> list[Callable]:
+        return []
+
+    def get_commands(self) -> dict[type[BaseToolParam], Callable]:
+        def f(task_id: int) -> int:
+            """Return double the task id."""
+            return task_id * 2
+
+        return {_HireParam: f}
+
+
+class _RaisingCard(ToolCard):
+    """Card whose command body raises when invoked."""
+
+    name: str = "raising-card"
+    description: str = "raising card"
+
+    def get_tools(self) -> list[Callable]:
+        return []
+
+    def get_commands(self) -> dict[type[BaseToolParam], Callable]:
+        def boom(arg: str) -> str:
+            """Always raises."""
+            raise RuntimeError("kaboom")
+
+        return {_HireParam: boom}
+
+
+def _registry(*cards: ToolCard) -> CommandRegistry:
+    factory = ToolFactory(tool_cards=list(cards))
+    return factory.get_command_registry()
+
+
+# ---------------------------------------------------------------------------
+# AC 1 — Registry construction keyed by canonical name
+# ---------------------------------------------------------------------------
+
+
+def test_registry_keyed_by_callable_name() -> None:
+    registry = _registry(_HireCard(), _FireCard())
+    assert registry.has("hire_member") is True
+    assert registry.has("fire_member") is True
+    assert registry.has("not_a_command") is False
+
+
+# ---------------------------------------------------------------------------
+# AC 2 — Cross-card name-collision detection
+# ---------------------------------------------------------------------------
+
+
+def test_cross_card_name_collision_raises() -> None:
+    class _DupCard(ToolCard):
+        name: str = "dup-card"
+        description: str = "dup card"
+
+        def get_tools(self) -> list[Callable]:
+            return []
+
+        def get_commands(self) -> dict[type[BaseToolParam], Callable]:
+            def hire_member(role: str) -> str:
+                """Duplicate hire_member."""
+                return role
+
+            return {_FireParam: hire_member}
+
+    factory = ToolFactory(tool_cards=[_HireCard(), _DupCard()])
+    with pytest.raises(ValueError) as exc:
+        factory.get_command_registry()
+    assert "hire_member" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# AC 3 — Signature-derived argument schema (required/optional + order)
+# ---------------------------------------------------------------------------
+
+
+def test_signature_derived_schema_required_optional_and_order() -> None:
+    registry = _registry(_HireCard())
+    descriptors = registry.descriptors()
+    assert len(descriptors) == 1
+    desc = descriptors[0]
+    assert [a.name for a in desc.args] == ["role", "name"]
+    assert desc.args[0].required is True
+    assert desc.args[1].required is False
+
+
+# ---------------------------------------------------------------------------
+# AC 4 — Loud rejection of un-derivable signatures
+# ---------------------------------------------------------------------------
+
+
+def test_var_positional_rejected_at_construction() -> None:
+    class _VarArgsCard(ToolCard):
+        name: str = "varargs"
+        description: str = "varargs"
+
+        def get_tools(self) -> list[Callable]:
+            return []
+
+        def get_commands(self) -> dict[type[BaseToolParam], Callable]:
+            def variadic(*args: str) -> str:
+                """Bad: *args."""
+                return "x"
+
+            return {_HireParam: variadic}
+
+    factory = ToolFactory(tool_cards=[_VarArgsCard()])
+    with pytest.raises(ValueError) as exc:
+        factory.get_command_registry()
+    assert "variadic" in str(exc.value)
+
+
+def test_var_keyword_rejected_at_construction() -> None:
+    class _KwargsCard(ToolCard):
+        name: str = "kwargs"
+        description: str = "kwargs"
+
+        def get_tools(self) -> list[Callable]:
+            return []
+
+        def get_commands(self) -> dict[type[BaseToolParam], Callable]:
+            def variadic_kw(**kwargs: str) -> str:
+                """Bad: **kwargs."""
+                return "x"
+
+            return {_HireParam: variadic_kw}
+
+    factory = ToolFactory(tool_cards=[_KwargsCard()])
+    with pytest.raises(ValueError) as exc:
+        factory.get_command_registry()
+    assert "variadic_kw" in str(exc.value)
+
+
+def test_untyped_param_rejected_at_construction() -> None:
+    class _UntypedCard(ToolCard):
+        name: str = "untyped"
+        description: str = "untyped"
+
+        def get_tools(self) -> list[Callable]:
+            return []
+
+        def get_commands(self) -> dict[type[BaseToolParam], Callable]:
+            def untyped(role) -> str:  # type: ignore[no-untyped-def]
+                """Bad: no annotation."""
+                return "x"
+
+            return {_HireParam: untyped}
+
+    factory = ToolFactory(tool_cards=[_UntypedCard()])
+    with pytest.raises(ValueError) as exc:
+        factory.get_command_registry()
+    assert "untyped" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# AC 5 — Dispatch parses, coerces, invokes, returns a string
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_quoted_args_happy_path() -> None:
+    registry = _registry(_HireCard())
+    result = registry.dispatch('/hire_member Developer "Alice Smith"')
+    assert isinstance(result, str)
+    assert "Developer" in result
+    assert "Alice Smith" in result
+
+
+def test_dispatch_optional_arg_omitted() -> None:
+    registry = _registry(_HireCard())
+    result = registry.dispatch("/hire_member Developer")
+    # name omitted -> callable default None applies; native return was ('Developer', None)
+    assert "Developer" in result
+    assert "None" in result
+
+
+# ---------------------------------------------------------------------------
+# AC 6 — Type coercion of positional args
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_coerces_int_arg() -> None:
+    registry = _registry(_IntCard())
+    # f(task_id) returns task_id * 2 -> 10 proves "5" coerced to int, not "55"
+    assert registry.dispatch("/f 5") == "10"
+
+
+# ---------------------------------------------------------------------------
+# AC 7 — Unknown first token raises CommandNotRecognized
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("text", ["/frobnicate", "/etc/passwd", "/", "/ "])
+def test_unknown_first_token_raises_command_not_recognized(text: str) -> None:
+    registry = _registry(_HireCard())
+    with pytest.raises(CommandNotRecognized):
+        registry.dispatch(text)
+
+
+def test_command_not_recognized_does_not_invoke_command() -> None:
+    invoked: list[str] = []
+
+    class _SpyCard(ToolCard):
+        name: str = "spy"
+        description: str = "spy"
+
+        def get_tools(self) -> list[Callable]:
+            return []
+
+        def get_commands(self) -> dict[type[BaseToolParam], Callable]:
+            def known(arg: str) -> str:
+                """Spy command."""
+                invoked.append(arg)
+                return arg
+
+            return {_HireParam: known}
+
+    registry = _registry(_SpyCard())
+    with pytest.raises(CommandNotRecognized):
+        registry.dispatch("/unknown x")
+    assert invoked == []
+
+
+# ---------------------------------------------------------------------------
+# AC 8 — Post-identification failures returned as result strings
+# ---------------------------------------------------------------------------
+
+
+def test_missing_required_arg_returns_string() -> None:
+    registry = _registry(_HireCard())
+    result = registry.dispatch("/hire_member")  # role is required
+    assert isinstance(result, str)
+    assert "hire_member" in result
+
+
+def test_extra_args_returns_string() -> None:
+    registry = _registry(_HireCard())
+    result = registry.dispatch("/hire_member a b c")  # max 2 args
+    assert isinstance(result, str)
+    assert "hire_member" in result
+
+
+def test_coercion_error_returns_string() -> None:
+    registry = _registry(_IntCard())
+    result = registry.dispatch("/f notanint")
+    assert isinstance(result, str)
+    assert "f" in result
+
+
+def test_command_body_raises_returns_string() -> None:
+    registry = _registry(_RaisingCard())
+    result = registry.dispatch("/boom hello")
+    assert isinstance(result, str)
+    assert "boom" in result
+
+
+@pytest.mark.parametrize(
+    "text",
+    ["/hire_member", "/hire_member a b c"],
+)
+def test_post_identification_failure_does_not_raise_command_not_recognized(text: str) -> None:
+    registry = _registry(_HireCard())
+    # Must NOT raise — identified command failures become result strings.
+    result = registry.dispatch(text)
+    assert isinstance(result, str)
+
+
+# ---------------------------------------------------------------------------
+# AC 9 — Programmatic typed access
+# ---------------------------------------------------------------------------
+
+
+def test_callable_returns_native_value() -> None:
+    registry = _registry(_HireCard())
+    fn = registry.callable("hire_member")
+    result = fn("Developer")
+    # Native (non-stringified) return value preserved.
+    assert result == ("Developer", None)
+
+
+def test_callable_unknown_raises_command_not_recognized() -> None:
+    registry = _registry(_HireCard())
+    with pytest.raises(CommandNotRecognized):
+        registry.callable("not_a_command")
+
+
+# ---------------------------------------------------------------------------
+# AC 10 — descriptors() returns serializable metadata
+# ---------------------------------------------------------------------------
+
+
+def test_descriptors_shape() -> None:
+    registry = _registry(_HireCard(), _FireCard())
+    descriptors = registry.descriptors()
+    assert all(isinstance(d, CommandDescriptor) for d in descriptors)
+    by_name = {d.name: d for d in descriptors}
+    assert set(by_name) == {"hire_member", "fire_member"}
+
+    hire = by_name["hire_member"]
+    assert hire.tool_card == "_HireCard"
+    assert "Hire a single new team member" in hire.description
+    assert [a.name for a in hire.args] == ["role", "name"]
+    assert hire.args[0].type == "string"
+    assert hire.args[0].required is True
+    assert hire.args[1].required is False
+
+    fire = by_name["fire_member"]
+    assert fire.tool_card == "_FireCard"
+    assert [a.name for a in fire.args] == ["name"]
+
+
+def test_descriptor_int_arg_type() -> None:
+    registry = _registry(_IntCard())
+    desc = registry.descriptors()[0]
+    assert desc.args[0].name == "task_id"
+    assert desc.args[0].type == "integer"
+
+
+# ---------------------------------------------------------------------------
+# AC 11 — Deprecated get_commands() alias retained
+# ---------------------------------------------------------------------------
+
+
+def test_get_commands_still_returns_legacy_dict_and_warns() -> None:
+    factory = ToolFactory(tool_cards=[_HireCard()])
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        commands = factory.get_commands()
+    assert _HireParam in commands  # legacy param-class keying preserved
+    assert any(issubclass(w.category, DeprecationWarning) for w in caught)
+
+
+# ---------------------------------------------------------------------------
+# retry_exception wrapping preserves name and translates RetriableError
+# ---------------------------------------------------------------------------
+
+
+def test_retry_exception_wrapping_preserves_name_and_translates() -> None:
+    class _MyRetryError(Exception):
+        pass
+
+    class _RetriableCmdCard(ToolCard):
+        name: str = "retriable-cmd"
+        description: str = "retriable cmd"
+
+        def get_tools(self) -> list[Callable]:
+            return []
+
+        def get_commands(self) -> dict[type[BaseToolParam], Callable]:
+            def needy(arg: str) -> str:
+                """Raises retriable when called."""
+                raise RetriableError("retry me")
+
+            return {_HireParam: needy}
+
+    factory = ToolFactory(tool_cards=[_RetriableCmdCard()], retry_exception=_MyRetryError)
+    registry = factory.get_command_registry()
+    # Name survives functools.wraps so name-keying still works.
+    assert registry.has("needy")
+    # The wrapped command translates RetriableError -> _MyRetry, which dispatch
+    # catches and returns as a string (identified-command failure semantics).
+    result = registry.dispatch("/needy x")
+    assert "needy" in result

--- a/tests/test_command_registry.py
+++ b/tests/test_command_registry.py
@@ -10,7 +10,7 @@ assertion checks for an ADR-reference string (Golden Rule #8 / NFR3).
 from __future__ import annotations
 
 import warnings
-from typing import Callable
+from typing import Callable, Literal
 
 import pytest
 
@@ -444,3 +444,227 @@ def test_retry_exception_wrapping_preserves_name_and_translates() -> None:
     # catches and returns as a string (identified-command failure semantics).
     result = registry.dispatch("/needy x")
     assert "needy" in result
+
+
+# ===========================================================================
+# Story 21.4 — keyword (key=value) arguments in command dispatch
+# ===========================================================================
+
+_Status = Literal["pending", "started", "completed", "abort"]
+
+
+class _SearchCard(ToolCard):
+    """``search_planning``-shaped all-optional, multi-parameter command.
+
+    Mirrors the motivating signature (status, owner, creator, query, mode) whose
+    all-optional shape positional-only dispatch cannot serve for later params.
+    """
+
+    name: str = "search-card"
+    description: str = "search card"
+
+    def get_tools(self) -> list[Callable]:
+        return []
+
+    def get_commands(self) -> dict[type[BaseToolParam], Callable]:
+        def search_planning(
+            status: _Status | None = None,
+            owner: str | None = None,
+            creator: str | None = None,
+            query: str | None = None,
+            mode: str = "hybrid",
+        ) -> dict[str, object]:
+            """Search planning tasks by optional filters."""
+            return {
+                "status": status,
+                "owner": owner,
+                "creator": creator,
+                "query": query,
+                "mode": mode,
+            }
+
+        return {_HireParam: search_planning}
+
+
+class _RequiredPairCard(ToolCard):
+    """``f(a: str, b: str)`` with both required, for merged-arity tests."""
+
+    name: str = "pair-card"
+    description: str = "pair card"
+
+    def get_tools(self) -> list[Callable]:
+        return []
+
+    def get_commands(self) -> dict[type[BaseToolParam], Callable]:
+        def f(a: str, b: str) -> str:
+            """Concatenate a and b."""
+            return f"{a}|{b}"
+
+        return {_HireParam: f}
+
+
+# --- AC1: positional dispatch unchanged (backward compatibility) ------------
+
+
+def test_kw_positional_dispatch_unchanged() -> None:
+    registry = _registry(_HireCard())
+    result = registry.dispatch('/hire_member Developer "Alice Smith"')
+    assert "Developer" in result
+    assert "Alice Smith" in result
+
+
+# --- AC2: a name=value token binds by parameter name ------------------------
+
+
+def test_kw_binds_by_name_with_coercion() -> None:
+    registry = _registry(_SearchCard())
+    result = registry.dispatch("/search_planning status=pending")
+    assert "'status': 'pending'" in result
+    # Every other parameter falls back to its own default.
+    assert "'owner': None" in result
+    assert "'mode': 'hybrid'" in result
+
+
+# --- AC3: keyword reaches a later optional without filling earlier ones ------
+
+
+def test_kw_reaches_later_optional_only() -> None:
+    registry = _registry(_SearchCard())
+    result = registry.dispatch('/search_planning query="deploy the service"')
+    assert "'query': 'deploy the service'" in result
+    assert "'status': None" in result
+    assert "'owner': None" in result
+    assert "'creator': None" in result
+
+
+# --- AC4: mixed positional + keyword; positional-after-keyword errors --------
+
+
+def test_kw_mixed_positional_and_keyword() -> None:
+    registry = _registry(_SearchCard())
+    result = registry.dispatch("/search_planning pending owner=@Manager")
+    assert "'status': 'pending'" in result
+    assert "'owner': '@Manager'" in result
+
+
+def test_kw_positional_after_keyword_is_result_string() -> None:
+    registry = _registry(_SearchCard())
+    result = registry.dispatch("/search_planning status=pending @Manager")
+    assert isinstance(result, str)
+    # Post-identification failure: names the offending positional, not CommandNotRecognized.
+    assert "search_planning" in result
+    assert "@Manager" in result
+
+
+def test_kw_positional_after_keyword_does_not_raise() -> None:
+    registry = _registry(_SearchCard())
+    # Must NOT raise CommandNotRecognized — command was identified.
+    result = registry.dispatch("/search_planning status=pending @Manager")
+    assert isinstance(result, str)
+
+
+# --- AC5: keyword only when LHS is a real parameter name; first-= split ------
+
+
+def test_kw_value_containing_equals_via_keyword() -> None:
+    registry = _registry(_SearchCard())
+    result = registry.dispatch('/search_planning query="a=b"')
+    # Split on the FIRST '=' only -> query value is "a=b".
+    assert "'query': 'a=b'" in result
+
+
+def test_kw_unknown_lhs_is_positional_value() -> None:
+    registry = _registry(_HireCard())
+    # 'x' is NOT a parameter name -> token 'x=y' is a POSITIONAL value bound to role.
+    result = registry.dispatch("/hire_member x=y")
+    # role coerces the literal string "x=y" (first-= split is irrelevant: positional).
+    assert "x=y" in result
+
+
+# --- AC6: unknown keyword name -> result string, not CommandNotRecognized ----
+
+
+def test_kw_unknown_keyword_is_result_string() -> None:
+    registry = _registry(_SearchCard())
+    result = registry.dispatch("/search_planning foo=bar")
+    assert isinstance(result, str)
+    assert "search_planning" in result
+    assert "foo" in result
+
+
+def test_kw_unknown_keyword_does_not_raise_command_not_recognized() -> None:
+    registry = _registry(_SearchCard())
+    result = registry.dispatch("/search_planning foo=bar")
+    assert isinstance(result, str)  # caught inside dispatch
+
+
+# --- AC7: duplicate binding -> result string --------------------------------
+
+
+def test_kw_duplicate_positional_and_keyword_is_result_string() -> None:
+    registry = _registry(_SearchCard())
+    result = registry.dispatch("/search_planning pending status=started")
+    assert isinstance(result, str)
+    assert "status" in result
+
+
+def test_kw_duplicate_same_keyword_twice_is_result_string() -> None:
+    registry = _registry(_SearchCard())
+    # shlex keeps both tokens; first-= classification yields a repeated keyword.
+    result = registry.dispatch("/search_planning status=pending status=started")
+    assert isinstance(result, str)
+    assert "status" in result
+
+
+# --- AC8: arity / required checks over the merged binding -------------------
+
+
+def test_kw_missing_required_over_merged_set() -> None:
+    registry = _registry(_RequiredPairCard())
+    result = registry.dispatch("/f a=x")  # b left unbound
+    assert isinstance(result, str)
+    assert "f" in result
+    assert "b" in result
+
+
+def test_kw_over_supply_positionals_is_result_string() -> None:
+    registry = _registry(_RequiredPairCard())
+    result = registry.dispatch("/f x y z")  # max 2
+    assert isinstance(result, str)
+    assert "f" in result
+
+
+# --- AC9: coercion identical for keyword and positional values --------------
+
+
+def test_kw_int_coercion() -> None:
+    registry = _registry(_IntCard())
+    # f(task_id) returns task_id * 2 -> 10 proves "5" coerced to int via keyword.
+    assert registry.dispatch("/f task_id=5") == "10"
+
+
+def test_kw_bad_int_coercion_is_result_string() -> None:
+    registry = _registry(_IntCard())
+    result = registry.dispatch("/f task_id=notanint")
+    assert isinstance(result, str)
+    assert "f" in result
+
+
+# --- AC10: descriptors unchanged; unknown first token still raises -----------
+
+
+def test_kw_descriptors_unchanged_with_keyword_support() -> None:
+    registry = _registry(_HireCard(), _FireCard())
+    descriptors = registry.descriptors()
+    by_name = {d.name: d for d in descriptors}
+    assert set(by_name) == {"hire_member", "fire_member"}
+    hire = by_name["hire_member"]
+    assert [a.name for a in hire.args] == ["role", "name"]
+    assert hire.args[0].required is True
+    assert hire.args[1].required is False
+
+
+def test_kw_unknown_first_token_still_raises() -> None:
+    registry = _registry(_SearchCard())
+    with pytest.raises(CommandNotRecognized):
+        registry.dispatch("/frobnicate status=pending")

--- a/tests/test_command_registry_weak_observer.py
+++ b/tests/test_command_registry_weak_observer.py
@@ -1,0 +1,131 @@
+"""Cross-tool gc-reclamation regression tests (Epic 22 / ADR-030, Story 22.3).
+
+A tool's command registry — built via the public ``ToolFactory`` API — must never
+pin a weak-referenced owning agent. After the only strong reference to the observer
+is dropped and ``gc.collect()`` runs, the agent is reclaimed even while the registry
+and its ``_CommandEntry`` closures are still held. This proves FR6: no tool, its
+closures, or the agent's command registry keeps a stopped ``BaseAgent`` alive.
+
+Also covers ``PlanningTool._update_planning_factory`` deref-at-call behaviour:
+the alive path performs the existing ``planning_proxy.update_planning(...)`` call;
+the gone path raises ``RetriableError`` (not ``AttributeError`` / ``ToolObserverGone``).
+"""
+
+from __future__ import annotations
+
+import gc
+import uuid
+import weakref
+from unittest.mock import Mock
+
+import pytest
+from akgentic.core import ActorAddressProxy
+from akgentic.core.orchestrator import Orchestrator
+from akgentic.tool.core import ToolFactory
+from akgentic.tool.errors import RetriableError
+from akgentic.tool.event import TeamManagementToolObserver
+from akgentic.tool.planning.planning import PlanningTool, UpdatePlanning
+from akgentic.tool.team import TeamTool
+
+
+def _address(name: str, role: str = "Agent") -> ActorAddressProxy:
+    """Create a mock ActorAddress for testing."""
+    return ActorAddressProxy(
+        {
+            "__actor_address__": True,
+            "__actor_type__": "test.Agent",
+            "agent_id": str(uuid.uuid4()),
+            "name": name,
+            "role": role,
+            "team_id": str(uuid.uuid4()),
+            "squad_id": str(uuid.uuid4()),
+            "user_message": True,
+        }
+    )
+
+
+def _make_observer() -> Mock:
+    """Weak-referenceable observer with a DETACHED orchestrator proxy.
+
+    ``Mock`` (unlike a bare ``object()``) is weak-referenceable. The orchestrator
+    proxy is a free-standing ``Mock`` (NOT a child of ``observer``): a child mock's
+    parent chain would back-edge to the observer and, pinned by a tool's strong
+    ``_orchestrator_proxy`` / ``_planning_proxy``, defeat gc reclamation.
+    ``proxy_ask`` returns that detached orchestrator for every call, so both
+    ``PlanningTool`` and ``TeamTool`` wire against it without pinning the observer.
+    """
+    observer = Mock(spec=TeamManagementToolObserver)
+    observer.orchestrator = _address("@Orchestrator", "Orchestrator")
+    observer.myAddress = _address("@Manager", "Manager")
+
+    orchestrator = Mock(spec=Orchestrator)
+    orchestrator.get_team.return_value = [_address("@Manager", "Manager")]
+    observer.proxy_ask = Mock(return_value=orchestrator)
+    return observer
+
+
+def _build_registry(observer: Mock) -> object:
+    """Wire TeamTool + PlanningTool through the public ToolFactory and build the registry.
+
+    ``PlanningTool(vector_store=False)`` runs in degraded mode so it declares no
+    ``VectorStoreTool`` dependency — the command wiring under test (and the weak
+    observer edge) is independent of the VectorStoreActor lookup.
+    """
+    factory = ToolFactory([TeamTool(), PlanningTool(vector_store=False)], observer=observer)
+    return factory.get_command_registry()
+
+
+# ── Cross-tool command-registry gc reclamation (AC6) ─────────────────────────
+
+
+def test_command_registry_does_not_pin_stopped_agent() -> None:
+    # AC6: a command registry built from TeamTool + PlanningTool must NOT keep the
+    # weak-referenced agent alive once the only strong ref is dropped + gc runs.
+    observer = _make_observer()
+    registry = _build_registry(observer)
+
+    agent_weakref = weakref.ref(observer)
+    del observer
+    gc.collect()
+
+    assert agent_weakref() is None  # registry + closures do not pin the agent
+    assert registry is not None  # registry is still held, yet the agent was reclaimed
+
+
+# ── PlanningTool._update_planning_factory deref-at-call (AC3, AC7) ────────────
+
+
+def test_update_planning_in_life_calls_proxy() -> None:
+    # AC7 alive path: while the agent is alive, update_planning performs the same
+    # planning_proxy.update_planning(update, observer.myAddress) call as before.
+    observer = _make_observer()
+    tool = PlanningTool(vector_store=False)
+    tool.observer(observer)
+
+    # Replace the wired PlanActor proxy with a dedicated mock to assert the call.
+    planning_proxy = Mock()
+    planning_proxy.update_planning.return_value = "updated"
+    tool._planning_proxy = planning_proxy
+    update_planning = tool._update_planning_factory(UpdatePlanning())
+
+    update = Mock()
+    result = update_planning(update)
+
+    assert result == "updated"
+    planning_proxy.update_planning.assert_called_once_with(update, observer.myAddress)
+
+
+def test_update_planning_raises_after_stop() -> None:
+    # AC3 gone path: once the agent is collected, update_planning raises
+    # RetriableError (not AttributeError / ToolObserverGone).
+    observer = _make_observer()
+    tool = PlanningTool(vector_store=False)
+    tool.observer(observer)
+    update_planning = tool._update_planning_factory(UpdatePlanning())
+
+    del observer
+    gc.collect()
+
+    assert tool._observer_or_none() is None
+    with pytest.raises(RetriableError, match="shutting down"):
+        update_planning(Mock())

--- a/tests/test_core_factory.py
+++ b/tests/test_core_factory.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar
 
 import pytest
-
 from akgentic.tool.core import (
     COMMAND,
     TOOL_CALL,
@@ -375,6 +374,8 @@ class StubPlanningTool(ToolCard):
 
 def test_tool_factory_topological_sort_happy_path() -> None:
     """VectorStore is wired before KG and Planning regardless of input order."""
+    from unittest.mock import MagicMock  # noqa: PLC0415
+
     calls: list[str] = []
 
     class _RecordingVS(StubVectorStoreTool):
@@ -400,7 +401,9 @@ def test_tool_factory_topological_sort_happy_path() -> None:
     plan = _RecordingPlan()
     vs = _RecordingVS()
 
-    factory = ToolFactory(tool_cards=[kg, plan, vs], observer=object())
+    # Observer is held weakly by ToolCard, so it must be weak-referenceable
+    # (a bare object() is not). The value is irrelevant to the ordering assertion.
+    factory = ToolFactory(tool_cards=[kg, plan, vs], observer=MagicMock())
     # VS must be first; KG and Planning preserve their relative input order (kg before plan).
     assert calls == ["_RecordingVS", "_RecordingKG", "_RecordingPlan"]
     assert [type(c).__name__ for c in factory.tool_cards] == [

--- a/tests/test_team_tool_weak_observer.py
+++ b/tests/test_team_tool_weak_observer.py
@@ -1,0 +1,182 @@
+"""Weak-observer regression tests for ``TeamTool`` (Epic 22 / ADR-030).
+
+Story 22.2: every observer-capturing closure factory captures the tool's weak
+accessor (``self._observer_or_none``) and derefs at call time, so a ``TeamTool``,
+its tool/command/prompt closures, and the agent's command registry can never pin
+a stopped owning agent. Once the agent is collected, hire/fire callables raise
+``RetriableError`` and the roster prompt returns the benign fallback.
+"""
+
+from __future__ import annotations
+
+import gc
+import uuid
+import weakref
+from unittest.mock import Mock
+
+import pytest
+from akgentic.core import ActorAddressProxy
+from akgentic.core.orchestrator import Orchestrator
+
+from akgentic.tool.errors import RetriableError
+from akgentic.tool.event import TeamManagementToolObserver
+from akgentic.tool.team import (
+    FireTeamMember,
+    GetTeamRoster,
+    HireTeamMember,
+    TeamTool,
+)
+
+
+def _address(name: str, role: str = "Agent") -> ActorAddressProxy:
+    """Create a mock ActorAddress for testing."""
+    return ActorAddressProxy(
+        {
+            "__actor_address__": True,
+            "__actor_type__": "test.Agent",
+            "agent_id": str(uuid.uuid4()),
+            "name": name,
+            "role": role,
+            "team_id": str(uuid.uuid4()),
+            "squad_id": str(uuid.uuid4()),
+            "user_message": True,
+        }
+    )
+
+
+def _make_observer() -> Mock:
+    """Weak-referenceable observer stand-in with a live orchestrator proxy.
+
+    ``Mock`` (unlike a bare ``object()``) is weak-referenceable, matching the
+    idiom the existing ``TeamTool`` tests rely on.
+    """
+    observer = Mock(spec=TeamManagementToolObserver)
+    observer.orchestrator = _address("@Orchestrator", "Orchestrator")
+    observer.myAddress = _address("@Manager", "Manager")
+
+    # Detached orchestrator mock: NOT a child of ``observer`` (a child mock's
+    # parent chain would strongly pin the observer through
+    # ``tool._orchestrator_proxy`` and defeat the gc reclamation assertions).
+    orchestrator = Mock(spec=Orchestrator)
+    orchestrator.get_team.return_value = [_address("@Manager", "Manager")]
+    observer.proxy_ask = Mock(return_value=orchestrator)
+    return observer
+
+
+# ── In-life parity (AC4) ─────────────────────────────────────────────────────
+
+
+def test_in_life_roster_unchanged() -> None:
+    # While the agent is alive, the roster prompt produces its usual output.
+    observer = _make_observer()
+    tool = TeamTool()
+    tool.observer(observer)
+
+    roster_prompt = tool.get_system_prompts()[0]
+    result = roster_prompt()
+    assert "Here is the team member list by name (and role):" in result
+    assert "@Manager (role: Manager)" in result
+    assert "[you]" in result
+
+
+def test_in_life_hire_unchanged() -> None:
+    # While the agent is alive, hire still calls createActor + on_hire.
+    observer = _make_observer()
+    orchestrator = observer.proxy_ask.return_value
+
+    agent_card = Mock()
+    agent_card.role = "Developer"
+    agent_card.get_agent_class.return_value = Mock
+    agent_card.get_config_copy.return_value = Mock()
+    orchestrator.get_team.return_value = []
+    orchestrator.get_agent_catalog.return_value = [agent_card]
+    observer.createActor.return_value = _address("@Developer123", "Developer")
+
+    tool = TeamTool()
+    tool.observer(observer)
+    hire_members = tool.get_tools()[0]
+
+    result = hire_members(["Developer"])
+    assert "Members hired:" in result
+    observer.createActor.assert_called_once()
+    observer.on_hire.assert_called_once()
+
+
+# ── Post-stop reclamation + clean failure (AC5) ──────────────────────────────
+
+
+def test_closures_do_not_pin_stopped_agent() -> None:
+    # AC5 (a)+(b): after dropping the only strong ref and gc, the observer is
+    # collected even though the built closures are still held.
+    observer = _make_observer()
+    tool = TeamTool()
+    tool.observer(observer)
+
+    ref = weakref.ref(observer)
+    # Build (and hold) tool/command/prompt closures — they must NOT pin the agent.
+    held = [
+        *tool.get_tools(),
+        *tool.get_system_prompts(),
+        *tool.get_commands().values(),
+    ]
+
+    del observer
+    gc.collect()
+
+    assert tool._observer_or_none() is None  # tool does not keep the observer alive
+    assert ref() is None  # closures do not pin the agent
+    assert held  # closures are still referenced here, yet the agent was reclaimed
+
+
+def test_hire_callables_raise_after_stop() -> None:
+    # AC5 (c): hire tool + command raise RetriableError (not AttributeError /
+    # ToolObserverGone) once the agent is gone.
+    observer = _make_observer()
+    tool = TeamTool()
+    tool.observer(observer)
+
+    hire_members = tool.get_tools()[0]
+    hire_member = tool.get_commands()[HireTeamMember]
+
+    del observer
+    gc.collect()
+
+    with pytest.raises(RetriableError, match="cannot hire"):
+        hire_members(["Developer"])
+    with pytest.raises(RetriableError, match="cannot hire"):
+        hire_member("Developer")
+
+
+def test_fire_callables_raise_after_stop() -> None:
+    # AC5 (c): fire tool + command raise RetriableError once the agent is gone.
+    observer = _make_observer()
+    tool = TeamTool()
+    tool.observer(observer)
+
+    fire_members = tool.get_tools()[1]
+    fire_member = tool.get_commands()[FireTeamMember]
+
+    del observer
+    gc.collect()
+
+    with pytest.raises(RetriableError, match="cannot fire"):
+        fire_members(["@Developer123"])
+    with pytest.raises(RetriableError, match="cannot fire"):
+        fire_member("@Developer123")
+
+
+def test_roster_prompt_returns_fallback_after_stop() -> None:
+    # AC5 (d): roster prompt returns the benign fallback (a string, no raise)
+    # once the agent is gone — observer.myAddress.name must never run on None.
+    observer = _make_observer()
+    tool = TeamTool()
+    tool.observer(observer)
+
+    roster_prompt = tool.get_commands()[GetTeamRoster]
+
+    del observer
+    gc.collect()
+
+    result = roster_prompt()
+    assert isinstance(result, str)
+    assert result == ""

--- a/tests/test_team_tool_weak_observer.py
+++ b/tests/test_team_tool_weak_observer.py
@@ -74,7 +74,7 @@ def test_in_life_roster_unchanged() -> None:
 
     roster_prompt = tool.get_system_prompts()[0]
     result = roster_prompt()
-    assert "Here is the team member list by name (and role):" in result
+    assert "**Team members:**" in result
     assert "@Manager (role: Manager)" in result
     assert "[you]" in result
 

--- a/tests/test_toolcard_weak_observer.py
+++ b/tests/test_toolcard_weak_observer.py
@@ -18,6 +18,9 @@ from akgentic.tool.errors import ToolObserverGone
 class _DummyToolCard(ToolCard):
     """Minimal concrete ``ToolCard`` for exercising base observer storage."""
 
+    name: str = "dummy"
+    description: str = "dummy tool card"
+
     def get_tools(self) -> list[Callable]:
         return []
 

--- a/tests/test_toolcard_weak_observer.py
+++ b/tests/test_toolcard_weak_observer.py
@@ -1,0 +1,89 @@
+"""Behavioral tests for the base ``ToolCard`` weak-observer storage (Epic 22 / ADR-030).
+
+The observer (owning agent) is held through a ``weakref`` so a tool, its closures,
+and its command registry can never pin a stopped agent in memory. Access goes
+through the ``_observer`` property, which derefs the weakref and raises
+``ToolObserverGone`` once the referent is collected.
+"""
+
+import gc
+import weakref
+from typing import Callable
+
+import pytest
+from akgentic.tool.core import ToolCard
+from akgentic.tool.errors import ToolObserverGone
+
+
+class _DummyToolCard(ToolCard):
+    """Minimal concrete ``ToolCard`` for exercising base observer storage."""
+
+    def get_tools(self) -> list[Callable]:
+        return []
+
+
+class _Observer:
+    """Trivial weak-referenceable observer stand-in (satisfies the shape used here)."""
+
+
+def test_observer_stores_a_weakref_and_does_not_pin() -> None:
+    # AC6(a): observer() stores a weakref — the card does not keep the observer alive.
+    card = _DummyToolCard()
+    obs = _Observer()
+    assert card.observer(obs) is card  # method chaining preserved
+
+    ref = weakref.ref(obs)
+    del obs
+    gc.collect()
+    assert ref() is None  # card did not pin it
+
+
+def test_observer_property_returns_live_observer() -> None:
+    # AC6(b): _observer returns the live observer while it is referenced.
+    card = _DummyToolCard()
+    obs = _Observer()
+    card.observer(obs)
+    assert card._observer is obs
+
+
+def test_observer_gone_after_collection() -> None:
+    # AC6(c): after drop + gc, _observer_or_none() is None and _observer raises.
+    card = _DummyToolCard()
+    obs = _Observer()
+    card.observer(obs)
+    del obs
+    gc.collect()
+    assert card._observer_or_none() is None
+    with pytest.raises(ToolObserverGone):
+        _ = card._observer
+
+
+def test_observer_or_none_when_unset() -> None:
+    # Covers the `_observer_ref is None` branch of _observer_or_none().
+    card = _DummyToolCard()
+    assert card._observer_or_none() is None
+    with pytest.raises(ToolObserverGone):
+        _ = card._observer
+
+
+def test_observer_setter_stores_weakly() -> None:
+    # LEAD DECISION (backward compatibility): `self._observer = obs` keeps working
+    # and stores the observer weakly, so direct assignment never pins the agent.
+    card = _DummyToolCard()
+    obs = _Observer()
+    card._observer = obs
+    assert card._observer is obs
+
+    ref = weakref.ref(obs)
+    del obs
+    gc.collect()
+    assert ref() is None
+    assert card._observer_or_none() is None
+
+
+def test_observer_ref_excluded_from_model_dump() -> None:
+    # AC6(d): _observer_ref is a PrivateAttr — excluded from serialization.
+    card = _DummyToolCard()
+    card.observer(_Observer())
+    assert "_observer_ref" not in card.model_dump()
+    assert "_observer_ref" not in card.model_dump(mode="json")

--- a/tests/workspace/test_read_tool.py
+++ b/tests/workspace/test_read_tool.py
@@ -664,6 +664,21 @@ class TestRetriableErrorReadTool:
             with pytest.raises(RetriableError, match="Path escapes workspace root"):
                 list_fn("some/path")
 
+    def test_list_missing_directory_raises_retriable_error(self, tmp_path: Path) -> None:
+        """workspace_list raises RetriableError for a non-existent directory."""
+        tool = make_tool(tmp_path)
+        list_fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_list")
+        with pytest.raises(RetriableError, match="Directory not found: nonexistent"):
+            list_fn("nonexistent")
+
+    def test_list_path_is_file_raises_retriable_error(self, tmp_path: Path) -> None:
+        """workspace_list raises RetriableError when the path points at a file."""
+        tool = make_tool(tmp_path)
+        (tool.workspace._root / "file.txt").write_text("data", encoding="utf-8")
+        list_fn = next(t for t in tool.get_tools() if t.__name__ == "workspace_list")
+        with pytest.raises(RetriableError, match="Directory not found: file.txt"):
+            list_fn("file.txt")
+
     def test_glob_permission_error_raises_retriable_error(self, tmp_path: Path) -> None:
         """workspace_glob raises RetriableError for path escaping workspace."""
         tool = make_tool(tmp_path)
@@ -1313,7 +1328,7 @@ class TestExpandMediaRefs:
         ]
 
     def test_expand_media_refs_not_in_get_tools(self, tmp_path: Path) -> None:
-        """AC-8 / Task 6.9: ExpandMediaRefs must NOT appear in get_tools() — COMMAND channel only."""
+        """ExpandMediaRefs must NOT appear in get_tools() — COMMAND channel only."""
         tool = make_tool(tmp_path)
         tools = tool.get_tools()
         tool_names = [fn.__name__ for fn in tools]

--- a/tests/workspace/test_workspace_tool.py
+++ b/tests/workspace/test_workspace_tool.py
@@ -2,15 +2,24 @@
 
 from __future__ import annotations
 
+import base64
+import binascii
 import uuid
+from enum import StrEnum
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from akgentic.core.utils import SerializableBaseModel
 
 from akgentic.tool.errors import RetriableError
 from akgentic.tool.workspace.edit import EditItem
-from akgentic.tool.workspace.tool import WorkspaceTool, _normalize_glob_pattern
+from akgentic.tool.workspace.tool import (
+    Resource,
+    ResourceType,
+    WorkspaceTool,
+    _normalize_glob_pattern,
+)
 from akgentic.tool.workspace.workspace import Filesystem
 
 # ---------------------------------------------------------------------------
@@ -998,3 +1007,84 @@ class TestFilesystemRootAbsolute:
         relative_base = str(tmp_path / "rel")
         fs = Filesystem(relative_base, "workspace")
         assert fs._root.is_absolute()
+
+
+# ---------------------------------------------------------------------------
+# Resource model and ResourceType encoding (Story 19.1, AC #1-#6)
+# ---------------------------------------------------------------------------
+
+
+class TestResourceType:
+    """ResourceType is a StrEnum with TEXT and IMAGE string members (AC #1)."""
+
+    def test_resourcetype_is_strenum(self) -> None:
+        """ResourceType members are str instances (StrEnum contract)."""
+        assert issubclass(ResourceType, StrEnum)
+        assert isinstance(ResourceType.TEXT, str)
+        assert isinstance(ResourceType.IMAGE, str)
+
+    def test_resourcetype_member_values(self) -> None:
+        """TEXT == 'text' and IMAGE == 'image'."""
+        assert ResourceType.TEXT.value == "text"
+        assert ResourceType.IMAGE.value == "image"
+
+
+class TestResourceModel:
+    """Resource construction, defaults, to_bytes, and serialization (AC #2-#5)."""
+
+    def test_construct_with_all_fields(self) -> None:
+        """Resource constructs with file_name, file_type, and content (AC #2)."""
+        res = Resource(file_name="logo.png", file_type=ResourceType.IMAGE, content="QUJD")
+        assert res.file_name == "logo.png"
+        assert res.file_type is ResourceType.IMAGE
+        assert res.content == "QUJD"
+
+    def test_file_type_defaults_to_text(self) -> None:
+        """file_type defaults to ResourceType.TEXT when omitted (AC #2)."""
+        res = Resource(file_name="notes.md", content="hello")
+        assert res.file_type is ResourceType.TEXT
+
+    def test_resource_is_serializable_base_model(self) -> None:
+        """Resource subclasses SerializableBaseModel (AC #2)."""
+        assert issubclass(Resource, SerializableBaseModel)
+
+    def test_to_bytes_text_returns_utf8(self) -> None:
+        """to_bytes() on a TEXT resource returns UTF-8 bytes of content (AC #3)."""
+        res = Resource(file_name="notes.md", file_type=ResourceType.TEXT, content="héllo")
+        assert res.to_bytes() == "héllo".encode("utf-8")
+
+    def test_to_bytes_image_returns_decoded_bytes(self) -> None:
+        """to_bytes() on an IMAGE resource returns base64-decoded bytes (AC #4)."""
+        raw = b"\x89PNG\r\n\x1a\n"
+        encoded = base64.b64encode(raw).decode("ascii")
+        res = Resource(file_name="logo.png", file_type=ResourceType.IMAGE, content=encoded)
+        assert res.to_bytes() == raw
+
+    def test_to_bytes_image_malformed_base64_raises(self) -> None:
+        """Malformed base64 content for an IMAGE resource raises binascii.Error (AC #4)."""
+        res = Resource(file_name="logo.png", file_type=ResourceType.IMAGE, content="not!base64!")
+        with pytest.raises(binascii.Error):
+            res.to_bytes()
+
+    def test_round_trip_text(self) -> None:
+        """A TEXT Resource round-trips through model_dump / model_validate (AC #5)."""
+        res = Resource(file_name="notes.md", file_type=ResourceType.TEXT, content="hello")
+        restored = Resource.model_validate(res.model_dump())
+        assert restored == res
+        assert restored.file_type is ResourceType.TEXT
+
+    def test_round_trip_image(self) -> None:
+        """An IMAGE Resource round-trips through model_dump / model_validate (AC #5)."""
+        res = Resource(file_name="logo.png", file_type=ResourceType.IMAGE, content="QUJD")
+        restored = Resource.model_validate(res.model_dump())
+        assert restored == res
+        assert restored.file_type is ResourceType.IMAGE
+
+
+def test_resource_and_resourcetype_importable_from_public_api() -> None:
+    """Resource and ResourceType import cleanly from akgentic.tool.workspace (AC #6)."""
+    from akgentic.tool.workspace import Resource as PublicResource
+    from akgentic.tool.workspace import ResourceType as PublicResourceType
+
+    assert PublicResource is Resource
+    assert PublicResourceType is ResourceType

--- a/tests/workspace/test_workspace_tool.py
+++ b/tests/workspace/test_workspace_tool.py
@@ -1123,3 +1123,134 @@ def test_resource_and_resourcetype_importable_from_public_api() -> None:
 
     assert PublicResource is Resource
     assert PublicResourceType is ResourceType
+
+
+# ---------------------------------------------------------------------------
+# Story 19.3: seed declared resources at WorkspaceTool startup (AC #1-#9)
+# ---------------------------------------------------------------------------
+
+
+def _seed_tool(
+    tmp_path: Path,
+    resources: list[Resource],
+) -> tuple[WorkspaceTool, Filesystem]:
+    """Wire a WorkspaceTool carrying *resources* to a real tmp Filesystem."""
+    observer, fs = make_observer(tmp_path)
+    with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
+        tool = WorkspaceTool(resources=resources)
+        tool.observer(observer)
+    return tool, fs
+
+
+class TestWorkspaceToolResourcesField:
+    """The `resources` field: default, typing, serialization (AC #1, #5)."""
+
+    def test_resources_defaults_to_empty_list(self) -> None:
+        """resources defaults to [] when not configured (AC #1, #5)."""
+        tool = WorkspaceTool()
+        assert tool.resources == []
+
+    def test_resources_round_trips_through_model_dump(self) -> None:
+        """A WorkspaceTool with resources round-trips identically (AC #1)."""
+        resources = [
+            Resource(file_name="notes.md", file_type=ResourceType.TEXT, content="hello"),
+            Resource(file_name="logo.png", file_type=ResourceType.IMAGE, content="QUJD"),
+        ]
+        tool = WorkspaceTool(resources=resources)
+        restored = WorkspaceTool.model_validate(tool.model_dump())
+        assert restored.resources == resources
+
+    def test_resources_serialize_as_plain_dicts(self) -> None:
+        """`resources` serializes to plain dicts — list[Resource] is serializable (AC #1)."""
+        resources = [
+            Resource(file_name="notes.md", file_type=ResourceType.TEXT, content="hello"),
+        ]
+        dumped = WorkspaceTool(resources=resources).model_dump()["resources"]
+        assert isinstance(dumped, list) and len(dumped) == 1
+        entry = dumped[0]
+        assert isinstance(entry, dict)
+        assert entry["file_name"] == "notes.md"
+        assert entry["file_type"] == "text"
+        assert entry["content"] == "hello"
+
+
+class TestWorkspaceToolSeedResources:
+    """observer() seeds declared resources into the workspace (AC #2-#8)."""
+
+    def test_observer_seeds_text_and_image_resources(self, tmp_path: Path) -> None:
+        """A TEXT resource lands as UTF-8, an IMAGE resource as decoded bytes (AC #2)."""
+        raw = b"\x89PNG\r\n\x1a\n"
+        encoded = base64.b64encode(raw).decode("ascii")
+        resources = [
+            Resource(file_name="notes.md", file_type=ResourceType.TEXT, content="héllo"),
+            Resource(file_name="logo.png", file_type=ResourceType.IMAGE, content=encoded),
+        ]
+        tool, fs = _seed_tool(tmp_path, resources)
+        assert fs.read("notes.md") == "héllo".encode("utf-8")
+        assert fs.read("logo.png") == raw
+
+    def test_observer_does_not_overwrite_existing_file(self, tmp_path: Path) -> None:
+        """A resource whose file_name already exists is preserved (AC #3)."""
+        observer, fs = make_observer(tmp_path)
+        fs.write("notes.md", b"original content")
+        resources = [Resource(file_name="notes.md", content="seeded content")]
+        with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
+            tool = WorkspaceTool(resources=resources)
+            tool.observer(observer)
+        assert fs.read("notes.md") == b"original content"
+
+    def test_observer_seeds_nested_path_creating_parents(self, tmp_path: Path) -> None:
+        """A nested file_name seeds with parent directories created (AC #4)."""
+        resources = [Resource(file_name="docs/spec.md", content="spec body")]
+        tool, fs = _seed_tool(tmp_path, resources)
+        assert fs.read("docs/spec.md") == b"spec body"
+
+    def test_observer_empty_resources_seeds_nothing(self, tmp_path: Path) -> None:
+        """Default empty resources → observer() seeds nothing (AC #5)."""
+        tool, fs = _seed_tool(tmp_path, [])
+        assert fs.list() == []
+
+    def test_observer_root_escaping_resource_raises_permission_error(
+        self, tmp_path: Path
+    ) -> None:
+        """A root-escaping file_name raises PermissionError out of observer() (AC #6)."""
+        observer, fs = make_observer(tmp_path)
+        resources = [Resource(file_name="../escape.txt", content="evil")]
+        with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
+            tool = WorkspaceTool(resources=resources)
+            with pytest.raises(PermissionError):
+                tool.observer(observer)
+
+    def test_observer_malformed_base64_image_raises_binascii_error(
+        self, tmp_path: Path
+    ) -> None:
+        """An IMAGE resource with malformed base64 raises binascii.Error (AC #7)."""
+        observer, fs = make_observer(tmp_path)
+        resources = [
+            Resource(file_name="logo.png", file_type=ResourceType.IMAGE, content="not!base64!")
+        ]
+        with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
+            tool = WorkspaceTool(resources=resources)
+            with pytest.raises(binascii.Error):
+                tool.observer(observer)
+
+    def test_observer_run_twice_preserves_existing_and_seeds_missing(
+        self, tmp_path: Path
+    ) -> None:
+        """A second observer() run preserves existing files, seeds still-missing ones (AC #8)."""
+        observer, fs = make_observer(tmp_path)
+        resources = [
+            Resource(file_name="kept.md", content="seeded once"),
+            Resource(file_name="later.md", content="later body"),
+        ]
+        with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
+            tool = WorkspaceTool(resources=resources)
+            tool.observer(observer)
+        # An agent/human edits the seeded file between team restores.
+        fs.write("kept.md", b"edited by agent")
+        # A team restore builds a fresh WorkspaceTool and re-runs observer().
+        with patch("akgentic.tool.workspace.tool.get_workspace", return_value=fs):
+            restored_tool = WorkspaceTool(resources=resources)
+            restored_tool.observer(observer)
+        assert fs.read("kept.md") == b"edited by agent"
+        assert fs.read("later.md") == b"later body"

--- a/tests/workspace/test_workspace_tool.py
+++ b/tests/workspace/test_workspace_tool.py
@@ -20,7 +20,7 @@ from akgentic.tool.workspace.tool import (
     WorkspaceTool,
     _normalize_glob_pattern,
 )
-from akgentic.tool.workspace.workspace import Filesystem
+from akgentic.tool.workspace.workspace import Filesystem, Workspace
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -605,6 +605,41 @@ class TestFilesystemMkdir:
         tool, fs = make_wired_tool(tmp_path)
         with pytest.raises(PermissionError):
             fs.mkdir("../../escape")
+
+
+# ---------------------------------------------------------------------------
+# Story 19.2: Filesystem.exists()
+# ---------------------------------------------------------------------------
+
+
+class TestFilesystemExists:
+    def test_exists_true_for_existing_file(self, tmp_path: Path) -> None:
+        """exists() returns True for a file that was written (AC #2)."""
+        tool, fs = make_wired_tool(tmp_path)
+        fs.write("notes/todo.txt", b"hello")
+        assert fs.exists("notes/todo.txt") is True
+
+    def test_exists_false_for_absent_path(self, tmp_path: Path) -> None:
+        """exists() returns False for a path that was never created (AC #3)."""
+        tool, fs = make_wired_tool(tmp_path)
+        assert fs.exists("missing.txt") is False
+
+    def test_exists_true_for_existing_directory(self, tmp_path: Path) -> None:
+        """exists() returns True for an existing directory (AC #4)."""
+        tool, fs = make_wired_tool(tmp_path)
+        fs.mkdir("src/utils")
+        assert fs.exists("src/utils") is True
+
+    def test_exists_traversal_raises(self, tmp_path: Path) -> None:
+        """exists() raises PermissionError for a root-escaping path (AC #5)."""
+        tool, fs = make_wired_tool(tmp_path)
+        with pytest.raises(PermissionError):
+            fs.exists("../escape")
+
+    def test_filesystem_satisfies_workspace_protocol(self, tmp_path: Path) -> None:
+        """Filesystem satisfies the runtime-checkable Workspace Protocol (AC #1)."""
+        tool, fs = make_wired_tool(tmp_path)
+        assert isinstance(fs, Workspace)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Backports resource-lifecycle and leak fixes from `master` onto `version-1.x`, and aligns the pydantic-ai pin to >=1.107.0,<2.

Cherry-picked (oldest to newest):
- Resource model + ResourceType (19-1), Filesystem.exists() (19-2), seed declared resources (19-3)
- lazy OpenAI client in DocumentReader, NotADirectoryError -> RetriableError
- Command channel registry + keyword args (epic 21)
- weak-reference the tool observer (epic 22) — primary leak fix
- pydantic-ai >=1.107.0,<2

Excludes 272f75b (drops ToolCard.name/description). One follow-up commit adapts epic-22's weak-observer tests to the version-1.x ToolCard surface (name/description remain required). All 1463 tool tests pass locally. Version line left for maintainer.

Relates to #188