### PR TITLE
feat(akgentic-tool): epic 23 — extra_commands on ToolFactory.get_command_registry (23-1)

### DIFF
--- a/src/akgentic/tool/core.py
+++ b/src/akgentic/tool/core.py
@@ -656,7 +656,9 @@ class ToolFactory:
             commands = {k: self._wrap_with_retry(v) for k, v in commands.items()}
         return commands
 
-    def get_command_registry(self) -> CommandRegistry:
+    def get_command_registry(
+        self, extra_commands: list[Callable[..., Any]] | None = None
+    ) -> CommandRegistry:
         """Build a name-keyed :class:`CommandRegistry` from every wired tool card.
 
         Iterates ``self.tool_cards`` in dependency order, calls each card's
@@ -667,11 +669,18 @@ class ToolFactory:
         wrapped via :meth:`_wrap_with_retry` (``functools.wraps`` preserves
         ``__name__``/``__doc__``), matching :meth:`get_commands` behavior.
 
+        Args:
+            extra_commands: Optional agent-owned plain callables (e.g. ``/compact``,
+                ``/clear``) that join the same collision-checked, signature-derived
+                table under the ``"BaseAgent"`` owner label. ``None`` (the default)
+                ⇒ tool-card commands only, byte-identical to the no-arg call.
+
         Raises:
-            ValueError: If two tool cards expose commands with the same canonical
-                name (collision is a wiring-time error, never a silent overwrite),
-                or if a command has an un-derivable signature. The message names
-                the offending command.
+            ValueError: If two commands resolve to the same canonical name —
+                whether two tool cards, a tool card and an extra callable, or two
+                extra callables (collision is a wiring-time error, never a silent
+                overwrite) — or if a command has an un-derivable signature. The
+                message names the offending command.
         """
         entries: dict[str, _CommandEntry] = {}
         for card in self.tool_cards:
@@ -685,7 +694,33 @@ class ToolFactory:
                         f"'{entries[name].tool_card}' and '{tool_card_name}'."
                     )
                 entries[name] = _build_command_entry(wrapped, tool_card_name)
+        self._register_extra_commands(entries, extra_commands)
         return CommandRegistry(entries)
+
+    def _register_extra_commands(
+        self,
+        entries: dict[str, _CommandEntry],
+        extra_commands: list[Callable[..., Any]] | None,
+    ) -> None:
+        """Fold agent-owned ``extra_commands`` into *entries* in place.
+
+        Each callable joins the same collision-checked, signature-derived table as
+        tool-card commands, under the ``"BaseAgent"`` owner label. When a
+        ``retry_exception`` is configured, the callable is retry-wrapped first;
+        ``functools.wraps`` preserves ``__name__``/``__wrapped__`` so a wrapped
+        ``compact`` still registers as ``/compact`` with its original signature.
+
+        Raises:
+            ValueError: If an extra callable's name collides with an already
+                registered command (a tool-card command OR an earlier extra
+                callable). The message names the colliding command.
+        """
+        for fn in extra_commands or []:
+            wrapped = self._wrap_with_retry(fn) if self._retry_exception is not None else fn
+            name = wrapped.__name__
+            if name in entries:
+                raise ValueError(f"Command name collision: '{name}'.")
+            entries[name] = _build_command_entry(wrapped, "BaseAgent")
 
     def get_toolsets(self) -> list[Any]:
         """Return toolset instances aggregated from all tool cards."""

--- a/tests/test_command_registry.py
+++ b/tests/test_command_registry.py
@@ -668,3 +668,145 @@ def test_kw_unknown_first_token_still_raises() -> None:
     registry = _registry(_SearchCard())
     with pytest.raises(CommandNotRecognized):
         registry.dispatch("/frobnicate status=pending")
+
+
+# ===========================================================================
+# Story 23.1 — additive ``extra_commands`` param on get_command_registry
+#
+# An agent-owned plain callable joins the same collision-checked,
+# signature-derived command table as tool-card commands, under the
+# "BaseAgent" owner label, without akgentic-tool importing llm/agent.
+# ===========================================================================
+
+
+# --- AC #1: additive, default-off param (parity with no-arg call) -----------
+
+
+def test_extra_commands_default_none_is_byte_identical() -> None:
+    factory = ToolFactory(tool_cards=[_HireCard(), _FireCard()])
+    reg_noarg = factory.get_command_registry()
+    reg_none = factory.get_command_registry(extra_commands=None)
+
+    # Same command names.
+    assert reg_noarg.has("hire_member") and reg_noarg.has("fire_member")
+    assert reg_none.has("hire_member") and reg_none.has("fire_member")
+    # Same descriptor set (field-wise model equality, same order).
+    assert reg_none.descriptors() == reg_noarg.descriptors()
+    # Same dispatch behaviour for an existing tool-card command.
+    assert reg_none.dispatch("/fire_member Bob") == reg_noarg.dispatch("/fire_member Bob")
+
+
+def test_extra_commands_empty_list_adds_nothing() -> None:
+    registry = _registry(_HireCard()).descriptors()
+    factory = ToolFactory(tool_cards=[_HireCard()])
+    reg_empty = factory.get_command_registry(extra_commands=[])
+    assert reg_empty.descriptors() == registry
+
+
+# --- AC #2: extra callable becomes a dispatchable command -------------------
+
+
+def test_extra_command_no_arg_dispatchable_under_baseagent() -> None:
+    def compact() -> str:
+        """Compact the conversation context."""
+        return "compacted"
+
+    factory = ToolFactory(tool_cards=[_HireCard()])
+    registry = factory.get_command_registry(extra_commands=[compact])
+
+    by_name = {d.name: d for d in registry.descriptors()}
+    assert "compact" in by_name
+    assert by_name["compact"].tool_card == "BaseAgent"
+    # Tool-card command still present alongside the agent-owned one.
+    assert by_name["hire_member"].tool_card == "_HireCard"
+    # Dispatch invokes the callable and string-renders its result.
+    assert registry.dispatch("/compact") == "compacted"
+
+
+def test_extra_command_typed_param_coerced_via_existing_path() -> None:
+    def echo(n: int) -> str:
+        """Echo double the integer argument."""
+        return str(n * 2)
+
+    factory = ToolFactory(tool_cards=[_HireCard()])
+    registry = factory.get_command_registry(extra_commands=[echo])
+
+    desc = {d.name: d for d in registry.descriptors()}["echo"]
+    assert [a.name for a in desc.args] == ["n"]
+    assert desc.args[0].type == "integer"
+    assert desc.args[0].required is True
+    # "21" coerced to int 21 via the same TypeAdapter machinery -> 42, not "2121".
+    assert registry.dispatch("/echo 21") == "42"
+
+
+# --- AC #3: collision raises at build time ----------------------------------
+
+
+def test_extra_command_collides_with_tool_card_command_raises() -> None:
+    def hire_member() -> str:
+        """Collides with _HireCard's hire_member."""
+        return "x"
+
+    factory = ToolFactory(tool_cards=[_HireCard()])
+    with pytest.raises(ValueError) as exc:
+        factory.get_command_registry(extra_commands=[hire_member])
+    assert "hire_member" in str(exc.value)
+
+
+def test_two_extra_commands_same_name_collide_raises() -> None:
+    def make(value: str) -> Callable[[], str]:
+        def compact() -> str:
+            """Duplicate-named extra callable."""
+            return value
+
+        return compact
+
+    factory = ToolFactory(tool_cards=[_HireCard()])
+    with pytest.raises(ValueError) as exc:
+        factory.get_command_registry(extra_commands=[make("a"), make("b")])
+    assert "compact" in str(exc.value)
+
+
+# --- AC #4: retry-wrapping preserves name + signature -----------------------
+
+
+def test_extra_command_retry_wrap_preserves_name_and_signature() -> None:
+    class _MyRetryError(Exception):
+        pass
+
+    def compact(scope: str) -> str:
+        """Raises retriable when invoked."""
+        raise RetriableError("retry me")
+
+    factory = ToolFactory(tool_cards=[_HireCard()], retry_exception=_MyRetryError)
+    registry = factory.get_command_registry(extra_commands=[compact])
+
+    # Registers under the ORIGINAL name (never "/wrapper") with its param intact.
+    assert registry.has("compact")
+    desc = {d.name: d for d in registry.descriptors()}["compact"]
+    assert desc.tool_card == "BaseAgent"
+    assert [a.name for a in desc.args] == ["scope"]
+    # The wrapped callable converts RetriableError -> the configured retry_exception.
+    fn = registry.callable("compact")
+    with pytest.raises(_MyRetryError):
+        fn("everything")
+    # Through dispatch, that failure is caught and surfaced as a result string.
+    assert "compact" in registry.dispatch("/compact everything")
+
+
+# --- AC #5: unknown command + boundary parity -------------------------------
+
+
+def test_unknown_command_raises_with_and_without_extra_commands() -> None:
+    def compact() -> str:
+        """Agent-owned built-in."""
+        return "compacted"
+
+    factory = ToolFactory(tool_cards=[_HireCard()])
+    reg_plain = factory.get_command_registry()
+    reg_extra = factory.get_command_registry(extra_commands=[compact])
+
+    with pytest.raises(CommandNotRecognized):
+        reg_plain.dispatch("/nope")
+    with pytest.raises(CommandNotRecognized):
+        reg_extra.dispatch("/nope")


### PR DESCRIPTION
## Epic 23 — `extra_commands` on `ToolFactory.get_command_registry`

Additive, import-free hook so an agent-owned plain callable joins the **same**
collision-checked, signature-derived slash-command table as tool-card commands,
registered under the `"BaseAgent"` owner label. Boundary-correct bridge for
akgentic-llm ADR-010 §6 (`/compact`, `/clear`): the compaction logic lives in
akgentic-llm and is never imported here — this epic only adds the generic hook.

### Stories

- [x] 23-1 — additive `extra_commands` param (Relates to #190)

### What changed

- `ToolFactory.get_command_registry` gains `extra_commands: list[Callable[..., Any]] | None = None`
  as its last (and only) parameter. `None`/no-arg is byte-identical to before.
- Extracted `_register_extra_commands(entries, extra_commands)` so the public
  method keeps orchestrating and stays within the method/complexity caps.
- Each extra callable is registered under its `__name__` via the existing
  `_build_command_entry`; collision against the live `entries` dict covers both
  tool-card names and earlier extra callables and raises `ValueError`.
- Retry-wrapping reuses `_wrap_with_retry` (`functools.wraps`), so a wrapped
  `compact` still registers as `/compact` with its original signature.

## Review status

**Outcome: Approve (done).** Verified all five behavioural ACs against the
ADR-010 §6 spec. The change is purely additive — no existing call site changes,
return type unchanged, `CommandRegistry` stays a plain class (Golden Rule #1b),
no `akgentic-llm`/`akgentic-agent` import introduced (Golden Rule #4), and no
ADR-string test assertions (Golden Rule #8). No HIGH/MEDIUM findings, so no
review fixup commit was required.

Local gates (CI parity):

- `pytest packages/akgentic-tool/tests/` → **1463 passed**
- `mypy --config-file packages/akgentic-tool/pyproject.toml packages/akgentic-tool/src/` → **clean**
- `ruff check packages/akgentic-tool/src/` → **clean**

(Root-config mypy reports 65 pre-existing bare-`Callable` diagnostics in the
submodule's `ignore_errors` modules — none at the new lines; the new code uses
fully-parameterized `Callable[..., Any]` and is strict-clean.)

## Scope guard

All changes stay inside `packages/akgentic-tool/` — only
`src/akgentic/tool/core.py` and `tests/test_command_registry.py` are touched.
No cross-submodule edits.

## Epic 23 slice complete

23-1 is the first **and** last/only story of Epic 23. With it merged, the epic
slice is complete: akgentic-tool now exposes the generic, import-free
`extra_commands` hook. The agent-owned callables (`/compact`, `/clear`) are
supplied by akgentic-agent Epic 12 and the compaction engine by akgentic-llm
Epic 12 — separate branches/PRs, no upstream dependency on this one.

Closes #190
